### PR TITLE
Fix active sensor ping detection

### DIFF
--- a/hybrid/core/event_bus.py
+++ b/hybrid/core/event_bus.py
@@ -14,6 +14,16 @@ class EventBus:
     def subscribe(self, event_name, callback):
         self.listeners.setdefault(event_name, []).append(callback)
 
-    def publish(self, event_name, payload):
+    def publish(self, event_name, payload=None, source=None):
+        """Publish an event to all subscribers.
+
+        Older callbacks expect a single ``payload`` argument while some newer
+        calls include a ``source`` parameter.  To remain backward compatible we
+        try calling the subscriber with just the payload first and fall back to
+        passing the optional source if required.
+        """
         for callback in self.listeners.get(event_name, []):
-            callback(payload)
+            try:
+                callback(payload)
+            except TypeError:
+                callback(payload, source)

--- a/hybrid/systems/sensors/sensor_system.py
+++ b/hybrid/systems/sensors/sensor_system.py
@@ -92,12 +92,10 @@ class SensorSystem(BaseSystem):
             self.active["cooldown"] -= dt
             self.active["cooldown"] = max(0, self.active["cooldown"])
             
-        # Check for active ping processing
-        if self.active["last_ping_time"] and not self.active["processed"]:
-            # This would be handled in a separate function that has access to all ships
-            # For now, we'll just mark it as processed
-            self.active["processed"] = True
-            logger.debug(f"Active ping completed for {ship.id}")
+
+        # Active ping results are processed externally in
+        # ``process_active_ping``.  Do not mark them as processed here or the
+        # simulator will skip detection entirely.
             
         # Passive sensor updates would happen here
         # This requires access to all ships, so it's typically done externally


### PR DESCRIPTION
## Summary
- allow an optional `source` argument when publishing events
- prevent `SensorSystem.tick()` from marking active pings as processed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b105f1f88324be3eb2a78f708220