### PR TITLE
Add mobile web UI client for socket protocol

### DIFF
--- a/mobile_ui/app.py
+++ b/mobile_ui/app.py
@@ -1,0 +1,63 @@
+import json
+import socket
+from typing import Any
+
+from flask import Flask, jsonify, render_template, request
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8765
+SOCKET_TIMEOUT = 3
+
+app = Flask(__name__)
+
+
+def send_socket_command(host: str, port: int, payload: dict[str, Any]) -> Any:
+    message = json.dumps(payload) + "\n"
+    with socket.create_connection((host, port), timeout=SOCKET_TIMEOUT) as sock:
+        sock.sendall(message.encode("utf-8"))
+        buffer = b""
+        while b"\n" not in buffer:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            buffer += chunk
+
+    if not buffer:
+        return {"ok": False, "error": "no response"}
+
+    line = buffer.split(b"\n", 1)[0].decode("utf-8")
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        return {"ok": False, "error": "invalid json", "raw": line}
+
+
+@app.get("/")
+def index() -> str:
+    return render_template(
+        "index.html",
+        default_host=DEFAULT_HOST,
+        default_port=DEFAULT_PORT,
+    )
+
+
+@app.post("/api/send")
+def api_send():
+    payload = request.get_json(silent=True) or {}
+    host = payload.get("host", DEFAULT_HOST)
+    port = int(payload.get("port", DEFAULT_PORT))
+    command = payload.get("payload")
+
+    if not isinstance(command, dict):
+        return jsonify({"ok": False, "error": "payload must be an object"}), 400
+
+    try:
+        response = send_socket_command(host, port, command)
+    except OSError as exc:
+        return jsonify({"ok": False, "error": str(exc)})
+
+    return jsonify({"ok": True, "response": response})
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/mobile_ui/static/app.js
+++ b/mobile_ui/static/app.js
@@ -1,0 +1,113 @@
+const logPanel = document.getElementById("log");
+
+function appendLog(message, type = "info") {
+  const item = document.createElement("div");
+  item.className = `log-item ${type}`;
+  item.textContent = message;
+  logPanel.prepend(item);
+}
+
+function getConnection() {
+  return {
+    host: document.getElementById("host").value.trim(),
+    port: Number(document.getElementById("port").value),
+    ship: document.getElementById("ship").value.trim(),
+  };
+}
+
+async function sendCommand(command, extra = {}) {
+  const { host, port, ship } = getConnection();
+  const payload = { cmd: command, ship, ...extra };
+
+  appendLog(`>> ${JSON.stringify(payload)}`, "request");
+
+  const response = await fetch("/api/send", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ host, port, payload }),
+  });
+
+  const data = await response.json();
+  if (!data.ok) {
+    appendLog(`!! ${data.error}`, "error");
+    return;
+  }
+
+  appendLog(`<< ${JSON.stringify(data.response)}`, "response");
+}
+
+function setUpActions() {
+  document.querySelectorAll("button[data-action]").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const action = button.dataset.action;
+
+      if (action === "test-connection") {
+        return sendCommand("get_state", {});
+      }
+
+      if (action === "get-state") {
+        return sendCommand("get_state", {});
+      }
+
+      if (action === "set-thrust") {
+        return sendCommand("set_thrust", {
+          x: Number(document.getElementById("thrust-x").value),
+          y: Number(document.getElementById("thrust-y").value),
+          z: Number(document.getElementById("thrust-z").value),
+        });
+      }
+
+      if (action === "set-course") {
+        return sendCommand("set_course", {
+          x: Number(document.getElementById("course-x").value),
+          y: Number(document.getElementById("course-y").value),
+          z: Number(document.getElementById("course-z").value),
+        });
+      }
+
+      if (action === "set-autopilot") {
+        return sendCommand("autopilot", {
+          enabled: document.getElementById("autopilot").value === "true",
+        });
+      }
+
+      if (action === "set-target") {
+        return sendCommand("set_target", {
+          target: document.getElementById("nav-target").value.trim(),
+        });
+      }
+
+      if (action === "ping-sensors") {
+        return sendCommand("ping_sensors", {
+          mode: document.getElementById("sensor-mode").value,
+          count: Number(document.getElementById("sensor-count").value),
+        });
+      }
+
+      if (action === "fire-weapon") {
+        return sendCommand("fire_weapon", {
+          target: document.getElementById("tactical-target").value.trim(),
+        });
+      }
+
+      if (action === "toggle-system") {
+        return sendCommand("toggle_system", {
+          system: document.getElementById("power-system").value.trim(),
+          state: document.getElementById("power-state").checked ? 1 : 0,
+        });
+      }
+
+      if (action === "set-power-allocation") {
+        return sendCommand("set_power_allocation", {
+          primary: Number(document.getElementById("power-primary").value),
+          secondary: Number(document.getElementById("power-secondary").value),
+          tertiary: Number(document.getElementById("power-tertiary").value),
+        });
+      }
+
+      appendLog(`Unknown action: ${action}`, "error");
+    });
+  });
+}
+
+setUpActions();

