### PR TITLE
Ensure CAPTAIN claims auto-elevate and fix Phase 2 tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stable station telemetry filter import path in `server/telemetry/station_filter.py`.
 - Station telemetry filtering tests for helm/captain behavior.
 
+### Fixed
+- Captain station claims now auto-elevate permissions for override actions.
+- Phase 2 integration tests no longer return values (removes pytest warnings).
+
 ### Planned
 - Quaternion-based attitude system (Sprint S3)
 - RCS thruster torque calculations (Sprint S3)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Flaxos Spaceship Simulator - Architecture Documentation
 
 **Version**: 0.2.0
-**Last Updated**: 2026-01-21
+**Last Updated**: 2026-01-22
 
 ---
 
@@ -142,6 +142,8 @@ class StationManager:
     assign_to_ship(client_id, ship_id)
     claim_station(client_id, ship_id, station)
     release_station(client_id, ship_id, station)
+
+    # Claims auto-upgrade CAPTAIN station permissions
 
     # Permission checking
     can_issue_command(client_id, ship_id, command) -> (bool, str)

--- a/docs/FEATURE_STATUS.md
+++ b/docs/FEATURE_STATUS.md
@@ -1,6 +1,6 @@
 # Feature Status Report
 
-**Last Updated**: 2026-01-21
+**Last Updated**: 2026-01-22
 **Project**: Flaxos Spaceship Simulator
 **Version**: 0.2.0 (Phase 2 Complete)
 
@@ -66,7 +66,7 @@ This document tracks the implementation status of all major features in the Flax
 |---------|--------|-------|-------|
 | Station types | ✅ Complete | 28/28 passing | 7 stations: Captain, Helm, Tactical, Ops, Engineering, Comms, Fleet Commander |
 | Permission system | ✅ Complete | ✅ | 4 levels: Observer, Crew, Officer, Captain |
-| Station manager | ✅ Complete | ✅ | Claim/release, session tracking |
+| Station manager | ✅ Complete | ✅ | Claim/release, session tracking, captain escalation |
 | Command dispatcher | ✅ Complete | ✅ | Permission-based routing |
 | Telemetry filtering | ✅ Complete | ✅ | Station-specific data views |
 | Event filtering | ✅ Complete | ✅ | Role-based event delivery |

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 **Project**: Flaxos Spaceship Simulator
 **Version**: 0.2.0
-**Last Updated**: 2026-01-21
+**Last Updated**: 2026-01-22
 
 ---
 

--- a/docs/NEXT_SPRINT.md
+++ b/docs/NEXT_SPRINT.md
@@ -18,6 +18,7 @@ Sprint S3 focuses on replacing the Euler angle orientation system with quaternio
 
 **Recent Updates**
 - Added a stable telemetry filter import path (`server/telemetry/station_filter.py`) and tests to validate station-scoped filtering. Keep this module updated if telemetry logic changes.
+- Captain station claims now auto-elevate permissions for cross-station overrides.
 
 ---
 

--- a/server/stations/station_manager.py
+++ b/server/stations/station_manager.py
@@ -207,6 +207,10 @@ class StationManager:
                 other_name = other_session.player_name if other_session else "Unknown"
                 return False, f"Station {station.value} is controlled by {other_name}"
 
+        # Ensure captains always receive captain-level permissions
+        if station == StationType.CAPTAIN:
+            permission_level = PermissionLevel.CAPTAIN
+
         # Claim the station
         now = datetime.now()
         claim = StationClaim(
@@ -256,7 +260,10 @@ class StationManager:
         if claim.client_id != client_id:
             # Check if requester is Captain (can force release)
             requester_session = self.sessions.get(client_id)
-            if not requester_session or requester_session.permission_level < PermissionLevel.CAPTAIN:
+            if (
+                not requester_session
+                or requester_session.permission_level.value < PermissionLevel.CAPTAIN.value
+            ):
                 return False, "You don't control this station"
 
         # Release the claim

--- a/test_phase2_integration.py
+++ b/test_phase2_integration.py
@@ -15,6 +15,8 @@ import sys
 import os
 import logging
 
+import pytest
+
 # Add project root to path
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, ROOT_DIR)
@@ -38,34 +40,36 @@ def test_fleet_manager_integration():
     logger.info("=" * 60)
 
     if not HAS_NUMPY:
