### PR TITLE
Add config path option to GUI runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ python -m hybrid.cli --fleet-dir hybrid_fleet --run 60
 
 ### GUI
 ```bash
-python -m hybrid.gui.run_gui
+python -m hybrid.gui.run_gui --config path/to/ships.json
 ```
-Launches a Tkinter window. Edit hybrid/gui/run_gui.py to customize widgets.
+Launches a Tkinter window. If no `--config` path is provided, the GUI will
+use `ships_config.json` when present or prompt for a file using a standard
+dialog. Edit `hybrid/gui/run_gui.py` to customize widgets.
 
 ### Sample Data
 Minimal ship examples are provided in `fleet_json/sample_ship.json` and

--- a/hybrid/gui/run_gui.py
+++ b/hybrid/gui/run_gui.py
@@ -1,8 +1,11 @@
 # hybrid/gui/run_gui.py
 
-import threading
+import argparse
 import json
+import os
+import threading
 import tkinter as tk
+from tkinter import filedialog
 from hybrid.systems.simulation import Simulation
 
 class SimulatorGUI(tk.Tk):
@@ -22,8 +25,32 @@ class SimulatorGUI(tk.Tk):
         thread.start()
 
 def main():
-    with open("ships_config.json", "r") as f:
+    parser = argparse.ArgumentParser(description="Run the simulator GUI")
+    parser.add_argument(
+        "--config",
+        "-c",
+        help="Path to ship configuration JSON file",
+    )
+    args = parser.parse_args()
+
+    config_path = args.config
+    if not config_path:
+        if os.path.exists("ships_config.json"):
+            config_path = "ships_config.json"
+        else:
+            root = tk.Tk()
+            root.withdraw()
+            config_path = filedialog.askopenfilename(
+                title="Select ship configuration file",
+                filetypes=[("JSON files", "*.json"), ("All files", "*.*")],
+            )
+            if not config_path:
+                print("No configuration file selected")
+                return
+
+    with open(config_path, "r") as f:
         ship_configs = json.load(f)
+
     app = SimulatorGUI(ship_configs)
     app.mainloop()
 


### PR DESCRIPTION
## Summary
- allow specifying ship config path in `hybrid/gui/run_gui.py`
- open a file dialog when no config path or default file is found
- document new `--config` argument in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436f5b4b5c8324b3122a074841908f