### PR TITLE
Fix GUI usage with command server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ This project provides a simulation environment for spacecraft with a hybrid obje
    python -m hybrid.converter fleet_json hybrid_fleet
    ```
 
-3. Run the simulation with GUI:
+3. Start the command server (required for GUI commands):
+   ```
+   python main.py
+   ```
+
+4. In a separate terminal, launch the GUI:
    ```
    python run_hybrid_sim.py
    ```

--- a/gui_control.py
+++ b/gui_control.py
@@ -1541,43 +1541,20 @@ class ShipConsoleGUI:
 
 
 def create_gui():
-    """Create and run the main GUI"""
-    # Initialize the hybrid runner
-    from hybrid_runner import HybridRunner
-    import os
-    
-    # Get scenario from environment variable if set
-    scenario_name = os.environ.get('HYBRID_SCENARIO', 'test_scenario')
-    
-    # Create the runner and load the scenario
-    runner = HybridRunner()
-    
-    try:
-        # Load the specified scenario
-        ship_count = runner.load_scenario(scenario_name)
-        print(f"Loaded {ship_count} ships from scenario: {scenario_name}")
-        
-        if ship_count == 0:
-            print(f"Falling back to default test_scenario")
-            runner.load_scenario("test_scenario")
-    except Exception as e:
-        print(f"Error loading scenario {scenario_name}: {e}")
-        print("Falling back to default test_scenario")
-        try:
-            runner.load_scenario("test_scenario")
-        except:
-            # Last resort - try to load ships from fleet directory
-            runner.load_ships()
-    
-    # Start the simulation
-    runner.start()
-    
-    # Create the GUI
+    """Create and run the main GUI.
+
+    This version of ``create_gui`` does **not** start an internal simulation.
+    The GUI relies on ``send.py`` to communicate with an external command
+    server (e.g. started via ``main.py``).  It simply launches the Tkinter
+    interface so the user can connect to that running simulator.
+    """
+
+    # Create the GUI window
     root = tk.Tk()
     app = ShipConsoleGUI(root)
-    
-    # Set window title with scenario name
-    root.title(f"Spaceship Command Console - {scenario_name}")
+
+    # Set a sensible window title
+    root.title("Spaceship Command Console")
     
     # Initialize state variables if needed
     if not hasattr(app, 'state_vars'):
@@ -1611,28 +1588,20 @@ def create_gui():
     if not hasattr(app, 'spike_var'):
         app.spike_var = tk.StringVar(value="None")
     
-    # Set ship selector to player_ship if available
+    # Initialise ship selector with known ship IDs
     if hasattr(app, 'ship_var') and app.ship_var:
-        states = runner.get_all_ship_states()
-        ship_ids = list(states.keys())
-        
-        # Update the ship combo values
         if hasattr(app, 'ship_combo') and app.ship_combo:
-            app.ship_combo['values'] = ship_ids
-        
-        # Set to player_ship if available, otherwise first ship
-        if "player_ship" in states:
-            app.ship_var.set("player_ship")
-        elif ship_ids:
-            app.ship_var.set(ship_ids[0])
-            
-        # Force an immediate refresh
+            app.ship_combo['values'] = SHIP_IDS
+
+        # Default to the first ship in the list
+        if SHIP_IDS:
+            app.ship_var.set(SHIP_IDS[0])
+
         if hasattr(app, 'refresh_panels'):
             app.refresh_panels()
     
     # Define cleanup function for when window is closed
     def on_closing():
-        runner.stop()
         root.destroy()
         
     root.protocol("WM_DELETE_WINDOW", on_closing)
@@ -1641,8 +1610,7 @@ def create_gui():
     try:
         root.mainloop()
     finally:
-        # Ensure simulation is stopped when GUI exits
-        runner.stop()
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- decouple GUI from internal simulation so it relies on `send.py`
- document that `main.py` must be running for GUI commands

## Testing
- `python -m py_compile gui_control.py run_hybrid_sim.py`

------
https://chatgpt.com/codex/tasks/task_e_683fee727a788324b9c4668f9073d966