### PR TITLE
Add power management defaults in scenarios

### DIFF
--- a/config/example_scenario.json
+++ b/config/example_scenario.json
@@ -43,6 +43,21 @@
         "capacity": 1000,
         "current": 1000,
         "generation": 5
+      },
+      "power_management": {
+        "primary": {"output": 100.0},
+        "secondary": {"output": 50.0},
+        "tertiary": {"output": 25.0},
+        "alert_threshold": 0.1,
+        "system_map": {
+          "propulsion": "primary",
+          "weapons": "primary",
+          "sensors": "secondary",
+          "defense": "secondary",
+          "rcs": "secondary",
+          "life_support": "tertiary",
+          "bio_monitor": "tertiary"
+        }
       }
     }
   },
@@ -90,9 +105,24 @@
         "capacity": 1000,
         "current": 1000,
         "generation": 5
+      },
+      "power_management": {
+        "primary": {"output": 100.0},
+        "secondary": {"output": 50.0},
+        "tertiary": {"output": 25.0},
+        "alert_threshold": 0.1,
+        "system_map": {
+          "propulsion": "primary",
+          "weapons": "primary",
+          "sensors": "secondary",
+          "defense": "secondary",
+          "rcs": "secondary",
+          "life_support": "tertiary",
+          "bio_monitor": "tertiary"
+        }
       }
-    }
-  },
+      }
+    },
   {
     "id": "probe_passive_target",
     "position": { "x": 250, "y": 0, "z": 0 },
@@ -108,6 +138,21 @@
           "fov": 120.0,
           "signature_threshold": 0.00001,
           "contacts": []
+        }
+      },
+      "power_management": {
+        "primary": {"output": 100.0},
+        "secondary": {"output": 50.0},
+        "tertiary": {"output": 25.0},
+        "alert_threshold": 0.1,
+        "system_map": {
+          "propulsion": "primary",
+          "weapons": "primary",
+          "sensors": "secondary",
+          "defense": "secondary",
+          "rcs": "secondary",
+          "life_support": "tertiary",
+          "bio_monitor": "tertiary"
         }
       }
     }
@@ -135,6 +180,21 @@
           "last_ping_time": null,
           "processed": false,
           "contacts": []
+        }
+      },
+      "power_management": {
+        "primary": {"output": 100.0},
+        "secondary": {"output": 50.0},
+        "tertiary": {"output": 25.0},
+        "alert_threshold": 0.1,
+        "system_map": {
+          "propulsion": "primary",
+          "weapons": "primary",
+          "sensors": "secondary",
+          "defense": "secondary",
+          "rcs": "secondary",
+          "life_support": "tertiary",
+          "bio_monitor": "tertiary"
         }
       }
     }

--- a/scenarios/test_scenario.json
+++ b/scenarios/test_scenario.json
@@ -77,6 +77,21 @@
               "z": 0.0
             }
           }
+        },
+        "power_management": {
+          "primary": {"output": 100.0},
+          "secondary": {"output": 50.0},
+          "tertiary": {"output": 25.0},
+          "alert_threshold": 0.1,
+          "system_map": {
+            "propulsion": "primary",
+            "weapons": "primary",
+            "sensors": "secondary",
+            "defense": "secondary",
+            "rcs": "secondary",
+            "life_support": "tertiary",
+            "bio_monitor": "tertiary"
+          }
         }
       }
     },
@@ -142,6 +157,21 @@
           },
           "signature_base": 1.0,
           "contacts": []
+        },
+        "power_management": {
+          "primary": {"output": 100.0},
+          "secondary": {"output": 50.0},
+          "tertiary": {"output": 25.0},
+          "alert_threshold": 0.1,
+          "system_map": {
+            "propulsion": "primary",
+            "weapons": "primary",
+            "sensors": "secondary",
+            "defense": "secondary",
+            "rcs": "secondary",
+            "life_support": "tertiary",
+            "bio_monitor": "tertiary"
+          }
         }
       }
     },
@@ -203,6 +233,21 @@
             "contact_count": 0
           },
           "signature_base": 1.2
+        },
+        "power_management": {
+          "primary": {"output": 100.0},
+          "secondary": {"output": 50.0},
+          "tertiary": {"output": 25.0},
+          "alert_threshold": 0.1,
+          "system_map": {
+            "propulsion": "primary",
+            "weapons": "primary",
+            "sensors": "secondary",
+            "defense": "secondary",
+            "rcs": "secondary",
+            "life_support": "tertiary",
+            "bio_monitor": "tertiary"
+          }
         }
       }
     },
@@ -264,6 +309,21 @@
             "contact_count": 0
           },
           "signature_base": 1.5
+        },
+        "power_management": {
+          "primary": {"output": 100.0},
+          "secondary": {"output": 50.0},
+          "tertiary": {"output": 25.0},
+          "alert_threshold": 0.1,
+          "system_map": {
+            "propulsion": "primary",
+            "weapons": "primary",
+            "sensors": "secondary",
+            "defense": "secondary",
+            "rcs": "secondary",
+            "life_support": "tertiary",
+            "bio_monitor": "tertiary"
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- add default `power_management` configs to `example_scenario.json`
- update `test_scenario.json` ships with `power_management` info

## Testing
- `pytest -q`
- `python - <<'PY'
from hybrid_runner import HybridRunner
runner = HybridRunner(dt=0.1)
print('count', runner.load_scenario('test_scenario'))
runner.start()
import time, json
time.sleep(0.2)
print('pm in player:', 'power_management' in runner.get_ship_state('player_ship')['systems'])
runner.stop()
PY`

------
https://chatgpt.com/codex/tasks/task_e_6840238afcc48324bcc61ac11347a5eb