### PR TITLE
Fix TCP server protocol, add main(), and align GUI clients to newline-delimited JSON

### DIFF
--- a/hybrid/gui/gui.py
+++ b/hybrid/gui/gui.py
@@ -12,9 +12,11 @@ class Client:
                 ch = s.recv(4096)
                 if not ch: break
                 data += ch
+                if b"\n" in data:
+                    break
             s.close()
         if not data: return {"ok": False, "error":"no response"}
-        return json.loads(data.decode('utf-8').splitlines()[-1])
+        return json.loads(data.decode('utf-8').splitlines()[0])
 class HUD(tk.Tk):
     def __init__(self, host='127.0.0.1', port=8765):
         super().__init__()

--- a/server/run_server.py
+++ b/server/run_server.py
@@ -11,6 +11,86 @@ if ROOT_DIR not in sys.path:
     sys.path.append(ROOT_DIR)
 
 from hybrid_runner import HybridRunner
+from hybrid.command_handler import route_command
+
+"""
+Protocol: newline-delimited JSON over TCP.
+
+Each request is a single JSON object terminated by "\n". Responses mirror
+the request framing with one JSON object per line. Clients should send a
+payload like:
+
+  {"cmd": "get_state"}
+  {"cmd": "ping_sensors", "ship": "alpha"}
+"""
+
+
+def _format_ship_state(state: dict) -> dict:
+    pos = state.get("position", {})
+    return {
+        "id": state.get("id"),
+        "name": state.get("name", state.get("id")),
+        "pos": pos,
+        "vel": state.get("velocity", {}),
+        "attitude": state.get("orientation", {}),
+        "systems": state.get("systems", {}),
+    }
+
+
+def dispatch(runner: HybridRunner, req: dict) -> dict:
+    cmd = req.get("cmd")
+    if not cmd:
+        return {"ok": False, "error": "missing cmd"}
+
+    if cmd == "get_state":
+        ship_id = req.get("ship")
+        states = runner.get_all_ship_states()
+        payload = {
+            "ok": True,
+            "t": runner.simulator.time,
+            "ships": [_format_ship_state(state) for state in states.values()],
+        }
+        if ship_id:
+            ship_state = runner.get_ship_state(ship_id)
+            payload["ship"] = ship_id
+            payload["state"] = ship_state
+            if isinstance(ship_state, dict) and "error" in ship_state:
+                payload["ok"] = False
+                payload["error"] = ship_state["error"]
+        return payload
+
+    if cmd == "get_events":
+        return {"ok": True, "events": []}
+
+    if cmd == "get_mission":
+        return {"ok": True, "mission": {"status": "unknown", "objectives": []}}
+
+    if cmd == "pause":
+        on = bool(req.get("on", True))
+        if on:
+            runner.stop()
+        else:
+            runner.start()
+        return {"ok": True, "paused": on}
+
+    ship_id = req.get("ship")
+    if not ship_id:
+        return {"ok": False, "error": "missing ship"}
+    ship = runner.simulator.ships.get(ship_id)
+    if not ship:
+        return {"ok": False, "error": f"ship {ship_id} not found"}
+
+    command_data = {"command": cmd, "ship": ship_id, **req}
+    command_data.pop("cmd", None)
+    result = route_command(ship, command_data)
+    if isinstance(result, dict) and "error" in result:
+        return {"ok": False, "error": result["error"], "response": result}
+    return {"ok": True, "response": result}
+
+
+def _serve(host: str, port: int, dt: float, fleet_dir: str) -> None:
+    runner = HybridRunner(fleet_dir=fleet_dir, dt=dt)
+    runner.load_ships()
     runner.start()
     print(f"Server on {host}:{port} dt={dt}")
 
@@ -27,42 +107,39 @@ from hybrid_runner import HybridRunner
                 if not data:
                     break
                 buf += data
-                if b"\n" in buf:
+                while b"\n" in buf:
                     line, buf = buf.split(b"\n", 1)
+                    if not line.strip():
+                        continue
                     try:
                         req = json.loads(line.decode("utf-8"))
-                    except Exception:
+                    except json.JSONDecodeError:
                         err = json.dumps({"ok": False, "error": "bad json"}) + "\n"
                         conn.sendall(err.encode("utf-8"))
-                        break
+                        continue
                     resp = dispatch(runner, req)
                     conn.sendall((json.dumps(resp) + "\n").encode("utf-8"))
-                    break
         finally:
             conn.close()
 
-    while True:
-        client, _ = srv.accept()
-        threading.Thread(target=handle, args=(client,), daemon=True).start()
+    try:
+        while True:
+            client, _ = srv.accept()
+            threading.Thread(target=handle, args=(client,), daemon=True).start()
+    finally:
+        runner.stop()
+        srv.close()
 
 
-def dispatch(runner: HybridRunner, req: dict) -> dict:
-    cmd = req.get("cmd")
-    if cmd == "get_state":
-
-    if cmd == "pause":
-        on = bool(req.get("on", True))
-        if on:
-            runner.stop()
-        else:
-            runner.start()
-        return {"ok": True, "paused": on}
-    return {"ok": False, "error": "unknown cmd"}
-
-
-if __name__ == "__main__":
+def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--host", default="127.0.0.1")
     ap.add_argument("--port", type=int, default=8765)
     ap.add_argument("--dt", type=float, default=0.1)
     ap.add_argument("--fleet-dir", default="hybrid_fleet")
+    args = ap.parse_args()
+    _serve(args.host, args.port, args.dt, args.fleet_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a working `main()` for the TCP server so the simulator can be started as a service and run `HybridRunner` reliably.
- Use a single, simple framing protocol (newline-delimited JSON) so mobile/GUI/CLI clients share the same request/response semantics.
- Ensure incoming client commands are dispatched into the existing hybrid command stack (`route_command` / `HybridRunner` / `Ship.command`) consistently.
- Add a minimal `get_state` path and small compatibility fields so HUD/GUI can render a basic scene and verify end-to-end connectivity.

### Description
- Rewrote `server/run_server.py` to provide `main()` and `_serve()`, implement newline-delimited JSON framing, a `dispatch()` that handles `get_state`, `get_events`, `get_mission`, `pause`, and forwards ship-scoped commands into `route_command`/`HybridRunner` and returns JSON responses.
- Added `_format_ship_state()` to produce HUD-friendly fields (`id`, `name`, `pos`, `vel`, `attitude`, `systems`) for `get_state` responses and guarded error propagation for missing ships.
- Updated `hybrid/gui/run_gui.py` to document the protocol, send newline-delimited JSON (`{

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b8fa37b48832486d0e0b1d28811d9)