-        logger.warning("⊘ SKIPPED: Test requires numpy (pip install numpy)")
-        return None  # None indicates skipped test
+        pytest.skip("Test requires numpy (pip install numpy)")
 
-    try:
-        from hybrid.simulator import Simulator
-        from hybrid.fleet.fleet_manager import FleetManager
+    from hybrid.simulator import Simulator
+    from hybrid.fleet.fleet_manager import FleetManager
 
-        # Create simulator
-        sim = Simulator(dt=0.1)
+    # Create simulator
+    sim = Simulator(dt=0.1)
 
-        # Check fleet_manager exists
-        assert hasattr(sim, 'fleet_manager'), "Simulator missing fleet_manager attribute"
-        assert isinstance(sim.fleet_manager, FleetManager), "fleet_manager is not a FleetManager instance"
-        assert sim.fleet_manager.simulator == sim, "FleetManager not properly linked to Simulator"
+    # Check fleet_manager exists
+    assert hasattr(sim, 'fleet_manager'), "Simulator missing fleet_manager attribute"
+    assert isinstance(sim.fleet_manager, FleetManager), "fleet_manager is not a FleetManager instance"
+    assert sim.fleet_manager.simulator == sim, "FleetManager not properly linked to Simulator"
 
-        logger.info("✓ FleetManager is integrated with Simulator")
-        logger.info("✓ FleetManager has reference to Simulator")
+    logger.info("✓ FleetManager is integrated with Simulator")
+    logger.info("✓ FleetManager has reference to Simulator")
 
-        # Test fleet creation
-        success = sim.fleet_manager.create_fleet("test_fleet", "Test Fleet", "test_ship", [])
-        logger.info(f"✓ Fleet creation test: {success}")
-
-        return True
-    except Exception as e:
-        logger.error(f"✗ Fleet Manager integration test failed: {e}")
-        import traceback
-        traceback.print_exc()
-        return False
+    # Test fleet creation
+    sim.add_ship(
+        "test_ship",
+        {
+            "name": "Test Ship",
+            "mass": 1000.0,
+            "class": "frigate",
+            "faction": "test",
+            "ai_enabled": False
+        },
+    )
+    success = sim.fleet_manager.create_fleet("test_fleet", "Test Fleet", "test_ship", [])
+    assert success is True
+    logger.info("✓ Fleet creation test passed")
 
 
 def test_ai_controller_integration():
@@ -75,51 +79,42 @@ def test_ai_controller_integration():
     logger.info("=" * 60)
 
     if not HAS_NUMPY:
-        logger.warning("⊘ SKIPPED: Test requires numpy (pip install numpy)")
-        return None  # None indicates skipped test
+        pytest.skip("Test requires numpy (pip install numpy)")
 
-    try:
-        from hybrid.ship import Ship
-        from hybrid.fleet.ai_controller import AIController, AIBehavior
+    from hybrid.ship import Ship
+    from hybrid.fleet.ai_controller import AIBehavior
 
-        # Create ship
-        config = {
-            "name": "Test Ship",
-            "mass": 1000.0,
-            "class": "frigate",
-            "faction": "test",
-            "ai_enabled": False
-        }
-        ship = Ship("test_ship", config)
+    # Create ship
+    config = {
+        "name": "Test Ship",
+        "mass": 1000.0,
+        "class": "frigate",
+        "faction": "test",
+        "ai_enabled": False
+    }
+    ship = Ship("test_ship", config)
 
-        # Check AI attributes exist
-        assert hasattr(ship, 'ai_controller'), "Ship missing ai_controller attribute"
-        assert hasattr(ship, 'fleet_id'), "Ship missing fleet_id attribute"
-        assert hasattr(ship, 'ai_enabled'), "Ship missing ai_enabled attribute"
+    # Check AI attributes exist
+    assert hasattr(ship, 'ai_controller'), "Ship missing ai_controller attribute"
+    assert hasattr(ship, 'fleet_id'), "Ship missing fleet_id attribute"
+    assert hasattr(ship, 'ai_enabled'), "Ship missing ai_enabled attribute"
 
-        logger.info("✓ Ship has AI-related attributes")
+    logger.info("✓ Ship has AI-related attributes")
 
