### PR TITLE
Fix scenario positions and clamp loader

### DIFF
--- a/scenario_loader.py
+++ b/scenario_loader.py
@@ -3,6 +3,19 @@
 import json
 from ship_factory import build_ship_from_config
 
+# Limit how far a ship can spawn from the origin to keep scenarios contained
+MAX_START_DISTANCE = 10000.0
+
+def _clamp_position(pos):
+    """Clamp position components to the allowed maximum distance"""
+    for axis in ("x", "y", "z"):
+        if axis in pos:
+            if pos[axis] > MAX_START_DISTANCE:
+                pos[axis] = MAX_START_DISTANCE
+            elif pos[axis] < -MAX_START_DISTANCE:
+                pos[axis] = -MAX_START_DISTANCE
+    return pos
+
 def load_scenario(path, sector_manager=None):
     with open(path) as f:
         data = json.load(f)
@@ -17,6 +30,10 @@ def load_scenario(path, sector_manager=None):
 
     ships = []
     for ship_cfg in ships_data:
+        # Clamp starting position to avoid extremely far spawns
+        if 'position' in ship_cfg:
+            ship_cfg['position'] = _clamp_position(ship_cfg['position'])
+
         ship = build_ship_from_config(ship_cfg)
         ships.append(ship)
         if sector_manager:

--- a/scenarios/test_scenario.json
+++ b/scenarios/test_scenario.json
@@ -83,9 +83,9 @@
     {
       "id": "enemy_probe",
       "position": {
-        "x": 1000.0,
+        "x": 600.0,
         "y": 0.0,
-        "z": 1000.0
+        "z": 600.0
       },
       "velocity": {
         "x": 0.0,
@@ -148,12 +148,12 @@
     {
       "id": "test_ship_001",
       "position": {
-        "x": -2000.0,
-        "y": 500.0,
-        "z": -1500.0
+        "x": 300.0,
+        "y": 100.0,
+        "z": 0.0
       },
       "velocity": {
-        "x": 5.0,
+        "x": 0.0,
         "y": 0.0,
         "z": 0.0
       },
@@ -209,13 +209,13 @@
     {
       "id": "test_ship_002",
       "position": {
-        "x": 3000.0,
-        "y": -1000.0,
-        "z": 2000.0
+        "x": 800.0,
+        "y": 150.0,
+        "z": 50.0
       },
       "velocity": {
-        "x": -3.0,
-        "y": 1.0,
+        "x": 0.0,
+        "y": 0.0,
         "z": 0.0
       },
       "orientation": {
@@ -266,82 +266,6 @@
           "signature_base": 1.5
         }
       }
-    }
-  ]
-}
-{
-  "name": "Test Scenario",
-  "description": "A simple test scenario with multiple ships",
-  "ships": [
-    {
-      "id": "player_ship",
-      "name": "Valiant",
-      "class": "corvette",
-      "faction": "alliance",
-      "mass": 5000.0,
-      "position": {"x": 0.0, "y": 0.0, "z": 0.0},
-      "velocity": {"x": 0.0, "y": 0.0, "z": 0.0},
-      "orientation": {"pitch": 0.0, "yaw": 0.0, "roll": 0.0},
-      "systems": {
-        "power": {
-          "enabled": true,
-          "generation": 200.0,
-          "capacity": 2000.0,
-          "efficiency": 0.95
-        },
-        "propulsion": {
-          "enabled": true,
-          "main_drive": {
-            "max_thrust": 150.0,
-            "efficiency": 0.9
-          },
-          "max_fuel": 2000.0,
-          "fuel_level": 2000.0
-        },
-        "sensors": {
-          "enabled": true,
-          "passive_range": 2000.0,
-          "active_range": 8000.0,
-          "ping_cooldown": 5.0
-        }
-      }
-    },
-    {
-      "id": "enemy_ship",
-      "name": "Marauder",
-      "class": "frigate",
-      "faction": "pirates",
-      "mass": 8000.0,
-      "position": {"x": 500.0, "y": 500.0, "z": 0.0},
-      "velocity": {"x": -5.0, "y": 0.0, "z": 0.0},
-      "orientation": {"pitch": 0.0, "yaw": 180.0, "roll": 0.0},
-      "systems": {
-        "power": {
-          "enabled": true,
-          "generation": 180.0,
-          "capacity": 1800.0,
-          "efficiency": 0.9
-        },
-        "propulsion": {
-          "enabled": true,
-          "main_drive": {
-            "max_thrust": 130.0,
-            "efficiency": 0.85
-          },
-          "max_fuel": 1800.0,
-          "fuel_level": 1500.0
-        }
-      }
-    },
-    {
-      "id": "neutral_ship",
-      "name": "Trader",
-      "class": "shuttle",
-      "faction": "civilian",
-      "mass": 2000.0,
-      "position": {"x": -800.0, "y": 200.0, "z": 100.0},
-      "velocity": {"x": 2.0, "y": 1.0, "z": 0.0},
-      "orientation": {"pitch": 0.0, "yaw": 45.0, "roll": 0.0}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- fix broken test scenario JSON
- place ships near each other
- add clamping in scenario loader to keep starting positions reasonable

## Testing
- `pytest -q` *(fails: Ship command and physics tests)*

------
https://chatgpt.com/codex/tasks/task_e_684001eb2d9483248eb43cfb9287da82