### PR TITLE
docs: add RCS configuration guide and update docs/indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Station telemetry filtering tests for helm/captain behavior.
 - Station `list_ships` command now surfaces live ship metadata from the simulator.
 - Quaternion API documentation in `docs/QUATERNION_API.md`.
+- RCS configuration guide for ship thruster YAML in `docs/RCS_CONFIGURATION_GUIDE.md`.
 
 ### Fixed
 - Captain station claims now auto-elevate permissions for override actions.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ python hybrid/gui/gui.py
 - [Known issues](docs/KNOWN_ISSUES.md)
 - [Sprint plan](docs/NEXT_SPRINT.md)
 - [Quaternion API](docs/QUATERNION_API.md)
+- [RCS configuration guide](docs/RCS_CONFIGURATION_GUIDE.md)
 
 ## Android/Pydroid UAT (TCP JSON)
 The sim server speaks **newline-delimited JSON over TCP** (one JSON object per line). The Android UI can run in Pydroid and connect over your LAN.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Flaxos Spaceship Simulator - Architecture Documentation
 
 **Version**: 0.2.0
-**Last Updated**: 2026-01-24
+**Last Updated**: 2026-01-26
 
 ---
 
@@ -639,6 +639,7 @@ Flaxos-Spaceshi_-Sim_0.01/
 - Replace `Ship.orientation` dict with `Ship.quaternion`
 - Update physics integration to use quaternion derivatives
 - Document quaternion usage in `docs/QUATERNION_API.md`
+- Define RCS configuration format in `docs/RCS_CONFIGURATION_GUIDE.md`
 
 ### Sprint S4: Damage Model
 - Add `hybrid/systems/damage/` module

--- a/docs/FEATURE_STATUS.md
+++ b/docs/FEATURE_STATUS.md
@@ -1,6 +1,6 @@
 # Feature Status Report
 
-**Last Updated**: 2026-01-25
+**Last Updated**: 2026-01-26
 **Project**: Flaxos Spaceship Simulator
 **Version**: 0.2.0 (Phase 2 Complete)
 
@@ -204,14 +204,15 @@ This document tracks the implementation status of all major features in the Flax
 | NEXT_SPRINT.md | ✅ Complete | 2026-01-21 |
 | CHANGELOG.md | ✅ Complete | 2026-01-21 |
 | QUATERNION_API.md | ✅ Complete | 2026-01-25 |
+| RCS_CONFIGURATION_GUIDE.md | ✅ Complete | 2026-01-26 |
 
 ---
 
 ## Testing Summary
 
 ### Test Coverage
-- **Total Tests**: 129
-- **Passing**: 129 (100%)
+- **Total Tests**: 132
+- **Passing**: 132 (100%)
 - **Failed**: 0
 - **Skipped**: 0
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,19 +1,19 @@
 # Handoff Notes
 
-**Last Updated**: 2026-01-25
+**Last Updated**: 2026-01-26
 **Sprint**: S3 (Quaternion Attitude)
 
 ---
 
 ## Session Goal
-- Deliverable: Quaternion API documentation ✅
+- Deliverable: RCS configuration guide ✅
 
 ---
 
 ## Summary of Changes
-- Added a dedicated quaternion API reference in `docs/QUATERNION_API.md`.
-- Linked the quaternion API documentation in sprint planning and architecture notes.
-- Refreshed documentation metadata (feature status, known issues, changelog, README).
+- Added the RCS configuration guide to document thruster YAML schema and best practices.
+- Linked the new RCS documentation in sprint planning, architecture notes, and README.
+- Refreshed documentation metadata (feature status, known issues, changelog).
 
 ---
 
@@ -26,7 +26,7 @@
 
 ## Notes for Next Agent
 - Quaternion math implementation already lives in `hybrid/utils/quaternion.py`; remaining Sprint S3 work centers on ship integration + RCS torque.
-- Update docs/FEATURE_STATUS.md test counts if/when new quaternion/RCS tests land.
+- Next documentation deliverables: physics update documentation and Euler → quaternion migration guide.
 
 ---
 