-        # Test enabling AI
-        success = ship.enable_ai(AIBehavior.IDLE)
-        assert success, "Failed to enable AI"
-        assert ship.ai_enabled, "AI not marked as enabled"
-        assert ship.ai_controller is not None, "AI controller not created"
+    # Test enabling AI
+    success = ship.enable_ai(AIBehavior.IDLE)
+    assert success, "Failed to enable AI"
+    assert ship.ai_enabled, "AI not marked as enabled"
+    assert ship.ai_controller is not None, "AI controller not created"
 
-        logger.info("✓ AI can be enabled on ships")
-        logger.info("✓ AI controller is created properly")
+    logger.info("✓ AI can be enabled on ships")
+    logger.info("✓ AI controller is created properly")
 
-        # Test disabling AI
-        ship.disable_ai()
-        assert not ship.ai_enabled, "AI not marked as disabled"
+    # Test disabling AI
+    ship.disable_ai()
+    assert not ship.ai_enabled, "AI not marked as disabled"
 
-        logger.info("✓ AI can be disabled on ships")
-
-        return True
-    except Exception as e:
-        logger.error(f"✗ AI Controller integration test failed: {e}")
-        import traceback
-        traceback.print_exc()
-        return False
+    logger.info("✓ AI can be disabled on ships")
 
 
 def test_captain_override_system():
@@ -128,53 +123,45 @@ def test_captain_override_system():
     logger.info("TEST 3: CAPTAIN Override System")
     logger.info("=" * 60)
 
-    try:
-        from server.stations.station_manager import StationManager
-        from server.stations.station_types import StationType, PermissionLevel
+    from server.stations.station_manager import StationManager
+    from server.stations.station_types import StationType, PermissionLevel
 
-        manager = StationManager()
+    manager = StationManager()
 
-        # Register two clients
-        captain_id = manager.generate_client_id()
-        helm_id = manager.generate_client_id()
+    # Register two clients
+    captain_id = manager.generate_client_id()
+    helm_id = manager.generate_client_id()
 
-        manager.register_client(captain_id, "Captain")
-        manager.register_client(helm_id, "Helm Officer")
+    manager.register_client(captain_id, "Captain")
+    manager.register_client(helm_id, "Helm Officer")
 
-        # Assign to ship
-        manager.assign_to_ship(captain_id, "test_ship")
-        manager.assign_to_ship(helm_id, "test_ship")
+    # Assign to ship
+    manager.assign_to_ship(captain_id, "test_ship")
+    manager.assign_to_ship(helm_id, "test_ship")
 
-        # Claim stations
-        manager.claim_station(captain_id, "test_ship", StationType.CAPTAIN, PermissionLevel.CAPTAIN)
-        manager.claim_station(helm_id, "test_ship", StationType.HELM, PermissionLevel.CREW)
+    # Claim stations
+    manager.claim_station(captain_id, "test_ship", StationType.CAPTAIN, PermissionLevel.CAPTAIN)
+    manager.claim_station(helm_id, "test_ship", StationType.HELM, PermissionLevel.CREW)
 
-        logger.info("✓ Test clients and stations created")
+    logger.info("✓ Test clients and stations created")
 
-        # Test CAPTAIN can issue HELM commands (override)
-        can_issue, reason = manager.can_issue_command(captain_id, "test_ship", "set_thrust")
-        assert can_issue, f"CAPTAIN should be able to override HELM commands: {reason}"
+    # Test CAPTAIN can issue HELM commands (override)
+    can_issue, reason = manager.can_issue_command(captain_id, "test_ship", "set_thrust")
+    assert can_issue, f"CAPTAIN should be able to override HELM commands: {reason}"
 
-        logger.info("✓ CAPTAIN can override HELM commands")
+    logger.info("✓ CAPTAIN can override HELM commands")
 
-        # Test HELM cannot issue TACTICAL commands
-        can_issue, reason = manager.can_issue_command(helm_id, "test_ship", "fire")
-        assert not can_issue, "HELM should not be able to issue TACTICAL commands"
+    # Test HELM cannot issue TACTICAL commands
+    can_issue, reason = manager.can_issue_command(helm_id, "test_ship", "fire")
+    assert not can_issue, "HELM should not be able to issue TACTICAL commands"
 
-        logger.info("✓ HELM cannot issue TACTICAL commands")
+    logger.info("✓ HELM cannot issue TACTICAL commands")
 