--- a/mobile_ui/static/styles.css
+++ b/mobile_ui/static/styles.css
@@ -1,0 +1,134 @@
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  background-color: #0a0d12;
+  color: #e6eef6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0 0 2rem;
+}
+
+.app-header {
+  padding: 1.5rem;
+  border-bottom: 1px solid #1f2a35;
+  background: linear-gradient(120deg, #0d141d, #0b1118);
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+}
+
+.layout {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.panel {
+  background: #121925;
+  border: 1px solid #202b38;
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.panel h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+}
+
+label.inline {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+input,
+select {
+  padding: 0.5rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid #2a3644;
+  background: #0c1119;
+  color: #f2f6ff;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  background: #2d80ff;
+  color: white;
+  padding: 0.55rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-bottom: 0.6rem;
+}
+
+button:hover {
+  background: #3b8bff;
+}
+
+.grid {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.grid.two {
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.grid.three {
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.log {
+  min-height: 180px;
+}
+
+#log {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-height: 240px;
+  overflow-y: auto;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.8rem;
+}
+
+.log-item {
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  background: #0d121b;
+  border: 1px solid #1f2a35;
+}
+
+.log-item.request {
+  border-color: #2d80ff;
+}
+
+.log-item.response {
+  border-color: #4fd18b;
+}
+
+.log-item.error {
+  border-color: #ff5a5a;
+}

--- a/mobile_ui/templates/index.html
+++ b/mobile_ui/templates/index.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Flaxos Mobile Station Console</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div>
+        <h1>Flaxos Mobile Station Console</h1>
+        <p>Socket protocol client for Nav, Tactical, and Power stations.</p>
+      </div>
+    </header>
+
+    <main class="layout">
+      <section class="panel">
+        <h2>Connection</h2>
+        <div class="grid two">
+          <label>
+            Host
+            <input id="host" type="text" value="{{ default_host }}" />
+          </label>
+          <label>
+            Port
+            <input id="port" type="number" inputmode="numeric" value="{{ default_port }}" />
+          </label>
+        </div>
+        <label>
+          Ship ID
+          <input id="ship" type="text" value="test_ship_001" />
+        </label>
+        <div class="actions">
+          <button data-action="test-connection">Test Connection</button>
+          <button data-action="get-state">Get State</button>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Nav / Helm</h2>
+        <div class="grid three">
+          <label>
+            Thrust X
+            <input id="thrust-x" type="number" step="0.1" value="0" />
+          </label>
+          <label>
+            Thrust Y
+            <input id="thrust-y" type="number" step="0.1" value="0" />
+          </label>
+          <label>
+            Thrust Z
+            <input id="thrust-z" type="number" step="0.1" value="0" />
+          </label>
+        </div>
+        <button data-action="set-thrust">Send Thrust</button>
+
+        <div class="grid three">
+          <label>
+            Course X
+            <input id="course-x" type="number" step="0.1" value="0" />
+          </label>
+          <label>
+            Course Y
+            <input id="course-y" type="number" step="0.1" value="0" />
+          </label>
+          <label>
+            Course Z
+            <input id="course-z" type="number" step="0.1" value="0" />
+          </label>
+        </div>
+        <button data-action="set-course">Set Course</button>
+
+        <div class="grid two">
+          <label>
+            Autopilot
+            <select id="autopilot">
+              <option value="true">Engage</option>
+              <option value="false">Disengage</option>
+            </select>
+          </label>
+          <label>
+            Target ID
+            <input id="nav-target" type="text" placeholder="target id" />
+          </label>
+        </div>
+        <div class="actions">
+          <button data-action="set-autopilot">Set Autopilot</button>
+          <button data-action="set-target">Set Target</button>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Tactical</h2>
+        <label>
+          Target ID
+          <input id="tactical-target" type="text" placeholder="target id" />
+        </label>
+        <div class="grid two">
+          <label>
+            Sensor Mode
+            <select id="sensor-mode">
+              <option value="active">Active</option>
+              <option value="passive">Passive</option>
+            </select>
+          </label>
+          <label>
+            Ping Count
+            <input id="sensor-count" type="number" value="1" min="1" />
+          </label>
+        </div>
+        <div class="actions">
+          <button data-action="ping-sensors">Ping Sensors</button>
+          <button data-action="fire-weapon">Fire Weapon</button>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Power</h2>
+        <label>
+          System Name
+          <input id="power-system" type="text" value="railgun" />
+        </label>
+        <label class="inline">
+          <input id="power-state" type="checkbox" checked />
+          Enabled
+        </label>
+        <button data-action="toggle-system">Toggle System</button>
+
+        <div class="grid three">
+          <label>
+            Primary
+            <input id="power-primary" type="number" step="0.05" value="0.5" />
+          </label>
+          <label>
+            Secondary
+            <input id="power-secondary" type="number" step="0.05" value="0.3" />
+          </label>
+          <label>
+            Tertiary
+            <input id="power-tertiary" type="number" step="0.05" value="0.2" />
+          </label>
+        </div>
+        <button data-action="set-power-allocation">Set Allocation</button>
+      </section>
+
+      <section class="panel log">
+        <h2>Command Log</h2>
+        <div id="log"></div>
+      </section>
+    </main>
+
+    <script src="/static/app.js"></script>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 pyyaml
+flask


### PR DESCRIPTION
### Motivation
- Provide a mobile-friendly client option (feasible in Pydroid) to control ships from Android via a lightweight UI.  
- Implement a thin client that speaks the project's newline-delimited JSON-over-TCP socket protocol.  
- Expose station-based menus for common command groups (Nav/Helm, Tactical, Power) mapping to existing commands like `set_thrust`, `set_course`, `autopilot`, and `ping_sensors`.  
- Allow host/port configuration so the client can target a local or LAN simulator server.  

### Description
- Add `mobile_ui/app.py`, a small Flask app that proxies UI payloads to the simulator over the socket protocol via a `/api/send` endpoint.  
- Add the web UI under `mobile_ui/templates/index.html` and `mobile_ui/static/{app.js,styles.css}` implementing Nav/Helm, Tactical, Power panels, button→payload mappings, and a command log.  
- Wire client payloads to send framed newline-delimited JSON matching server `cmd` format (e.g., `{"cmd":"set_thrust","ship":...}`).  
- Add `flask` to `requirements.txt` so the web console can be launched with `python mobile_ui/app.py`.  

### Testing
- Installed `flask` and started the Flask app (`python mobile_ui/app.py`), which served successfully on `http://127.0.0.1:5000`.  
- Loaded the UI with Playwright and captured a screenshot to verify the page and static assets rendered correctly.  
- Exercised the UI which loaded `/static/app.js` and `/static/styles.css` returning HTTP 200 responses during the smoke test.  
- No unit tests were added; only the above integration/smoke checks were performed and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b93e87a648324990b70c227371864)