### PR TITLE
docs: add Quaternion API reference and link into sprint docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stable station telemetry filter import path in `server/telemetry/station_filter.py`.
 - Station telemetry filtering tests for helm/captain behavior.
 - Station `list_ships` command now surfaces live ship metadata from the simulator.
+- Quaternion API documentation in `docs/QUATERNION_API.md`.
 
 ### Fixed
 - Captain station claims now auto-elevate permissions for override actions.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ python -m server.run_server --fleet-dir hybrid_fleet --dt 0.1 --port 8765
 python hybrid/gui/gui.py
 ```
 
+## Documentation
+- [Architecture overview](docs/ARCHITECTURE.md)
+- [Feature status](docs/FEATURE_STATUS.md)
+- [Known issues](docs/KNOWN_ISSUES.md)
+- [Sprint plan](docs/NEXT_SPRINT.md)
+- [Quaternion API](docs/QUATERNION_API.md)
+
 ## Android/Pydroid UAT (TCP JSON)
 The sim server speaks **newline-delimited JSON over TCP** (one JSON object per line). The Android UI can run in Pydroid and connect over your LAN.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -638,6 +638,7 @@ Flaxos-Spaceshi_-Sim_0.01/
 - Add `hybrid/utils/quaternion.py`
 - Replace `Ship.orientation` dict with `Ship.quaternion`
 - Update physics integration to use quaternion derivatives
+- Document quaternion usage in `docs/QUATERNION_API.md`
 
 ### Sprint S4: Damage Model
 - Add `hybrid/systems/damage/` module

--- a/docs/FEATURE_STATUS.md
+++ b/docs/FEATURE_STATUS.md
@@ -1,6 +1,6 @@
 # Feature Status Report
 
-**Last Updated**: 2026-01-24
+**Last Updated**: 2026-01-25
 **Project**: Flaxos Spaceship Simulator
 **Version**: 0.2.0 (Phase 2 Complete)
 
@@ -118,7 +118,7 @@ This document tracks the implementation status of all major features in the Flax
 ### Quaternion Attitude System 📋
 | Feature | Status | Tests | Notes |
 |---------|--------|-------|-------|
-| Quaternion math library | 📋 Planned | - | Creation, multiplication, SLERP |
+| Quaternion math library | ✅ Complete | ✅ | Creation, multiplication, SLERP |
 | Quaternion integration | 📋 Planned | - | Replace Euler angles in physics |
 | RCS thruster system | 📋 Planned | - | YAML configuration format |
 | Torque calculation | 📋 Planned | - | Position × force vector |
@@ -203,6 +203,7 @@ This document tracks the implementation status of all major features in the Flax
 | KNOWN_ISSUES.md | ✅ Complete | 2026-01-21 |
 | NEXT_SPRINT.md | ✅ Complete | 2026-01-21 |
 | CHANGELOG.md | ✅ Complete | 2026-01-21 |
+| QUATERNION_API.md | ✅ Complete | 2026-01-25 |
 
 ---
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,0 +1,38 @@
+# Handoff Notes
+
+**Last Updated**: 2026-01-25
+**Sprint**: S3 (Quaternion Attitude)
+
+---
+
+## Session Goal
+- Deliverable: Quaternion API documentation ✅
+
+---
+
+## Summary of Changes
+- Added a dedicated quaternion API reference in `docs/QUATERNION_API.md`.
+- Linked the quaternion API documentation in sprint planning and architecture notes.
+- Refreshed documentation metadata (feature status, known issues, changelog, README).
+
+---
+
+## Tests & Validation
+- `python -m pytest -q`
+- `python -m server.run_server --port 8765` smoke test + TCP probe
+- Android core import check for GUI deps
+
+---
+
+## Notes for Next Agent
+- Quaternion math implementation already lives in `hybrid/utils/quaternion.py`; remaining Sprint S3 work centers on ship integration + RCS torque.
+- Update docs/FEATURE_STATUS.md test counts if/when new quaternion/RCS tests land.
+
+---
+
+## Model Switch Anchor
+If you are taking over this work, start by reviewing:
+- `docs/QUATERNION_API.md`
+- `docs/NEXT_SPRINT.md`
+- `docs/FEATURE_STATUS.md`
+

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 **Project**: Flaxos Spaceship Simulator
 **Version**: 0.2.0
-**Last Updated**: 2026-01-24
+**Last Updated**: 2026-01-25
 
 ---
 
@@ -404,6 +404,9 @@ Documentation is text-based only. No video tutorials or gameplay demonstrations.
 - Documented 13 known issues
 - Categorized by priority
 - Added resolution plans
+
+**2026-01-25**: Documentation refresh
+- Linked quaternion API documentation into sprint planning updates
 
 ---
 

--- a/docs/NEXT_SPRINT.md
+++ b/docs/NEXT_SPRINT.md
@@ -21,6 +21,7 @@ Sprint S3 focuses on replacing the Euler angle orientation system with quaternio
 - Captain station claims now auto-elevate permissions for cross-station overrides.
 - Station management `list_ships` now returns live ship metadata via the station server.
 - Station transfer now enforces officer-or-higher permissions.
+- Published quaternion API documentation (`docs/QUATERNION_API.md`).
 
 ---
 
@@ -569,7 +570,7 @@ class InterceptAutopilot:
 - [ ] Regression tests all passing
 
 ### Documentation
-- [ ] Quaternion API documentation
+- [x] Quaternion API documentation
 - [ ] RCS configuration guide
 - [ ] Physics update documentation
 - [ ] Migration guide (Euler → Quaternion)

--- a/docs/QUATERNION_API.md
+++ b/docs/QUATERNION_API.md
@@ -1,0 +1,160 @@
+# Quaternion API Reference
+
+**Status**: ✅ Implemented
+**Sprint**: S3 (Quaternion Attitude Foundation)
+**Last Updated**: 2026-01-25
+
+---
+
+## Overview
+
+The quaternion module provides a complete rotation math API used by the
+attitude system to eliminate gimbal lock and support smooth interpolation.
+All public methods use **degrees** for angle inputs/outputs unless noted.
+
+**Location**: `hybrid/utils/quaternion.py`
+
+---
+
+## Coordinate & Rotation Conventions
+
+- **Euler order**: ZYX intrinsic rotations (yaw → pitch → roll).
+- **Angles**: Degrees in public API.
+- **Vector rotation**: Uses `q * v * q⁻¹`.
+- **Unit quaternions** represent pure rotations (no scaling).
+
+---
+
+## Class: `Quaternion`
+
+### Constructor
+```python
+Quaternion(w=1.0, x=0.0, y=0.0, z=0.0)
+```
+Creates a quaternion from raw components. Defaults to the identity rotation.
+
+### Factory Methods
+```python
+Quaternion.from_euler(pitch, yaw, roll)
+```
+Creates a quaternion from Euler angles (degrees, ZYX intrinsic order).
+
+```python
+Quaternion.from_axis_angle(axis, angle)
+```
+Creates a quaternion from an axis vector and a rotation angle in degrees.
+Axis inputs are normalized automatically.
+
+### Conversion Methods
+```python
+Quaternion.to_euler()
+```
+Returns `(pitch, yaw, roll)` in degrees.
+
+```python
+Quaternion.to_axis_angle()
+```
+Returns `(axis, angle)` where axis is a normalized numpy vector and
+angle is in degrees.
+
+```python
+Quaternion.to_rotation_matrix()
+```
+Returns a `3x3` numpy rotation matrix.
+
+### Core Operations
+```python
+Quaternion.normalize()
+```
+Normalizes the quaternion in place.
+
+```python
+Quaternion.normalized()
+```
+Returns a normalized copy.
+
+```python
+Quaternion.conjugate()
+```
+Returns the conjugate (inverse for unit quaternions).
+
+```python
+Quaternion.inverse()
+```
+Returns the inverse (conjugate / ||q||²).
+
+```python
+Quaternion.__mul__(other)
+```
+Quaternion multiplication (rotation composition).
+
+```python
+Quaternion.rotate_vector(vector)
+```
+Rotates a vector (x, y, z) using `q * v * q⁻¹`.
+
+### Interpolation
+```python
+Quaternion.slerp(q1, q2, t)
+```
+Spherical linear interpolation from `q1` to `q2` with `t ∈ [0, 1]`.
+
+### Utility
+```python
+Quaternion.magnitude()
+Quaternion.is_unit(epsilon=1e-6)
+Quaternion.dot(other)
+```
+Magnitude, unit check, and dot product helpers.
+
+---
+
+## Module Helpers
+
+```python
+quaternion_identity()
+```
+Returns the identity quaternion `(1, 0, 0, 0)`.
+
+```python
+quaternion_from_to(from_vec, to_vec)
+```
+Creates a quaternion that rotates one vector to align with another.
+
+---
+
+## Usage Examples
+
+### Convert Euler → Quaternion → Euler
+```python
+from hybrid.utils.quaternion import Quaternion
+
+q = Quaternion.from_euler(10, 20, 30)
+pitch, yaw, roll = q.to_euler()
+```
+
+### Rotate a Vector
+```python
+from hybrid.utils.quaternion import Quaternion
+
+q = Quaternion.from_axis_angle([0, 0, 1], 90)  # 90° yaw
+forward = [1, 0, 0]
+left = q.rotate_vector(forward)
+```
+
+### Smoothly Interpolate Orientation
+```python
+from hybrid.utils.quaternion import Quaternion
+
+q_start = Quaternion.from_euler(0, 0, 0)
+q_end = Quaternion.from_euler(0, 90, 0)
+q_mid = Quaternion.slerp(q_start, q_end, 0.5)
+```
+
+---
+
+## Tests
+
+- `tests/utils/test_quaternion.py` exercises creation, conversions,
+  multiplication, SLERP, and vector rotation.
+


### PR DESCRIPTION
### Motivation
- Provide a focused API reference for the newly implemented quaternion math in `hybrid/utils/quaternion.py` so Sprint S3 work is discoverable and usable. 
- Surface the new documentation across planning and status artifacts to mark progress on the Quaternion Foundation deliverable. 

### Description
- Add `docs/QUATERNION_API.md` containing conventions, public API, examples, and test pointers for `Quaternion` and helpers. 
- Link the quaternion API doc from `docs/NEXT_SPRINT.md`, `docs/ARCHITECTURE.md`, and `README.md` and mark the API doc as completed in `docs/FEATURE_STATUS.md`. 
- Update `CHANGELOG.md` and `docs/KNOWN_ISSUES.md` with the documentation refresh and add `docs/HANDOFF.md` with handoff notes. 

### Testing
- Ran the full test suite with `python -m pytest -q` which passed all tests (`132 passed`). 
- Performed a server smoke test using `python -m server.run_server --port 8765` with a TCP probe which completed but produced known telemetry warnings (`ActiveSensor` serialization and `power_management` config messages) that are documented in `docs/KNOWN_ISSUES.md`. 
- Ran a GUI import scan using `grep -RInE "(tkinter|pygame|PyQt)" --include="*.py" server utils` which returned no desktop-GUI dependency hits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6c1ab7d083248bbad141035637ad)