-        # Test CAPTAIN can issue TACTICAL commands
-        can_issue, reason = manager.can_issue_command(captain_id, "test_ship", "fire")
-        assert can_issue, f"CAPTAIN should be able to issue TACTICAL commands: {reason}"
+    # Test CAPTAIN can issue TACTICAL commands
+    can_issue, reason = manager.can_issue_command(captain_id, "test_ship", "fire")
+    assert can_issue, f"CAPTAIN should be able to issue TACTICAL commands: {reason}"
 
-        logger.info("✓ CAPTAIN can override TACTICAL commands")
-
-        return True
-    except Exception as e:
-        logger.error(f"✗ CAPTAIN override test failed: {e}")
-        import traceback
-        traceback.print_exc()
-        return False
+    logger.info("✓ CAPTAIN can override TACTICAL commands")
 
 
 def test_officer_role():
@@ -183,53 +170,45 @@ def test_officer_role():
     logger.info("TEST 4: OFFICER Role Functionality")
     logger.info("=" * 60)
 
-    try:
-        from server.stations.station_manager import StationManager
-        from server.stations.station_types import StationType, PermissionLevel
+    from server.stations.station_manager import StationManager
+    from server.stations.station_types import StationType, PermissionLevel
 
-        manager = StationManager()
+    manager = StationManager()
 
-        # Register clients
-        captain_id = manager.generate_client_id()
-        officer_id = manager.generate_client_id()
-        crew_id = manager.generate_client_id()
+    # Register clients
+    captain_id = manager.generate_client_id()
+    officer_id = manager.generate_client_id()
+    crew_id = manager.generate_client_id()
 
-        manager.register_client(captain_id, "Captain")
-        manager.register_client(officer_id, "Officer")
-        manager.register_client(crew_id, "Crew")
+    manager.register_client(captain_id, "Captain")
+    manager.register_client(officer_id, "Officer")
+    manager.register_client(crew_id, "Crew")
 
-        # Assign to ship
-        manager.assign_to_ship(captain_id, "test_ship")
-        manager.assign_to_ship(officer_id, "test_ship")
-        manager.assign_to_ship(crew_id, "test_ship")
+    # Assign to ship
+    manager.assign_to_ship(captain_id, "test_ship")
+    manager.assign_to_ship(officer_id, "test_ship")
+    manager.assign_to_ship(crew_id, "test_ship")
 
-        # Claim stations
-        manager.claim_station(captain_id, "test_ship", StationType.CAPTAIN, PermissionLevel.CAPTAIN)
-        manager.claim_station(officer_id, "test_ship", StationType.HELM, PermissionLevel.OFFICER)
-        manager.claim_station(crew_id, "test_ship", StationType.TACTICAL, PermissionLevel.CREW)
+    # Claim stations
+    manager.claim_station(captain_id, "test_ship", StationType.CAPTAIN, PermissionLevel.CAPTAIN)
+    manager.claim_station(officer_id, "test_ship", StationType.HELM, PermissionLevel.OFFICER)
+    manager.claim_station(crew_id, "test_ship", StationType.TACTICAL, PermissionLevel.CREW)
 
-        logger.info("✓ Test clients with different permission levels created")
+    logger.info("✓ Test clients with different permission levels created")
 
-        # Verify permission levels
-        captain_session = manager.get_session(captain_id)
-        officer_session = manager.get_session(officer_id)
-        crew_session = manager.get_session(crew_id)
+    # Verify permission levels
+    captain_session = manager.get_session(captain_id)
+    officer_session = manager.get_session(officer_id)
+    crew_session = manager.get_session(crew_id)
 
-        assert captain_session.permission_level == PermissionLevel.CAPTAIN, "Captain not at CAPTAIN level"
-        assert officer_session.permission_level == PermissionLevel.OFFICER, "Officer not at OFFICER level"
-        assert crew_session.permission_level == PermissionLevel.CREW, "Crew not at CREW level"
+    assert captain_session.permission_level == PermissionLevel.CAPTAIN, "Captain not at CAPTAIN level"
+    assert officer_session.permission_level == PermissionLevel.OFFICER, "Officer not at OFFICER level"
+    assert crew_session.permission_level == PermissionLevel.CREW, "Crew not at CREW level"
 
