### PR TITLE
Fix import side effect in sector_manager

### DIFF
--- a/sector_manager.py
+++ b/sector_manager.py
@@ -42,5 +42,3 @@ class SectorManager:
                     keys.append((cx + dx, cy + dy, cz + dz))
         return keys
 
-print("[DEBUG] Simulation exited unexpectedly.")
-


### PR DESCRIPTION
## Summary
- remove stray debug print statement from `sector_manager.py`

## Testing
- `python -m py_compile sector_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_683f794a4a548324946a795d0078e1ac