### PR TITLE
Fix GUI module import

### DIFF
--- a/hybrid/gui/run_gui.py
+++ b/hybrid/gui/run_gui.py
@@ -4,6 +4,14 @@ from tkinter import ttk, scrolledtext
 import json
 import time
 import threading
+import os
+import sys
+
+# Allow importing modules from the project root when running this script
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
 from hybrid_runner import HybridRunner
 
 # Constants


### PR DESCRIPTION
## Summary
- modify GUI to adjust Python path so it can import `hybrid_runner`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a4b725b0832480f53c79bb6041ce