### PR TITLE
Add Pydroid all-in-one runner (server + mobile UI) and README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ python mobile_ui/app.py
 ```
 Then open `http://<android-ip>:5000` in a mobile browser. Use the form to set the sim server host/port.
 
+#### Optional: all-in-one runtime (server + UI in one command)
+If you want a single Pydroid command that runs both the sim server and the mobile UI:
+```bash
+python pydroid_run.py --server-host 127.0.0.1 --server-port 8765 --ui-port 5000
+```
+Then open `http://<android-ip>:5000` and set the host/port to `127.0.0.1:8765`.
+
 ### 4) Port/host + LAN requirements
 - **Server host/port:** bind to `0.0.0.0:8765` on the desktop to accept LAN traffic.
 - **Client host/port:** in the UI, set host to the desktop's LAN IP (e.g. `192.168.1.20`) and port `8765`.

--- a/pydroid_run.py
+++ b/pydroid_run.py
@@ -1,0 +1,35 @@
+import argparse
+import threading
+
+from mobile_ui.app import app as mobile_app
+from server.run_server import _serve
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run sim server + mobile UI in one process (Pydroid-friendly)."
+    )
+    parser.add_argument("--server-host", default="127.0.0.1")
+    parser.add_argument("--server-port", type=int, default=8765)
+    parser.add_argument("--dt", type=float, default=0.1)
+    parser.add_argument("--fleet-dir", default="hybrid_fleet")
+    parser.add_argument("--ui-host", default="0.0.0.0")
+    parser.add_argument("--ui-port", type=int, default=5000)
+    args = parser.parse_args()
+
+    server_thread = threading.Thread(
+        target=_serve,
+        args=(args.server_host, args.server_port, args.dt, args.fleet_dir),
+        daemon=True,
+    )
+    server_thread.start()
+    print(
+        "Mobile UI running at "
+        f"http://{args.ui_host}:{args.ui_port} -> "
+        f"server {args.server_host}:{args.server_port}"
+    )
+    mobile_app.run(host=args.ui_host, port=args.ui_port, debug=False, use_reloader=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a single-command runtime for Android/Pydroid that runs both the sim server and the mobile UI together.
- Keep the existing dedicated server options available while enabling local Android execution for UAT and constrained devices.
- Avoid Flask reloader and use a simple threading approach to be Pydroid-friendly.

### Description
- Add `pydroid_run.py`, which starts the sim server by invoking `server.run_server._serve` in a daemon thread and then runs the Flask `mobile_ui.app` in the main thread.
- Expose CLI arguments in `pydroid_run.py` for `--server-host`, `--server-port`, `--dt`, `--fleet-dir`, `--ui-host`, and `--ui-port` with sensible defaults.
- Print a startup message showing the UI and server endpoints and run Flask with `debug=False` and `use_reloader=False` to avoid reloader issues on Pydroid.
- Update `README.md` with an "Optional: all-in-one runtime" usage example showing how to run `python pydroid_run.py` on Android.

### Testing
- No automated tests were run for this change.
- Manual usage instructions were added to the README for verification via Pydroid and a mobile browser.
- Basic static inspection was used to ensure the new entrypoint imports `mobile_ui.app` and `server.run_server._serve` correctly.
- No runtime regressions were detected in the automated checks that were executed (none were run specifically for this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b8eea4dbc8324aa9623fe8c4d2d2f)