### PR TITLE
Add Android/Pydroid UAT instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,47 @@ python -m server.run_server --fleet-dir hybrid_fleet --dt 0.1 --port 8765
 python hybrid/gui/gui.py
 ```
 
+## Android/Pydroid UAT (TCP JSON)
+The sim server speaks **newline-delimited JSON over TCP** (one JSON object per line). The Android UI can run in Pydroid and connect over your LAN.
+
+### 1) Install dependencies in Pydroid
+```bash
+pip install numpy pyyaml flask
+```
+
+### 2) Start the server (desktop recommended)
+Run the sim server from your desktop/laptop so it can host the simulation loop:
+```bash
+python -m server.run_server --fleet-dir hybrid_fleet --dt 0.1 --host 0.0.0.0 --port 8765
+```
+
+> If you must run the server on Android, use the same entrypoint/flags in Pydroid; just be mindful of device performance.
+
+### 3) Run the Android UI client (Pydroid)
+From the repo root on the Android device:
+```bash
+python mobile_ui/app.py
+```
+Then open `http://<android-ip>:5000` in a mobile browser. Use the form to set the sim server host/port.
+
+### 4) Port/host + LAN requirements
+- **Server host/port:** bind to `0.0.0.0:8765` on the desktop to accept LAN traffic.
+- **Client host/port:** in the UI, set host to the desktop's LAN IP (e.g. `192.168.1.20`) and port `8765`.
+- **Network:** both devices must be on the same Wi‑Fi/LAN and firewall must allow TCP 8765.
+
+### Smoke test (connectivity)
+Run from any machine on the LAN (including Pydroid) to verify the TCP JSON protocol:
+```bash
+python - <<'PY'
+import json, socket
+host = "192.168.1.20"  # replace with your server IP
+port = 8765
+with socket.create_connection((host, port), timeout=3) as sock:
+    sock.sendall((json.dumps({"cmd": "get_state"}) + "\n").encode())
+    print(sock.recv(4096).decode().strip())
+PY
+```
+
 ## Demo
 - **Interceptor** (torp launcher) vs **Target** (PDC + ECM=0.4, evasive AI).
 - In HUD: click `Target` to lock, press **F** to fire, **P** to ping, **A** toggle autopilot, **R** record.


### PR DESCRIPTION
### Motivation
- Provide guidance for running the mobile UI from Android/Pydroid to support quick UAT.
- Document required Python packages and the minimal setup needed on-device to run the UI client.
- Align user-facing instructions with the actual server entrypoint and network protocol used by the sim.
- Give a simple connectivity smoke test to verify the TCP JSON protocol and `get_state` command.

### Description
- Updated `README.md` to add an "Android/Pydroid UAT (TCP JSON)" section with step-by-step instructions.
- Specified dependency installation for Pydroid using `pip install numpy pyyaml flask`.
- Clarified the server entrypoint and flags using `python -m server.run_server --host 0.0.0.0 --port 8765` and noted the protocol is newline-delimited JSON over TCP.
- Added instructions to run the Android UI via `python mobile_ui/app.py` and included a smoke test snippet that sends `{"cmd": "get_state"}`.

### Testing
- No automated tests were executed because this is a documentation-only change.
- The change does not modify runtime code paths, so existing test suites are unaffected.
- Manual verification steps and a smoke test command were included for users to validate connectivity.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b964734888324a0b3baae05741c77)