### PR TITLE
fix: Station system API bugs and test failures

### DIFF
--- a/hybrid/command_handler.py
+++ b/hybrid/command_handler.py
@@ -10,6 +10,20 @@ from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
+# System command mappings (system_name, action)
+# This dict maps command names to (system, action) tuples for routing
+system_commands = {
+    "set_thrust": ("propulsion", "set_thrust"),
+    "set_orientation": ("helm", "set_orientation"),
+    "set_angular_velocity": ("helm", "set_angular_velocity"),
+    "rotate": ("helm", "rotate"),
+    "set_course": ("navigation", "set_course"),
+    "autopilot": ("navigation", "set_autopilot"),
+    "helm_override": ("helm", "set_mode"),
+    "ping_sensors": ("sensors", "ping"),
+    "override_bio_monitor": ("bio_monitor", "override")
+}
+
 def parse_command(data):
     """
     Parse a command string or dictionary
@@ -78,29 +92,16 @@ def route_command(ship, command_data):
 def execute_command(ship, command_type, command_data):
     """
     Execute a command on a ship
-    
+
     Args:
         ship (Ship): The ship to execute the command on
         command_type (str): The type of command to execute
         command_data (dict): The command data
-        
+
     Returns:
         dict: Command response
     """
-    # Special handling for system-specific commands
-    system_commands = {
-        "set_thrust": ("propulsion", "set_thrust"),
-        "set_orientation": ("helm", "set_orientation"),
-        "set_angular_velocity": ("helm", "set_angular_velocity"),
-        "rotate": ("helm", "rotate"),
-        "set_course": ("navigation", "set_course"),
-        "autopilot": ("navigation", "set_autopilot"),
-        "helm_override": ("helm", "set_mode"),
-        "ping_sensors": ("sensors", "ping"),
-        "override_bio_monitor": ("bio_monitor", "override")
-    }
-    
-    # Check if this is a system-specific command
+    # Check if this is a system-specific command (uses module-level system_commands)
     if command_type in system_commands:
         system_name, action = system_commands[command_type]
         


### PR DESCRIPTION
Critical fixes for station-based control system:

## Bug Fixes

1. **Server startup crash** (station_dispatch.py:245)
   - Moved system_commands to module level in command_handler.py
   - Was defined as local variable, causing ImportError on server init
   - Server now starts successfully

2. **Station manager test API mismatches** (7 failing tests)
   - Fixed release_station() signature - now requires ship_id and station params
   - Fixed get_ship_stations() return type - returns Dict[StationType, str]
   - Fixed can_issue_command() method name and signature
   - Fixed heartbeat() -> update_activity() method name
   - Fixed cleanup_stale_sessions() -> cleanup_stale_claims() method name
   - Fixed disconnect() -> unregister_client() method name
   - Replaced get_claim() calls with get_station_owner()

## Test Results
- Before: 7 failed, 65 passed
- After: 72 passed, 0 failed

## Server Status
- Server starts and listens successfully
- Client connections working
- Station management commands registered
- Fleet system operational

## Known Issues (non-critical)
- ActiveSensor subscripting error in telemetry generation (log spam)
- Power management config loading error in test_ship_001.json
- These don't prevent operation but should be addressed