-        logger.info("✓ Permission levels set correctly")
-        logger.info(f"  - CAPTAIN: {captain_session.permission_level.name}")
-        logger.info(f"  - OFFICER: {officer_session.permission_level.name}")
-        logger.info(f"  - CREW: {crew_session.permission_level.name}")
-
-        return True
-    except Exception as e:
-        logger.error(f"✗ OFFICER role test failed: {e}")
-        import traceback
-        traceback.print_exc()
-        return False
+    logger.info("✓ Permission levels set correctly")
+    logger.info(f"  - CAPTAIN: {captain_session.permission_level.name}")
+    logger.info(f"  - OFFICER: {officer_session.permission_level.name}")
+    logger.info(f"  - CREW: {crew_session.permission_level.name}")
 
 
 def test_crew_efficiency_system():
@@ -238,77 +217,69 @@ def test_crew_efficiency_system():
     logger.info("TEST 5: Crew Efficiency System")
     logger.info("=" * 60)
 
-    try:
-        from server.stations.crew_system import CrewManager, CrewSkills, StationSkill, SkillLevel
+    from server.stations.crew_system import CrewManager, CrewSkills, StationSkill, SkillLevel
 
-        crew_manager = CrewManager()
+    crew_manager = CrewManager()
 
-        # Create crew member
-        skills = CrewSkills()
-        skills.set_skill(StationSkill.PILOTING, SkillLevel.EXPERT.value)
-        skills.set_skill(StationSkill.GUNNERY, SkillLevel.SKILLED.value)
+    # Create crew member
+    skills = CrewSkills()
+    skills.set_skill(StationSkill.PILOTING, SkillLevel.EXPERT.value)
+    skills.set_skill(StationSkill.GUNNERY, SkillLevel.SKILLED.value)
 
-        crew = crew_manager.create_crew_member(
-            ship_id="test_ship",
-            name="Test Pilot",
-            client_id="test_client",
-            skills=skills
-        )
+    crew = crew_manager.create_crew_member(
+        ship_id="test_ship",
+        name="Test Pilot",
+        client_id="test_client",
+        skills=skills
+    )
 
-        logger.info("✓ Crew member created")
-        logger.info(f"  - Name: {crew.name}")
-        logger.info(f"  - ID: {crew.crew_id}")
+    logger.info("✓ Crew member created")
+    logger.info(f"  - Name: {crew.name}")
+    logger.info(f"  - ID: {crew.crew_id}")
 
-        # Test efficiency calculation
-        piloting_efficiency = crew.get_current_efficiency(StationSkill.PILOTING)
-        gunnery_efficiency = crew.get_current_efficiency(StationSkill.GUNNERY)
+    # Test efficiency calculation
+    piloting_efficiency = crew.get_current_efficiency(StationSkill.PILOTING)
+    gunnery_efficiency = crew.get_current_efficiency(StationSkill.GUNNERY)
 
-        logger.info("✓ Efficiency calculation working")
-        logger.info(f"  - Piloting efficiency (EXPERT): {piloting_efficiency:.2%}")
-        logger.info(f"  - Gunnery efficiency (SKILLED): {gunnery_efficiency:.2%}")
+    logger.info("✓ Efficiency calculation working")
+    logger.info(f"  - Piloting efficiency (EXPERT): {piloting_efficiency:.2%}")
+    logger.info(f"  - Gunnery efficiency (SKILLED): {gunnery_efficiency:.2%}")
 
-        assert piloting_efficiency > gunnery_efficiency, "EXPERT should have higher efficiency than SKILLED"
+    assert piloting_efficiency > gunnery_efficiency, "EXPERT should have higher efficiency than SKILLED"
 
-        # Test fatigue system
-        initial_fatigue = crew.fatigue
-        crew.update_fatigue(3600.0)  # 1 hour
-        assert crew.fatigue > initial_fatigue, "Fatigue should increase over time"
+    # Test fatigue system
+    initial_fatigue = crew.fatigue
+    crew.update_fatigue(3600.0)  # 1 hour
+    assert crew.fatigue > initial_fatigue, "Fatigue should increase over time"
 
-        logger.info("✓ Fatigue system working")
-        logger.info(f"  - Initial fatigue: {initial_fatigue:.2f}")
-        logger.info(f"  - After 1 hour: {crew.fatigue:.2f}")
+    logger.info("✓ Fatigue system working")
+    logger.info(f"  - Initial fatigue: {initial_fatigue:.2f}")
+    logger.info(f"  - After 1 hour: {crew.fatigue:.2f}")
 
