### PR TITLE
feat(demo): add android loopback socket smoke test and update docs

### DIFF
--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -64,16 +64,14 @@ Expected output (example):
 If your device supports local TCP loopback in Pydroid, you can also run:
 
 ```bash
-python -m server.run_server --host 127.0.0.1 --port 8765
+python tools/android_socket_smoke.py
 ```
 
-And in another Pydroid terminal/session:
+This script starts a single-shot server, connects a client, and prints the
+response payload so you can verify end-to-end socket connectivity.
+
+If you want to run the full server instead, use:
 
 ```bash
-python - <<'PY'
-import socket, json
-s = socket.create_connection(("127.0.0.1", 8765), 5)
-s.sendall((json.dumps({"cmd":"get_state"}) + "\n").encode("utf-8"))
-print(s.recv(4096).decode("utf-8", "replace"))
-PY
+python -m server.run_server --host 127.0.0.1 --port 8765
 ```

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,16 +1,17 @@
 # HANDOFF
 ## Demo Slice Status
 - D1–D6: Not validated this session.
-- Platform parity: Desktop ✅ (tests + smoke script), Android ⚠️ (on-device run pending).
+- Platform parity: Desktop ⚠️ (telemetry errors still log in legacy server), Android ⚠️ (on-device run pending).
 ## What Works (exact commands)
 - `python -m pytest -q`
+- `python tools/android_socket_smoke.py`
 - `python tools/android_smoke.py`
 ## What’s Broken (max 3)
 - `server.run_server` telemetry still logs `ActiveSensor` serialization errors (known issue in `docs/KNOWN_ISSUES.md`).
 - Inline socket probe in validation script reported `/bin/bash: line 4: python: command not found` when run in a multi-line command block.
 ## Next 1–3 Actions
 1) Run `python tools/android_smoke.py` on a real Android/Pydroid device and capture output.
-2) If feasible, run `python -m server.run_server --host 127.0.0.1 --port 8765` and a loopback socket probe on-device.
-3) Investigate why inline `python - <<'PY'` failed in the validation block despite `python` being available.
+2) Run `python tools/android_socket_smoke.py` on-device to confirm loopback socket connectivity.
+3) Attempt optional loopback server smoke (`python -m server.run_server --host 127.0.0.1 --port 8765`) on-device if feasible.
 ## Guardrails (Do Not Touch)
 - Avoid UI dependencies in core sim/server modules to preserve Android parity.

--- a/docs/NEXT_SPRINT.md
+++ b/docs/NEXT_SPRINT.md
@@ -26,7 +26,8 @@ Sprint S3 focuses on replacing the Euler angle orientation system with quaternio
 
 **Demo Slice Short-Term Actions (next 1-3)**
 1. Run `python tools/android_smoke.py` on a real Android/Pydroid device and record output for parity.
-2. Attempt optional loopback server smoke (`python -m server.run_server --host 127.0.0.1 --port 8765`) on-device if feasible.
+2. Run `python tools/android_socket_smoke.py` on-device to confirm loopback socket connectivity.
+3. Attempt optional loopback server smoke (`python -m server.run_server --host 127.0.0.1 --port 8765`) on-device if feasible.
 
 ---
 

--- a/tools/android_socket_smoke.py
+++ b/tools/android_socket_smoke.py
@@ -1,0 +1,98 @@
+import argparse
+import json
+import os
+import socket
+import sys
+import threading
+import time
+
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+
+from hybrid_runner import HybridRunner
+from server.run_server import dispatch
+
+
+def _serve_once(host: str, port: int, dt: float, fleet_dir: str, ready: threading.Event, port_holder: dict) -> None:
+    runner = HybridRunner(fleet_dir=fleet_dir, dt=dt)
+    runner.load_ships()
+    runner.start()
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind((host, port))
+    port_holder["port"] = srv.getsockname()[1]
+    srv.listen(1)
+    ready.set()
+
+    try:
+        conn, _ = srv.accept()
+        conn.settimeout(5)
+        buf = b""
+        data = conn.recv(4096)
+        if data:
+            buf += data
+        line = buf.split(b"\n", 1)[0]
+        if line:
+            req = json.loads(line.decode("utf-8"))
+            resp = dispatch(runner, req)
+            conn.sendall((json.dumps(resp) + "\n").encode("utf-8"))
+        conn.close()
+    finally:
+        runner.stop()
+        srv.close()
+
+
+def run_loopback(host: str, port: int, dt: float, fleet_dir: str, timeout: float) -> dict:
+    ready = threading.Event()
+    port_holder: dict = {"port": None}
+    thread = threading.Thread(
+        target=_serve_once,
+        args=(host, port, dt, fleet_dir, ready, port_holder),
+        daemon=True,
+    )
+    thread.start()
+    if not ready.wait(timeout=timeout):
+        raise TimeoutError("Server failed to start in time")
+
+    actual_port = port_holder["port"]
+    client = socket.create_connection((host, actual_port), timeout=timeout)
+    client.sendall((json.dumps({"cmd": "get_state"}) + "\n").encode("utf-8"))
+    response = client.recv(4096).decode("utf-8", "replace").strip()
+    client.close()
+    thread.join(timeout=timeout)
+
+    return {
+        "ok": True,
+        "host": host,
+        "port": actual_port,
+        "response": response,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Android/Pydroid loopback socket smoke test (server + client)."
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--dt", type=float, default=0.1)
+    parser.add_argument("--fleet-dir", default="hybrid_fleet")
+    parser.add_argument("--timeout", type=float, default=5.0)
+    args = parser.parse_args()
+
+    result = run_loopback(
+        host=args.host,
+        port=args.port,
+        dt=args.dt,
+        fleet_dir=args.fleet_dir,
+        timeout=args.timeout,
+    )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a reliable, single-shot loopback socket smoke test for Android/Pydroid to verify core server+client connectivity without requiring the full persistent server and to avoid inline multi-line probe issues in some shells. 
- Make the Android parity verification step repeatable and explicit in the demo runbook and sprint/handoff notes.

### Description
- Add `tools/android_socket_smoke.py`, a single-shot loopback script that starts a `HybridRunner` server, accepts one client request, dispatches it via `server.run_server.dispatch`, and returns the response. 
- Update `docs/DEMO.md` to reference the new loopback script and clarify that the full server can be used as an alternative. 
- Update `docs/NEXT_SPRINT.md` and `docs/HANDOFF.md` to include the new on-device loopback verification step and adjust the platform parity notes.

### Testing
- Ran `python -m pytest -q`, which completed successfully with `132 passed` unit/integration tests. 
- Ran `python tools/android_socket_smoke.py`, which started the temporary server and returned an `ok` JSON response confirming end-to-end loopback connectivity.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f757779748324ac61c4f95697905a)