### PR TITLE
feat(demo): add Android parity smoke test and demo runbook

### DIFF
--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,0 +1,79 @@
+# Demo Slice Runbook
+
+This runbook captures the minimum repeatable steps to exercise the demo slice on
+desktop Python and Android/Pydroid.
+
+## Desktop Demo (CLI + Socket)
+
+1. Install dependencies (optional but recommended):
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Start the TCP server:
+
+   ```bash
+   python -m server.run_server --port 8765
+   ```
+
+3. In another terminal, send a minimal request:
+
+   ```bash
+   python - <<'PY'
+import socket, json
+s = socket.create_connection(("localhost", 8765), 5)
+s.sendall((json.dumps({"cmd":"get_state"}) + "\n").encode("utf-8"))
+print(s.recv(4096).decode("utf-8", "replace"))
+PY
+   ```
+
+## Android / Pydroid Demo (Parity Smoke Test)
+
+> Goal: verify core imports + sim tick work on Android (no GUI deps).
+
+1. Copy the repo to your device (Git clone, or transfer the folder).
+2. In Pydroid, install dependencies if needed:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Run the Android-safe smoke test:
+
+   ```bash
+   python tools/android_smoke.py
+   ```
+
+Expected output (example):
+
+```json
+{
+  "ok": true,
+  "ticks": 3,
+  "dt": 0.1,
+  "time": 0.30000000000000004,
+  "ship": "sample_ship",
+  "position": {"x": 0.0, "y": 0.0, "z": 0.0},
+  "velocity": {"x": 0.0, "y": 0.0, "z": 0.0}
+}
+```
+
+### Optional: Android Loopback Socket Smoke
+
+If your device supports local TCP loopback in Pydroid, you can also run:
+
+```bash
+python -m server.run_server --host 127.0.0.1 --port 8765
+```
+
+And in another Pydroid terminal/session:
+
+```bash
+python - <<'PY'
+import socket, json
+s = socket.create_connection(("127.0.0.1", 8765), 5)
+s.sendall((json.dumps({"cmd":"get_state"}) + "\n").encode("utf-8"))
+print(s.recv(4096).decode("utf-8", "replace"))
+PY
+```

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,38 +1,16 @@
-# Handoff Notes
-
-**Last Updated**: 2026-01-20
-**Sprint**: S3 (Quaternion Attitude)
-
----
-
-## Session Goal
-- Deliverable: Physics update documentation ✅
-
----
-
-## Summary of Changes
-- Added physics update documentation for Sprint S3 quaternion + torque integration.
-- Linked the new physics update documentation in sprint planning, architecture notes, and README.
-- Refreshed documentation metadata (feature status, known issues, changelog).
-
----
-
-## Tests & Validation
+# HANDOFF
+## Demo Slice Status
+- D1–D6: Not validated this session.
+- Platform parity: Desktop ✅ (tests + smoke script), Android ⚠️ (on-device run pending).
+## What Works (exact commands)
 - `python -m pytest -q`
-- `python -m server.run_server --port 8765` smoke test + TCP probe
-- Android core import check for GUI deps
-
----
-
-## Notes for Next Agent
-- Quaternion math implementation already lives in `hybrid/utils/quaternion.py`; remaining Sprint S3 work centers on ship integration + RCS torque.
-- Next documentation deliverable: Euler → quaternion migration guide.
-
----
-
-## Model Switch Anchor
-If you are taking over this work, start by reviewing:
-- `docs/QUATERNION_API.md`
-- `docs/PHYSICS_UPDATE.md`
-- `docs/NEXT_SPRINT.md`
-- `docs/FEATURE_STATUS.md`
+- `python tools/android_smoke.py`
+## What’s Broken (max 3)
+- `server.run_server` telemetry still logs `ActiveSensor` serialization errors (known issue in `docs/KNOWN_ISSUES.md`).
+- Inline socket probe in validation script reported `/bin/bash: line 4: python: command not found` when run in a multi-line command block.
+## Next 1–3 Actions
+1) Run `python tools/android_smoke.py` on a real Android/Pydroid device and capture output.
+2) If feasible, run `python -m server.run_server --host 127.0.0.1 --port 8765` and a loopback socket probe on-device.
+3) Investigate why inline `python - <<'PY'` failed in the validation block despite `python` being available.
+## Guardrails (Do Not Touch)
+- Avoid UI dependencies in core sim/server modules to preserve Android parity.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -271,6 +271,21 @@ Running the simulation server on Android devices may have reduced performance co
 
 ---
 