-        # Test rest
-        crew.rest(4.0)  # 4 hours rest
-        assert crew.fatigue < 0.5, "Rest should reduce fatigue significantly"
+    # Test rest
+    crew.rest(4.0)  # 4 hours rest
+    assert crew.fatigue < 0.5, "Rest should reduce fatigue significantly"
 
-        logger.info("✓ Rest system working")
-        logger.info(f"  - After 4 hours rest: {crew.fatigue:.2f}")
+    logger.info("✓ Rest system working")
+    logger.info(f"  - After 4 hours rest: {crew.fatigue:.2f}")
 
-        # Test skill improvement
-        initial_level = crew.skills.get_skill(StationSkill.COMMUNICATIONS)
-        crew.improve_skill(StationSkill.COMMUNICATIONS, 1.0)
-        new_level = crew.skills.get_skill(StationSkill.COMMUNICATIONS)
+    # Test skill improvement
+    initial_level = crew.skills.get_skill(StationSkill.COMMUNICATIONS)
+    crew.improve_skill(StationSkill.COMMUNICATIONS, 1.0)
+    new_level = crew.skills.get_skill(StationSkill.COMMUNICATIONS)
 
-        logger.info("✓ Skill improvement system working")
-        logger.info(f"  - Communications skill: {initial_level} -> {new_level}")
+    logger.info("✓ Skill improvement system working")
+    logger.info(f"  - Communications skill: {initial_level} -> {new_level}")
 
-        # Test performance tracking
-        crew.record_command(True)
-        crew.record_command(True)
-        crew.record_command(False)
+    # Test performance tracking
+    crew.record_command(True)
+    crew.record_command(True)
+    crew.record_command(False)
 
-        success_rate = crew.get_success_rate()
-        logger.info("✓ Performance tracking working")
-        logger.info(f"  - Commands executed: {crew.commands_executed}")
-        logger.info(f"  - Success rate: {success_rate:.2%}")
-
-        return True
-    except Exception as e:
-        logger.error(f"✗ Crew efficiency system test failed: {e}")
-        import traceback
-        traceback.print_exc()
-        return False
+    success_rate = crew.get_success_rate()
+    logger.info("✓ Performance tracking working")
+    logger.info(f"  - Commands executed: {crew.commands_executed}")
+    logger.info(f"  - Success rate: {success_rate:.2%}")
 
 
 def test_scenario_loading():
@@ -317,52 +288,44 @@ def test_scenario_loading():
     logger.info("TEST 6: Multi-Ship Combat Scenario")
     logger.info("=" * 60)
 
-    try:
-        import json
+    import json
 
-        scenario_path = os.path.join(ROOT_DIR, "scenarios", "fleet_combat_scenario.json")
+    scenario_path = os.path.join(ROOT_DIR, "scenarios", "fleet_combat_scenario.json")
 
-        # Load scenario
-        with open(scenario_path, 'r') as f:
-            scenario = json.load(f)
+    # Load scenario
+    with open(scenario_path, 'r') as f:
+        scenario = json.load(f)
 
-        logger.info("✓ Fleet combat scenario loaded")
-        logger.info(f"  - Name: {scenario['name']}")
-        logger.info(f"  - Description: {scenario['description']}")
+    logger.info("✓ Fleet combat scenario loaded")
+    logger.info(f"  - Name: {scenario['name']}")
+    logger.info(f"  - Description: {scenario['description']}")
 
-        # Validate fleet definitions
-        assert 'fleets' in scenario, "Scenario missing fleets"
-        assert len(scenario['fleets']) >= 2, "Scenario should have at least 2 fleets"
+    # Validate fleet definitions
+    assert 'fleets' in scenario, "Scenario missing fleets"
+    assert len(scenario['fleets']) >= 2, "Scenario should have at least 2 fleets"
 
-        logger.info(f"✓ Scenario has {len(scenario['fleets'])} fleets")
+    logger.info(f"✓ Scenario has {len(scenario['fleets'])} fleets")
 
-        for fleet in scenario['fleets']:
-            logger.info(f"  - Fleet: {fleet['name']} ({fleet['faction']})")
-            logger.info(f"    Ships: {len(fleet['ships'])}")
-            logger.info(f"    Formation: {fleet['formation']}")
+    for fleet in scenario['fleets']:
+        logger.info(f"  - Fleet: {fleet['name']} ({fleet['faction']})")
+        logger.info(f"    Ships: {len(fleet['ships'])}")
+        logger.info(f"    Formation: {fleet['formation']}")
 
