### PR TITLE
Fix GUI import for Simulator

### DIFF
--- a/hybrid/gui/run_gui.py
+++ b/hybrid/gui/run_gui.py
@@ -6,13 +6,17 @@ import os
 import threading
 import tkinter as tk
 from tkinter import filedialog
-from hybrid.systems.simulation import Simulation
+# Use the newer Simulator class instead of the deprecated Simulation
+from hybrid.simulator import Simulator
 
 class SimulatorGUI(tk.Tk):
     def __init__(self, ship_configs):
         super().__init__()
         self.title("Spaceship Simulator")
-        self.sim = Simulation(ship_configs)
+        # Create the simulator and load ships from the provided config
+        self.sim = Simulator()
+        for ship_id, config in ship_configs.items():
+            self.sim.add_ship(ship_id, config)
         self._build_widgets()
         self._start_simulation_thread()
 

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
 .PHONY: test
 
 test:
-pytest --maxfail=1 -q
+	pytest --maxfail=1 -q


### PR DESCRIPTION
## Summary
- update GUI to use `Simulator` from `hybrid.simulator`
- load ships from config file
- fix Makefile to run tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6843797a82188324bb760e8453847469