@@ -35,4 +35,3 @@ If you are taking over this work, start by reviewing:
 - `docs/QUATERNION_API.md`
 - `docs/NEXT_SPRINT.md`
 - `docs/FEATURE_STATUS.md`
-

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 **Project**: Flaxos Spaceship Simulator
 **Version**: 0.2.0
-**Last Updated**: 2026-01-25
+**Last Updated**: 2026-01-26
 
 ---
 

--- a/docs/NEXT_SPRINT.md
+++ b/docs/NEXT_SPRINT.md
@@ -571,7 +571,7 @@ class InterceptAutopilot:
 
 ### Documentation
 - [x] Quaternion API documentation
-- [ ] RCS configuration guide
+- [x] RCS configuration guide
 - [ ] Physics update documentation
 - [ ] Migration guide (Euler → Quaternion)
 

--- a/docs/RCS_CONFIGURATION_GUIDE.md
+++ b/docs/RCS_CONFIGURATION_GUIDE.md
@@ -1,0 +1,151 @@
+# RCS Configuration Guide
+
+**Last Updated**: 2026-01-26
+**Sprint**: S3 (Quaternion Attitude)
+
+---
+
+## Overview
+
+This guide documents the Reaction Control System (RCS) configuration format used by ship YAML definitions in `hybrid_fleet/ship_configs/`. The RCS system defines thruster placement, thrust vectors, and fuel consumption so the simulator can compute torque from each nozzle and apply it to the ship’s attitude controller.
+
+RCS configurations are **data-only**: they describe the ship’s thruster hardware and do not encode control logic. Control logic lives in the RCS system implementation and autopilot logic.
+
+---
+
+## Where RCS Configurations Live
+
+Place RCS definitions in a ship’s YAML configuration under the `systems.rcs` key. Example file locations include:
+
+- `hybrid_fleet/ship_configs/frigate.yaml`
+- `hybrid_fleet/ship_configs/corvette.yaml`
+
+The ship factory will read these configurations when the RCS system is implemented and registered in `hybrid/ship_factory.py`.
+
+---
+
+## YAML Structure
+
+```yaml
+systems:
+  rcs:
+    enabled: true
+    fuel_type: "rcs_propellant"
+    thrusters:
+      - id: "bow_port"
+        position: [10.0, -5.0, 0.0]   # meters from center of mass
+        direction: [0.0, 1.0, 0.0]    # unit vector for thrust direction
+        max_thrust: 1000.0            # Newtons
+        fuel_consumption: 0.1         # kg/s at max thrust
+```
+
+### Top-Level Fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `enabled` | bool | Yes | Enables or disables the RCS system at startup. |
+| `fuel_type` | string | Yes | Fuel resource key used by the ship’s resource system. |
+| `thrusters` | list | Yes | Array of thruster definitions (see below). |
+
+### Thruster Fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | Yes | Unique ID for telemetry and debugging. |
+| `position` | list[float, float, float] | Yes | Position in meters relative to ship center of mass. |
+| `direction` | list[float, float, float] | Yes | **Unit vector** for thrust direction. |
+| `max_thrust` | float | Yes | Maximum thrust output in Newtons. |
+| `fuel_consumption` | float | Yes | Fuel usage in kg/s at full thrust. |
+
+---
+
+## Example Configuration (Frigate)
+
+```yaml
+systems:
+  rcs:
+    enabled: true
+    fuel_type: "rcs_propellant"
+    thrusters:
+      # Bow thrusters (yaw control)
+      - id: "bow_port"
+        position: [10.0, -5.0, 0.0]
+        direction: [0.0, 1.0, 0.0]
+        max_thrust: 1000.0
+        fuel_consumption: 0.1
+
+      - id: "bow_starboard"
+        position: [10.0, 5.0, 0.0]
+        direction: [0.0, -1.0, 0.0]
+        max_thrust: 1000.0
+        fuel_consumption: 0.1
+
+      # Stern thrusters (yaw control)
+      - id: "stern_port"
+        position: [-10.0, -5.0, 0.0]
+        direction: [0.0, -1.0, 0.0]
+        max_thrust: 1000.0
+        fuel_consumption: 0.1
+
+      - id: "stern_starboard"
+        position: [-10.0, 5.0, 0.0]
+        direction: [0.0, 1.0, 0.0]
+        max_thrust: 1000.0
+        fuel_consumption: 0.1
+
+      # Dorsal/ventral thrusters (pitch control)
+      - id: "dorsal_bow"
+        position: [8.0, 0.0, 3.0]
+        direction: [0.0, 0.0, -1.0]
+        max_thrust: 800.0
+        fuel_consumption: 0.08
+
+      - id: "ventral_bow"
+        position: [8.0, 0.0, -3.0]
+        direction: [0.0, 0.0, 1.0]
+        max_thrust: 800.0
+        fuel_consumption: 0.08
+
+      # Roll thrusters (port/starboard sides)
+      - id: "port_roll_fwd"
+        position: [5.0, -6.0, 2.0]
+        direction: [0.0, 0.0, -1.0]
+        max_thrust: 500.0
+        fuel_consumption: 0.05
+
+      - id: "starboard_roll_fwd"
+        position: [5.0, 6.0, -2.0]
+        direction: [0.0, 0.0, 1.0]
+        max_thrust: 500.0
+        fuel_consumption: 0.05
+```
+
+---
+
+## Configuration Notes & Best Practices
+
+1. **Use consistent coordinate frames.** Positions are measured in meters from the ship’s center of mass using the same axes as ship physics.
+2. **Normalize direction vectors.** Direction should be a unit vector; the RCS system will scale it by `max_thrust`.
+3. **Balance opposing thrusters.** Pairing thrusters on opposite sides of the hull improves control authority and reduces unintended translation.
+4. **Keep IDs stable.** Telemetry and debugging rely on the `id` field.
+5. **Avoid hardcoding bus/system names.** RCS system registration should reference schema keys defined in `systems_schema.py`.
+
+---
+
+## Validation Checklist
+
+Before shipping a new RCS configuration:
+
+- [ ] Positions are relative to center of mass.
+- [ ] Direction vectors are normalized.
+- [ ] `max_thrust` values match ship class scale.
+- [ ] Fuel consumption values align with ship propellant capacity.
+- [ ] Thruster IDs are unique across the ship.
+
+---
+
+## Next Steps
+
+- Implement `hybrid/systems/rcs_system.py` and register it in `hybrid/ship_factory.py`.
+- Add unit tests in `tests/systems/test_rcs_system.py` to validate config parsing and torque calculations.
+- Create or update ship configurations in `hybrid_fleet/ship_configs/`.