-        # Validate ships
-        assert 'ships' in scenario, "Scenario missing ships"
-        assert len(scenario['ships']) >= 6, "Scenario should have at least 6 ships"
+    # Validate ships
+    assert 'ships' in scenario, "Scenario missing ships"
+    assert len(scenario['ships']) >= 6, "Scenario should have at least 6 ships"
 
-        logger.info(f"✓ Scenario has {len(scenario['ships'])} ships")
+    logger.info(f"✓ Scenario has {len(scenario['ships'])} ships")
 
-        ai_enabled_count = sum(1 for ship in scenario['ships'] if ship.get('ai_enabled', False))
-        logger.info(f"  - Ships with AI: {ai_enabled_count}/{len(scenario['ships'])}")
+    ai_enabled_count = sum(1 for ship in scenario['ships'] if ship.get('ai_enabled', False))
+    logger.info(f"  - Ships with AI: {ai_enabled_count}/{len(scenario['ships'])}")
 
-        # Validate objectives
-        assert 'objectives' in scenario, "Scenario missing objectives"
-        logger.info(f"✓ Scenario has {len(scenario['objectives'])} objectives")
+    # Validate objectives
+    assert 'objectives' in scenario, "Scenario missing objectives"
+    logger.info(f"✓ Scenario has {len(scenario['objectives'])} objectives")
 
-        for obj in scenario['objectives']:
-            logger.info(f"  - {obj['type'].upper()}: {obj['description']}")
-
-        return True
-    except Exception as e:
-        logger.error(f"✗ Scenario loading test failed: {e}")
-        import traceback
-        traceback.print_exc()
-        return False
+    for obj in scenario['objectives']:
+        logger.info(f"  - {obj['type'].upper()}: {obj['description']}")
 
 
 def test_simulator_tick_integration():
@@ -372,58 +335,48 @@ def test_simulator_tick_integration():
     logger.info("=" * 60)
 
     if not HAS_NUMPY:
-        logger.warning("⊘ SKIPPED: Test requires numpy (pip install numpy)")
-        return None  # None indicates skipped test
+        pytest.skip("Test requires numpy (pip install numpy)")
 
-    try:
-        from hybrid.simulator import Simulator
-        from hybrid.ship import Ship
-        from hybrid.fleet.ai_controller import AIBehavior
+    from hybrid.simulator import Simulator
+    from hybrid.fleet.ai_controller import AIBehavior
 
-        # Create simulator
-        sim = Simulator(dt=0.1)
+    # Create simulator
+    sim = Simulator(dt=0.1)
 
-        # Add a test ship
-        config = {
-            "name": "Test Ship",
-            "mass": 1000.0,
-            "class": "test",
-            "faction": "test",
-            "ai_enabled": True,
-            "systems": {}
-        }
-        ship = sim.add_ship("test_ship", config)
+    # Add a test ship
+    config = {
+        "name": "Test Ship",
+        "mass": 1000.0,
+        "class": "test",
+        "faction": "test",
+        "ai_enabled": True,
+        "systems": {}
+    }
+    ship = sim.add_ship("test_ship", config)
 
-        # Enable AI
-        ship.enable_ai(AIBehavior.IDLE)
+    # Enable AI
+    ship.enable_ai(AIBehavior.IDLE)
 
-        logger.info("✓ Test ship with AI added to simulator")
+    logger.info("✓ Test ship with AI added to simulator")
 
-        # Start simulation
-        sim.start()
+    # Start simulation
+    sim.start()
 
-        # Run a few ticks
-        initial_time = sim.time
-        for i in range(5):
-            sim.tick()
+    # Run a few ticks
+    initial_time = sim.time
+    for _ in range(5):
+        sim.tick()
 
-        logger.info(f"✓ Simulator tick executed 5 times")
-        logger.info(f"  - Initial time: {initial_time:.2f}s")
-        logger.info(f"  - Final time: {sim.time:.2f}s")
-        logger.info(f"  - Time delta: {sim.time - initial_time:.2f}s")
+    logger.info("✓ Simulator tick executed 5 times")
+    logger.info(f"  - Initial time: {initial_time:.2f}s")
+    logger.info(f"  - Final time: {sim.time:.2f}s")
+    logger.info(f"  - Time delta: {sim.time - initial_time:.2f}s")
 
