### PR TITLE
Add sample ship config

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ pip install -r requirements.txt
 ## Usage
 ### CLI
 ```bash
-python -m hybrid.cli.run_cli --config path/to/ships.json --time 60
+python -m hybrid.cli.run_cli --config ships_config.json --time 60
 ```
-`--config` should be a JSON mapping each ship ID to its configuration (power, weapons, navigation, sensors).
+`--config` should be a JSON mapping each ship ID to its configuration (power, weapons, navigation, sensors). See `ships_config.json` for a minimal example.
 
 `--time` is total simulation duration in seconds.
 

--- a/ships_config.json
+++ b/ships_config.json
@@ -1,0 +1,8 @@
+{
+  "testship": {
+    "power": {"primary": {}, "secondary": {}, "tertiary": {}},
+    "weapons": {"weapons": []},
+    "navigation": {},
+    "sensors": {}
+  }
+}


### PR DESCRIPTION
## Summary
- add `ships_config.json` as a minimal example config
- reference new file in README CLI usage

## Testing
- `pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_68436a0fada08324a32e4641dc4c9c1d