### PR DESCRIPTION
### Motivation
- Provide a formal, shareable specification for Reaction Control System (RCS) thruster YAML so ship configs and future RCS implementation have a clear schema and validation guidance.
- Surface the new doc across project indexes and sprint planning so Sprint S3 work (quaternion + RCS) references the configuration format in architecture and planning materials.

### Description
- Add `docs/RCS_CONFIGURATION_GUIDE.md` documenting the `systems.rcs` YAML schema, thruster fields, examples, best practices, and a validation checklist for ship authors.
- Update documentation indexes and metadata by editing `docs/NEXT_SPRINT.md`, `docs/ARCHITECTURE.md`, `docs/FEATURE_STATUS.md`, `docs/HANDOFF.md`, `docs/KNOWN_ISSUES.md`, `README.md`, and `CHANGELOG.md` to reference and mark the new guide.
- Increment test count and last-updated metadata in `docs/FEATURE_STATUS.md` and refresh changelog/hand-off notes to reflect the new documentation asset.

### Testing
- Ran the full test suite with `python -m pytest -q`, which passed: **132 passed, 0 failed**.
- Performed a server smoke probe using `python -m server.run_server --port 8765` and a TCP `get_state` probe; the server emitted known telemetry warnings (`ActiveSensor` serialization and a power-management config warning) which are documented in `docs/KNOWN_ISSUES.md` and not introduced by this PR.
- Verified no desktop-only GUI imports with `grep -RInE "(tkinter|pygame|PyQt)" --include="*.py" server utils || true`, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6e4571688324ace25b829d2a3706)