### PR TITLE
docs: add physics update notes for Sprint S3 (quaternion & RCS torque)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Station `list_ships` command now surfaces live ship metadata from the simulator.
 - Quaternion API documentation in `docs/QUATERNION_API.md`.
 - RCS configuration guide for ship thruster YAML in `docs/RCS_CONFIGURATION_GUIDE.md`.
+- Physics update documentation for Sprint S3 in `docs/PHYSICS_UPDATE.md`.
 
 ### Fixed
 - Captain station claims now auto-elevate permissions for override actions.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ python hybrid/gui/gui.py
 - [Sprint plan](docs/NEXT_SPRINT.md)
 - [Quaternion API](docs/QUATERNION_API.md)
 - [RCS configuration guide](docs/RCS_CONFIGURATION_GUIDE.md)
+- [Physics update notes](docs/PHYSICS_UPDATE.md)
 
 ## Android/Pydroid UAT (TCP JSON)
 The sim server speaks **newline-delimited JSON over TCP** (one JSON object per line). The Android UI can run in Pydroid and connect over your LAN.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Flaxos Spaceship Simulator - Architecture Documentation
 
 **Version**: 0.2.0
-**Last Updated**: 2026-01-26
+**Last Updated**: 2026-01-20
 
 ---
 
@@ -15,6 +15,7 @@
 6. [Station System](#station-system)
 7. [Fleet System](#fleet-system)
 8. [Extension Points](#extension-points)
+9. [Physics Update Notes (S3)](#physics-update-notes-s3)
 
 ---
 
@@ -550,6 +551,14 @@ dispatcher.register_command(
     station=StationType.NEW_STATION
 )
 ```
+
+---
+
+## Physics Update Notes (S3)
+
+Sprint S3 introduces quaternion-based attitude representation and torque-driven angular dynamics. The new physics flow keeps Euler angles for telemetry and commands but stores the authoritative attitude state as a normalized quaternion. RCS thrusters will generate torque that feeds angular acceleration, replacing direct Euler velocity updates.
+
+For implementation details, integration sketches, and rollout checklists, see `docs/PHYSICS_UPDATE.md`.
 
 ---
 

--- a/docs/FEATURE_STATUS.md
+++ b/docs/FEATURE_STATUS.md
@@ -1,6 +1,6 @@
 # Feature Status Report
 
-**Last Updated**: 2026-01-26
+**Last Updated**: 2026-01-20
 **Project**: Flaxos Spaceship Simulator
 **Version**: 0.2.0 (Phase 2 Complete)
 
@@ -205,6 +205,7 @@ This document tracks the implementation status of all major features in the Flax
 | CHANGELOG.md | ✅ Complete | 2026-01-21 |
 | QUATERNION_API.md | ✅ Complete | 2026-01-25 |
 | RCS_CONFIGURATION_GUIDE.md | ✅ Complete | 2026-01-26 |
+| PHYSICS_UPDATE.md | ✅ Complete | 2026-01-20 |
 
 ---
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,18 +1,18 @@
 # Handoff Notes
 
-**Last Updated**: 2026-01-26
+**Last Updated**: 2026-01-20
 **Sprint**: S3 (Quaternion Attitude)
 
 ---
 
 ## Session Goal
-- Deliverable: RCS configuration guide ✅
+- Deliverable: Physics update documentation ✅
 
 ---
 
 ## Summary of Changes
-- Added the RCS configuration guide to document thruster YAML schema and best practices.
-- Linked the new RCS documentation in sprint planning, architecture notes, and README.
+- Added physics update documentation for Sprint S3 quaternion + torque integration.
+- Linked the new physics update documentation in sprint planning, architecture notes, and README.
 - Refreshed documentation metadata (feature status, known issues, changelog).
 
 ---
@@ -26,12 +26,13 @@
 
 ## Notes for Next Agent
 - Quaternion math implementation already lives in `hybrid/utils/quaternion.py`; remaining Sprint S3 work centers on ship integration + RCS torque.
-- Next documentation deliverables: physics update documentation and Euler → quaternion migration guide.
+- Next documentation deliverable: Euler → quaternion migration guide.
 
 ---
 
 ## Model Switch Anchor
 If you are taking over this work, start by reviewing:
 - `docs/QUATERNION_API.md`
+- `docs/PHYSICS_UPDATE.md`
 - `docs/NEXT_SPRINT.md`
 - `docs/FEATURE_STATUS.md`

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,7 +2,7 @@
 
 **Project**: Flaxos Spaceship Simulator
 **Version**: 0.2.0
-**Last Updated**: 2026-01-26
+**Last Updated**: 2026-01-20
 
 ---
 
@@ -404,6 +404,9 @@ Documentation is text-based only. No video tutorials or gameplay demonstrations.
 - Documented 13 known issues
 - Categorized by priority
 - Added resolution plans
+
+**2026-01-20**: Documentation update
+- Added physics update documentation reference for Sprint S3 planning
 
 **2026-01-25**: Documentation refresh
 - Linked quaternion API documentation into sprint planning updates

--- a/docs/NEXT_SPRINT.md
+++ b/docs/NEXT_SPRINT.md
@@ -22,6 +22,7 @@ Sprint S3 focuses on replacing the Euler angle orientation system with quaternio
 - Station management `list_ships` now returns live ship metadata via the station server.
 - Station transfer now enforces officer-or-higher permissions.
 - Published quaternion API documentation (`docs/QUATERNION_API.md`).
+- Added physics update documentation (`docs/PHYSICS_UPDATE.md`).
 
 ---
 
@@ -572,7 +573,7 @@ class InterceptAutopilot:
 ### Documentation
 - [x] Quaternion API documentation
 - [x] RCS configuration guide
-- [ ] Physics update documentation
+- [x] Physics update documentation
 - [ ] Migration guide (Euler → Quaternion)
 
 ---

--- a/docs/PHYSICS_UPDATE.md
+++ b/docs/PHYSICS_UPDATE.md
@@ -1,0 +1,123 @@
+# Physics Update Notes — Quaternion Attitude & RCS Torque (Sprint S3)
+
+**Version**: 0.5.0
+**Last Updated**: 2026-01-20
+
+---
+
+## Purpose
+
+This document captures the physics updates planned for Sprint S3: the transition from Euler angles to quaternions for ship attitude, plus torque-based angular dynamics driven by RCS thrusters. It is intended to guide implementation work in `hybrid/ship.py`, `hybrid/systems/rcs_system.py`, and related telemetry/autopilot modules.
+
+---
+
+## Current State (Pre-S3)
+
+- Orientation is stored as Euler angles in `Ship.orientation` (pitch, yaw, roll).
+- Angular velocity is tracked per-axis in degrees per second.
+- Quaternion math utilities are implemented in `hybrid/utils/quaternion.py`.
+- RCS thruster configuration is documented in `docs/RCS_CONFIGURATION_GUIDE.md`.
+
+---
+
+## Planned Changes
+
+### 1) Quaternion Attitude State
+
+**Goal:** Add `Ship.quaternion` as the authoritative attitude state, while keeping Euler angles for telemetry and legacy command inputs.
+
+**Key decisions:**
+- Euler angles remain supported for command inputs (e.g., heading, pitch, yaw).
+- Telemetry continues to report Euler angles for UI display.
+- Quaternions are normalized after each integration step to prevent drift.
+
+**Integration sketch:**
+```python
+# In Ship.__init__
+self.orientation = {"pitch": 0.0, "yaw": 0.0, "roll": 0.0}
+self.quaternion = Quaternion.from_euler(0.0, 0.0, 0.0)
+
+# In Ship._update_physics
+omega = Quaternion(0, omega_x, omega_y, omega_z)
+q_dot = 0.5 * self.quaternion * omega
+self.quaternion = self.quaternion + q_dot * dt
+self.quaternion.normalize()
+
+# Keep Euler telemetry in sync
+pitch, yaw, roll = self.quaternion.to_euler()
+self.orientation.update({"pitch": pitch, "yaw": yaw, "roll": roll})
+```
+
+### 2) Torque-Based Angular Dynamics
+
+**Goal:** Drive angular acceleration from RCS torque instead of direct Euler velocity changes.
+
+**Core formula:**
+- **Torque:** τ = r × F
+- **Angular acceleration:** α = τ / I
+
+**Integration sketch:**
+```python
+# In Ship._update_physics
+rcs_torque = self.systems.get("rcs").get_total_torque() if "rcs" in self.systems else np.zeros(3)
+angular_accel = rcs_torque / self.moment_of_inertia
+
+self.angular_velocity["pitch"] += angular_accel[0] * dt
+self.angular_velocity["yaw"] += angular_accel[1] * dt
+self.angular_velocity["roll"] += angular_accel[2] * dt
+```
+
+### 3) RCS Thruster Allocation
+
+**Goal:** The RCS system determines thruster output levels to achieve desired angular velocity targets.
+
+**Key behaviors:**
+- Thruster torque contribution is computed from per-thruster position and force direction.
+- Allocation is currently heuristic; optimization can follow later.
+- Fuel use is proportional to thruster level and `dt`.
+
+**Reference:** `docs/RCS_CONFIGURATION_GUIDE.md`
+
+---
+
+## Telemetry & API Considerations
+
+- Telemetry continues to expose Euler angles in `orientation` for compatibility.
+- Consider adding a `quaternion` field to telemetry for advanced clients (opt-in).
+- Command handlers that accept Euler angles should update the quaternion state via `Quaternion.from_euler()`.
+
+---
+
+## Testing & Validation Checklist
+
+**Unit tests**
+- Quaternion integration accuracy for small rotations
+- Quaternion → Euler → quaternion round-trip checks
+- Torque integration and angular acceleration correctness
+
+**Integration tests**
+- Full rotation using RCS thrusters
+- Autopilot pointing accuracy with quaternion attitude
+- Edge cases: pitch = ±90° (no gimbal lock)
+
+**Performance checks**
+- Compare tick timing before/after quaternion integration
+- Ensure normalization does not cause numerical instability
+
+---
+
+## Rollout Checklist
+
+1. Add `Ship.quaternion` + update physics integration.
+2. Update `Ship.set_heading()` and autopilot programs to use quaternions.
+3. Implement `hybrid/systems/rcs_system.py` and ship configs.
+4. Add torque integration + fuel consumption tracking.
+5. Extend telemetry tests to validate Euler + quaternion sync.
+
+---
+
+## References
+
+- `docs/QUATERNION_API.md`
+- `docs/RCS_CONFIGURATION_GUIDE.md`
+- `hybrid/utils/quaternion.py`


### PR DESCRIPTION
### Motivation
- Capture the planned physics migration from Euler angles to quaternion attitude and introduce torque-driven RCS angular dynamics for Sprint S3.
- Provide integration sketches, rollout checklists, and testing guidance to reduce implementation ambiguity for subsequent code work.
- Surface the new documentation across the repo so sprint planning, architecture, and release notes reflect the updated plan.

### Description
- Add `docs/PHYSICS_UPDATE.md` describing quaternion attitude state, torque-based angular dynamics, RCS allocation, telemetry considerations, and rollout/testing checklists. 
- Link and mark the new doc as completed across project docs by updating `docs/NEXT_SPRINT.md`, `docs/ARCHITECTURE.md`, `README.md`, and `docs/FEATURE_STATUS.md`. 
- Refresh handoff and known-issues metadata by updating `docs/HANDOFF.md` and `docs/KNOWN_ISSUES.md`, and add an Unreleased entry in `CHANGELOG.md` referring to the new documentation. 
- Minor metadata/date adjustments to documentation headers to reflect the addition and ensure discoverability from planning and architecture pages.

### Testing
- Ran the unit test suite with `python -m pytest -q`, which passed: `132 passed`. 
- Performed a server smoke test by starting `python -m server.run_server --port 8765` and connecting via a TCP probe, which succeeded in responding but produced known telemetry errors (`'ActiveSensor' object is not subscriptable` and `Error loading system power_management: 'float' object has no attribute 'get'`) that are tracked in `docs/KNOWN_ISSUES.md`. 
- Verified GUI dependency check with `rg -n "(tkinter|pygame|PyQt)" server utils` which returned no desktop-GUI-only matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f70e5b148832496c3d828d2205ff0)