### PR TITLE
Fix status_var initialization

### DIFF
--- a/gui_control.py
+++ b/gui_control.py
@@ -388,7 +388,8 @@ class ShipConsoleGUI:
         self.cooldown_label = None
         self.state_vars = {}
         self.command_runner = CommandRunner()
-        
+        self.status_var = tk.StringVar(value="Ready")
+
         # Create and configure the main layout
         self.create_layout()
         
@@ -472,9 +473,9 @@ class ShipConsoleGUI:
         status_frame = ttk.Frame(self.root)
         status_frame.grid(row=1, column=0, columnspan=2, sticky="ew")
         
-        self.status_var = tk.StringVar(value="Ready")
-        status_label = ttk.Label(status_frame, textvariable=self.status_var, 
-                               relief=tk.SUNKEN, anchor=tk.W)
+        self.status_var.set("Ready")
+        status_label = ttk.Label(status_frame, textvariable=self.status_var,
+                                 relief=tk.SUNKEN, anchor=tk.W)
         status_label.pack(fill=tk.X)
         
         # Initialize auto-refresh


### PR DESCRIPTION
## Summary
- initialize `status_var` before creating the GUI layout
- use existing `status_var` when creating the status bar

## Testing
- `pytest -q` *(fails: KeyError and TypeError in tests)*
- `python run_hybrid_sim.py` *(fails: no display name and $DISPLAY variable)*

------
https://chatgpt.com/codex/tasks/task_e_683f81eb63308324a37ca9b5b0a3879d