-        # Verify time advanced
-        assert sim.time > initial_time, "Simulation time should advance"
+    # Verify time advanced
+    assert sim.time > initial_time, "Simulation time should advance"
 
-        logger.info("✓ Fleet manager is updated during tick")
-        logger.info("✓ Ships receive sim_time parameter")
-
-        return True
-    except Exception as e:
-        logger.error(f"✗ Simulator tick integration test failed: {e}")
-        import traceback
-        traceback.print_exc()
-        return False
+    logger.info("✓ Fleet manager is updated during tick")
+    logger.info("✓ Ships receive sim_time parameter")
 
 
 def main():
@@ -448,7 +401,9 @@ def main():
     for test_name, test_func in tests:
         try:
             passed = test_func()
-            results.append((test_name, passed))
+            results.append((test_name, True if passed is None else passed))
+        except pytest.skip.Exception:
+            results.append((test_name, None))
         except Exception as e:
             logger.error(f"Test {test_name} crashed: {e}")
             results.append((test_name, False))

--- a/tests/stations/test_station_manager.py
+++ b/tests/stations/test_station_manager.py
@@ -174,6 +174,28 @@ def test_captain_can_issue_any_command(manager):
     assert allowed3 is True
 
 
+def test_captain_claim_sets_permission_and_allows_release(manager):
+    """Test captain claims are elevated and can release other stations"""
+    captain_id = manager.generate_client_id()
+    helm_id = manager.generate_client_id()
+
+    manager.register_client(captain_id, "captain_player")
+    manager.register_client(helm_id, "helm_player")
+
+    manager.assign_to_ship(captain_id, "test_ship_001")
+    manager.assign_to_ship(helm_id, "test_ship_001")
+
+    # Claim with default crew permission to mimic command path
+    manager.claim_station(captain_id, "test_ship_001", StationType.CAPTAIN, PermissionLevel.CREW)
+    manager.claim_station(helm_id, "test_ship_001", StationType.HELM, PermissionLevel.CREW)
+
+    session = manager.sessions[captain_id]
+    assert session.permission_level == PermissionLevel.CAPTAIN
+
+    success, message = manager.release_station(captain_id, "test_ship_001", StationType.HELM)
+    assert success is True
+
+
 def test_update_heartbeat(manager):
     """Test heartbeat updates session activity"""
     client_id = manager.generate_client_id()


### PR DESCRIPTION
### Motivation
- Prevent incorrect permission levels when claiming the CAPTAIN station so captain clients can always override other stations and perform enforcement actions. 
- Remove pytest warnings and make integration checks robust by converting return-based test scripts to proper `pytest` style and ensuring test setup mirrors runtime expectations (e.g., simulator has ships before fleet creation). 

### Description
- Station permission handling: `claim_station` now forces CAPTAIN claims to be stored with `PermissionLevel.CAPTAIN`, and `release_station` compares permission levels via `.value` to avoid enum comparison errors. (`server/stations/station_manager.py`)
- Tests: added `test_captain_claim_sets_permission_and_allows_release` to verify captain escalation and release behavior, and updated `tests/stations/test_station_manager.py` accordingly. (`tests/stations/test_station_manager.py`)
- Phase 2 integration test script converted to pytest-style assertions, uses `pytest.skip` for NumPy-dependent tests, ensures a ship is added to the simulator before calling `create_fleet`, and normalizes test result handling for skipped tests. (`test_phase2_integration.py`)
- Documentation and changelog updated to record the captain escalation change and test fixes. (`CHANGELOG.md`, `docs/ARCHITECTURE.md`, `docs/FEATURE_STATUS.md`, `docs/NEXT_SPRINT.md`, `docs/KNOWN_ISSUES.md`)

### Testing
- Ran the full test suite with `python -m pytest -v` and all tests passed: `130 passed`. 
- Ran a server smoke test by launching `python -m server.run_server --port 8765` and sending a `get_state` request; the server returned state successfully but logs contain the known telemetry errors (`'ActiveSensor' object is not subscriptable` and a `power_management` config warning) which match entries in `docs/KNOWN_ISSUES.md`.
- Verified there are no desktop-only GUI imports via `grep/rg` for `tkinter|pygame|PyQt` (none found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f646712c88324be7f25f8a7c8540d)