+### 11. Android/Pydroid Parity Pending On-Device Verification
+**Status**: 🔴 Demo Requirement Pending
+**Severity**: High (Demo parity)
+
+**Description:**
+The repository now includes a minimal Android-safe smoke test script, but it has not yet been executed on a real Android/Pydroid device in this environment.
+
+**Impact:**
+- Demo parity for Android remains unconfirmed until the smoke test is run on-device.
+
+**Next Step:**
+- Run `python tools/android_smoke.py` on-device and capture output for verification.
+
+---
+
 ## Testing Gaps
 
 ### 11. No Network Stress Testing

--- a/docs/NEXT_SPRINT.md
+++ b/docs/NEXT_SPRINT.md
@@ -24,6 +24,10 @@ Sprint S3 focuses on replacing the Euler angle orientation system with quaternio
 - Published quaternion API documentation (`docs/QUATERNION_API.md`).
 - Added physics update documentation (`docs/PHYSICS_UPDATE.md`).
 
+**Demo Slice Short-Term Actions (next 1-3)**
+1. Run `python tools/android_smoke.py` on a real Android/Pydroid device and record output for parity.
+2. Attempt optional loopback server smoke (`python -m server.run_server --host 127.0.0.1 --port 8765`) on-device if feasible.
+
 ---
 
 ## Sprint Goals

--- a/tools/android_smoke.py
+++ b/tools/android_smoke.py
@@ -1,0 +1,63 @@
+import argparse
+import json
+import os
+import sys
+
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+
+def load_ship_config(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def run_smoke(config_path: str, ticks: int, dt: float) -> dict:
+    from hybrid.simulator import Simulator
+
+    simulator = Simulator(dt=dt)
+    ship_config = load_ship_config(config_path)
+    ship_id = ship_config.get("id") or "android_smoke_ship"
+    simulator.add_ship(ship_id, ship_config)
+    simulator.start()
+
+    for _ in range(ticks):
+        simulator.tick()
+
+    ship_state = simulator.get_ship(ship_id).get_state()
+    return {
+        "ok": True,
+        "ticks": ticks,
+        "dt": dt,
+        "time": simulator.time,
+        "ship": ship_id,
+        "position": ship_state.get("position"),
+        "velocity": ship_state.get("velocity"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Android/Pydroid smoke test for core sim import + tick."
+    )
+    parser.add_argument(
+        "--ship-config",
+        default=os.path.join("fleet_json", "sample_ship.json"),
+        help="Path to ship JSON config (relative to repo root).",
+    )
+    parser.add_argument("--ticks", type=int, default=3)
+    parser.add_argument("--dt", type=float, default=0.1)
+    args = parser.parse_args()
+
+    config_path = os.path.join(ROOT_DIR, args.ship_config)
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"Ship config not found: {config_path}")
+
+    result = run_smoke(config_path=config_path, ticks=args.ticks, dt=args.dt)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a minimal, Android/Pydroid-safe verification that core sim modules import and advance ticks to close the demo parity gap for mobile devices. 
- Document repeatable desktop and mobile demo steps so contributors can verify the demo slice on both platforms. 
- Track parity follow-ups in planning and handoff docs to make on-device verification and remaining server telemetry issues visible. 

### Description
- Add `tools/android_smoke.py`, a small smoke test that imports `hybrid.simulator`, loads a ship JSON, runs a few ticks, and prints a JSON summary. 
- Add `docs/DEMO.md` with one-line run steps for the desktop TCP server and the Android/Pydroid smoke test. 
- Update `docs/NEXT_SPRINT.md` to include short-term parity actions, `docs/KNOWN_ISSUES.md` to record Android parity pending verification, and `docs/HANDOFF.md` to summarize demo status and next actions. 

### Testing
- Ran `python -m pytest -q` and observed `132 passed` which completed successfully. 
- Ran `python tools/android_smoke.py` which returned a JSON result with `"ok": true` confirming import + tick path on the host environment. 
- Started `python -m server.run_server --port 8765` and attempted a loopback probe; the server ran but logged existing `ActiveSensor` telemetry serialization errors and the inline probe in the validation block failed with `/bin/bash: line 4: python: command not found`, so the socket probe step is marked partial and requires follow-up on the probe invocation and telemetry serialization.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f73e8ef708324871d51c759bc57f3)