### PR TITLE
Add stable station telemetry filter entrypoint and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Stable station telemetry filter import path in `server/telemetry/station_filter.py`.
+- Station telemetry filtering tests for helm/captain behavior.
+
 ### Planned
 - Quaternion-based attitude system (Sprint S3)
 - RCS thruster torque calculations (Sprint S3)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Flaxos Spaceship Simulator - Architecture Documentation
 
 **Version**: 0.2.0
-**Last Updated**: 2026-01-20
+**Last Updated**: 2026-01-21
 
 ---
 
@@ -167,6 +167,12 @@ class StationTelemetryFilter:
 
     filter_ship_telemetry(ship_data, station) -> filtered_data
     filter_telemetry_for_client(client_id, full_snapshot) -> filtered_snapshot
+```
+
+**telemetry/station_filter.py**
+```python
+# Stable import path for station telemetry filtering
+from server.stations.station_telemetry import StationTelemetryFilter
 ```
 
 **fleet_commands.py**

--- a/docs/FEATURE_STATUS.md
+++ b/docs/FEATURE_STATUS.md
@@ -1,6 +1,6 @@
 # Feature Status Report
 
-**Last Updated**: 2026-01-20
+**Last Updated**: 2026-01-21
 **Project**: Flaxos Spaceship Simulator
 **Version**: 0.2.0 (Phase 2 Complete)
 
@@ -78,6 +78,7 @@ This document tracks the implementation status of all major features in the Flax
 - `server/stations/station_manager.py` - Claim management and sessions
 - `server/stations/station_dispatch.py` - Command routing with permissions
 - `server/stations/station_telemetry.py` - Data filtering per station
+- `server/telemetry/station_filter.py` - Station telemetry filter import path
 - `server/stations/station_commands.py` - Station-specific commands
 - `server/station_server.py` - TCP server with station support
 
@@ -195,29 +196,33 @@ This document tracks the implementation status of all major features in the Flax
 | TUTORIAL.md | ✅ Complete | 2026-01-19 |
 | SPRINT_RECOMMENDATIONS.md | ✅ Complete | 2026-01-19 |
 | PROJECT_PLAN.md | ✅ Complete | 2026-01-19 |
-| FEATURE_STATUS.md | ✅ Complete | 2026-01-20 |
-| ARCHITECTURE.md | 📋 Pending | - |
-| KNOWN_ISSUES.md | 📋 Pending | - |
-| NEXT_SPRINT.md | 📋 Pending | - |
-| CHANGELOG.md | 📋 Pending | - |
+| FEATURE_STATUS.md | ✅ Complete | 2026-01-21 |
+| ARCHITECTURE.md | ✅ Complete | 2026-01-21 |
+| KNOWN_ISSUES.md | ✅ Complete | 2026-01-21 |
+| NEXT_SPRINT.md | ✅ Complete | 2026-01-21 |
+| CHANGELOG.md | ✅ Complete | 2026-01-21 |
 
 ---
 
 ## Testing Summary
 
 ### Test Coverage
-- **Total Tests**: 72
-- **Passing**: 72 (100%)
+- **Total Tests**: 129
+- **Passing**: 129 (100%)
 - **Failed**: 0
 - **Skipped**: 0
 
 ### Test Suites
-- Core physics tests: ✅ 12 passing
-- Navigation tests: ✅ 8 passing
-- Weapon tests: ✅ 10 passing
-- Sensor tests: ✅ 6 passing
-- Station tests: ✅ 28 passing
-- Hybrid integration tests: ✅ 8 passing
+- Core event bus tests: ✅ 1 passing
+- Core physics tests: ✅ 27 passing
+- Navigation tests: ✅ 1 passing
+- Power system tests: ✅ 2 passing
+- Weapon tests: ✅ 2 passing
+- Sensor tests: ✅ 1 passing
+- Station tests: ✅ 30 passing
+- Utility math tests: ✅ 55 passing
+- Integration tests: ✅ 9 passing
+- Smoke tests: ✅ 1 passing
 
 ### CI/CD
 - GitHub Actions: 📋 Planned (Sprint S6)

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 **Project**: Flaxos Spaceship Simulator
 **Version**: 0.2.0
-**Last Updated**: 2026-01-20
+**Last Updated**: 2026-01-21
 
 ---
 
@@ -40,6 +40,29 @@ Sprint S3 will implement quaternion-based attitude representation, completely el
 - `hybrid/ship.py` - Add quaternion state
 - `hybrid/utils/quaternion.py` - New quaternion math library
 - `hybrid/navigation/` - Update autopilot to use quaternions
+
+---
+
+### 2. Telemetry snapshot errors in `server.run_server`
+**Status**: 🔴 Known Issue
+**Severity**: High (Server telemetry)
+**Affected Components**: `hybrid/telemetry.py`, `hybrid/systems/sensors/active.py`, ship configs
+
+**Description:**
+Running `python -m server.run_server` logs repeated telemetry errors:
+- `Error getting state ... 'ActiveSensor' object is not subscriptable`
+- `Error loading system power_management: 'float' object has no attribute 'get'`
+
+**Impact:**
+- `get_state` responses can fail or be incomplete
+- Server logs are spammed with errors during telemetry collection
+
+**Workaround:**
+Use the station-aware server (`python -m server.station_server`) for multi-crew workflows and avoid telemetry polling when running the legacy server.
+
+**Resolution Plan:**
+- Normalize sensor telemetry serialization for `ActiveSensor`
+- Validate power management config structure in ship definitions before load
 
 ---
 

--- a/docs/NEXT_SPRINT.md
+++ b/docs/NEXT_SPRINT.md
@@ -16,6 +16,9 @@ Sprint S3 focuses on replacing the Euler angle orientation system with quaternio
 3. **Improved aim fidelity** - Weapon pointing accuracy
 4. **Foundation for Sprint S4** - Advanced combat mechanics
 
+**Recent Updates**
+- Added a stable telemetry filter import path (`server/telemetry/station_filter.py`) and tests to validate station-scoped filtering. Keep this module updated if telemetry logic changes.
+
 ---
 
 ## Sprint Goals

--- a/server/station_server.py
+++ b/server/station_server.py
@@ -26,7 +26,7 @@ from server.stations import StationManager
 from server.stations.station_dispatch import StationAwareDispatcher, CommandResult, register_legacy_commands
 from server.stations.station_commands import register_station_commands
 from server.stations.fleet_commands import register_fleet_commands
-from server.stations.station_telemetry import StationTelemetryFilter
+from server.telemetry.station_filter import StationTelemetryFilter
 from server.stations.crew_system import CrewManager
 
 logging.basicConfig(level=logging.INFO)

--- a/server/telemetry/__init__.py
+++ b/server/telemetry/__init__.py
@@ -1,0 +1,5 @@
+"""Telemetry filtering helpers for station-aware clients."""
+
+from .station_filter import StationTelemetryFilter, create_station_specific_telemetry
+
+__all__ = ["StationTelemetryFilter", "create_station_specific_telemetry"]

--- a/server/telemetry/station_filter.py
+++ b/server/telemetry/station_filter.py
@@ -1,0 +1,13 @@
+"""
+Station telemetry filtering entry point.
+
+This module provides a stable import path for station-aware telemetry filtering,
+wrapping the implementation that lives in the station system.
+"""
+
+from server.stations.station_telemetry import (
+    StationTelemetryFilter,
+    create_station_specific_telemetry,
+)
+
+__all__ = ["StationTelemetryFilter", "create_station_specific_telemetry"]

--- a/tests/stations/test_station_filter.py
+++ b/tests/stations/test_station_filter.py
@@ -1,0 +1,58 @@
+"""Tests for station telemetry filtering entry point."""
+
+from server.stations.station_manager import StationManager
+from server.stations.station_types import StationType
+from server.telemetry.station_filter import StationTelemetryFilter
+
+
+def _sample_ship_telemetry():
+    return {
+        "id": "test_ship_001",
+        "name": "Test Ship",
+        "class": "frigate",
+        "position": {"x": 1, "y": 2, "z": 3},
+        "velocity": {"x": 0, "y": 1, "z": 0},
+        "orientation": {"pitch": 0, "yaw": 0, "roll": 0},
+        "fuel": {"mass": 100},
+        "systems": {"propulsion": "online"},
+        "weapons": {"status": "armed"},
+        "timestamp": 123.4,
+    }
+
+
+def test_helm_filter_excludes_tactical_data():
+    manager = StationManager()
+    client_id = manager.generate_client_id()
+    manager.register_client(client_id, "helm_player")
+    manager.assign_to_ship(client_id, "test_ship_001")
+    manager.claim_station(client_id, "test_ship_001", StationType.HELM)
+
+    telemetry_filter = StationTelemetryFilter(manager)
+    filtered = telemetry_filter.filter_ship_state_for_client(
+        client_id,
+        "test_ship_001",
+        _sample_ship_telemetry(),
+    )
+
+    assert "position" in filtered
+    assert "velocity" in filtered
+    assert "orientation" in filtered
+    assert "weapons" not in filtered
+
+
+def test_captain_filter_includes_all_data():
+    manager = StationManager()
+    client_id = manager.generate_client_id()
+    manager.register_client(client_id, "captain_player")
+    manager.assign_to_ship(client_id, "test_ship_001")
+    manager.claim_station(client_id, "test_ship_001", StationType.CAPTAIN)
+
+    telemetry_filter = StationTelemetryFilter(manager)
+    sample = _sample_ship_telemetry()
+    filtered = telemetry_filter.filter_ship_state_for_client(
+        client_id,
+        "test_ship_001",
+        sample,
+    )
+
+    assert filtered == sample


### PR DESCRIPTION
### Motivation
- Provide a stable import path for station-aware telemetry filtering so server code and external modules can reliably import telemetry helpers. 
- Add focused unit tests to validate that station-scoped telemetry filtering returns the expected views (e.g., Helm excludes weapons, Captain receives full telemetry). 
- Record the current `server.run_server` telemetry issues discovered during smoke testing so they are tracked for follow-up fixes.

### Description
- Added a telemetry entrypoint package `server/telemetry` with `__init__.py` and `station_filter.py` that re-exports `StationTelemetryFilter` and `create_station_specific_telemetry` from the station system. 
- Updated `server/station_server.py` to import the telemetry filter from the new stable path (`server.telemetry.station_filter`). 
- Added tests `tests/stations/test_station_filter.py` that exercise Helm vs Captain telemetry filtering, and updated documentation (`docs/*`) and `CHANGELOG.md` to reflect the new import path and test coverage adjustments.

### Testing
- Ran the new test file with `python -m pytest tests/stations/test_station_filter.py -q`, which passed `2` tests. 
- Ran the full test suite with `python -m pytest -v`, resulting in `129 passed, 7 warnings` (warnings are `PytestReturnNotNoneWarning` originating from `test_phase2_integration.py`). 
- Performed a smoke server run (`python -m server.run_server` + a `get_state` probe) which exercised telemetry code and surfaced recurring telemetry errors: `ActiveSensor` serialization errors and a power management config parsing error (`'float' object has no attribute 'get'`), which are documented in `docs/KNOWN_ISSUES.md` for follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f60d56d0c83248fd0414c790315fb)