### PR TITLE
Add default test_ship_001 ship config to hybrid_fleet

### DIFF
--- a/hybrid_fleet/test_ship_001.json
+++ b/hybrid_fleet/test_ship_001.json
@@ -1,0 +1,82 @@
+{
+  "id": "test_ship_001",
+  "position": {
+    "x": -2000.0,
+    "y": 500.0,
+    "z": -1500.0
+  },
+  "velocity": {
+    "x": 5.0,
+    "y": 0.0,
+    "z": 0.0
+  },
+  "orientation": {
+    "pitch": 0.0,
+    "yaw": 90.0,
+    "roll": 0.0
+  },
+  "angular_velocity": {
+    "pitch": 0.0,
+    "yaw": 0.0,
+    "roll": 0.0
+  },
+  "mass": 800.0,
+  "systems": {
+    "propulsion": {
+      "enabled": true,
+      "power_draw": 30,
+      "mass": 150,
+      "slot_type": "propulsion",
+      "tech_level": 1,
+      "main_drive": {
+        "thrust": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "max_thrust": 150.0
+      },
+      "power_status": true
+    },
+    "sensors": {
+      "enabled": true,
+      "power_draw": 8,
+      "mass": 40,
+      "slot_type": "sensor",
+      "tech_level": 1,
+      "passive": {
+        "range": 800.0,
+        "contacts": []
+      },
+      "active": {
+        "scan_range": 6000.0,
+        "scan_fov": 150.0,
+        "cooldown": 0,
+        "cooldown_time": 8.0,
+        "contact_count": 0
+      },
+      "signature_base": 1.2
+    },
+    "power_management": {
+      "primary": {
+        "output": 100.0
+      },
+      "secondary": {
+        "output": 50.0
+      },
+      "tertiary": {
+        "output": 25.0
+      },
+      "alert_threshold": 0.1,
+      "system_map": {
+        "propulsion": "primary",
+        "weapons": "primary",
+        "sensors": "secondary",
+        "defense": "secondary",
+        "rcs": "secondary",
+        "life_support": "tertiary",
+        "bio_monitor": "tertiary"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Ensure the server and UI have a default ship named `test_ship_001` available so commands and client interactions that reference that id return a valid ship state at startup.

### Description
- Add `hybrid_fleet/test_ship_001.json`, a ship configuration for `test_ship_001` containing position, velocity, mass and default `systems` entries including `propulsion`, `sensors`, and `power_management` with sensible default values.

### Testing
- No automated tests were run for this data-only change; the file was added so runtime server instances should now include `test_ship_001` in their ship list.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c61b40e6c8324b7cf3388fd9b688c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a default ship configuration for `test_ship_001` to seed runtime with a valid vessel.
> 
> - New `hybrid_fleet/test_ship_001.json` defines position/velocity/orientation, `mass`, and `systems` including `propulsion` (with `main_drive` and `max_thrust`), `sensors` (passive/active params), and `power_management` (tiered outputs and `system_map`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6008fcdb0f970494ed43fda3b70332da9b196310. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->