### PR TITLE
Surface socket errors in mobile UI and accept `command` key in server

### DIFF
--- a/mobile_ui/app.py
+++ b/mobile_ui/app.py
@@ -56,6 +56,15 @@ def api_send():
     except OSError as exc:
         return jsonify({"ok": False, "error": str(exc)})
 
+    if isinstance(response, dict) and response.get("ok") is False:
+        return jsonify(
+            {
+                "ok": False,
+                "error": response.get("error", "server error"),
+                "response": response,
+            }
+        )
+
     return jsonify({"ok": True, "response": response})
 
 

--- a/mobile_ui/static/app.js
+++ b/mobile_ui/static/app.js
@@ -21,19 +21,23 @@ async function sendCommand(command, extra = {}) {
 
   appendLog(`>> ${JSON.stringify(payload)}`, "request");
 
-  const response = await fetch("/api/send", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ host, port, payload }),
-  });
+  try {
+    const response = await fetch("/api/send", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ host, port, payload }),
+    });
 
-  const data = await response.json();
-  if (!data.ok) {
-    appendLog(`!! ${data.error}`, "error");
-    return;
+    const data = await response.json();
+    if (!data.ok) {
+      appendLog(`!! ${data.error}`, "error");
+      return;
+    }
+
+    appendLog(`<< ${JSON.stringify(data.response)}`, "response");
+  } catch (error) {
+    appendLog(`!! ${error}`, "error");
   }
-
-  appendLog(`<< ${JSON.stringify(data.response)}`, "response");
 }
 
 function setUpActions() {

--- a/server/run_server.py
+++ b/server/run_server.py
@@ -38,7 +38,7 @@ def _format_ship_state(state: dict) -> dict:
 
 
 def dispatch(runner: HybridRunner, req: dict) -> dict:
-    cmd = req.get("cmd")
+    cmd = req.get("cmd") or req.get("command")
     if not cmd:
         return {"ok": False, "error": "missing cmd"}
 


### PR DESCRIPTION
### Motivation
- The mobile UI sometimes failed silently when the TCP server returned error objects or when network/fetch failed, making debugging difficult.
- Some clients send `command` instead of `cmd` in the TCP JSON payload, causing the server to reject valid requests.
- Improve observability and compatibility so errors are surfaced to the UI and the server accepts both keys.

### Description
- Updated `server/run_server.py` dispatch to accept `req.get("cmd") or req.get("command")` so `command` is a fallback key for incoming socket requests.
- Changed `mobile_ui/app.py` to propagate server-side socket error responses (where the socket response contains `ok: False`) back to the HTTP API as an error payload.
- Wrapped the fetch call in `mobile_ui/static/app.js` in a `try/catch` and log network/fetch exceptions to the UI command log to avoid silent failures.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c64f32810832481b1f32e5dca1f37)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves error visibility in the mobile UI and expands server command key compatibility.
> 
> - mobile_ui/app.py: Propagates socket error responses (`{"ok": false}`) from TCP server as HTTP errors, including the original `response` payload
> - mobile_ui/static/app.js: Wraps fetch in try/catch and logs network/fetch exceptions to the UI log
> - server/run_server.py: `dispatch` accepts `cmd` or `command` for incoming requests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2be989a2837725b312352c9d0bf84a0f42961c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->