### PR TITLE
fix(telemetry): handle sensor contacts safely and stabilize state cache

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,14 +1,14 @@
 # HANDOFF
 ## Demo Slice Status
-- D1–D6: Not validated this session.
-- Platform parity: Desktop ⚠️ (telemetry errors still log in legacy server), Android ⚠️ (on-device run pending).
+- D1–D6: Not validated this session (legacy server telemetry improved; power_management error still logs).
+- Platform parity: Desktop ⚠️ (legacy server still logs power_management load error), Android ⚠️ (on-device run pending).
 ## What Works (exact commands)
 - `python -m pytest -q`
 - `python tools/android_socket_smoke.py`
 - `python tools/android_smoke.py`
 ## What’s Broken (max 3)
-- `server.run_server` telemetry still logs `ActiveSensor` serialization errors (known issue in `docs/KNOWN_ISSUES.md`).
-- Inline socket probe in validation script reported `/bin/bash: line 4: python: command not found` when run in a multi-line command block.
+- `server.run_server` still logs `Error loading system power_management: 'float' object has no attribute 'get'` (known issue in `docs/KNOWN_ISSUES.md`).
+- Inline socket probe in validation script reported `/bin/bash: line 1: python: command not found` when run in a multi-line command block.
 ## Next 1–3 Actions
 1) Run `python tools/android_smoke.py` on a real Android/Pydroid device and capture output.
 2) Run `python tools/android_socket_smoke.py` on-device to confirm loopback socket connectivity.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -46,11 +46,10 @@ Sprint S3 will implement quaternion-based attitude representation, completely el
 ### 2. Telemetry snapshot errors in `server.run_server`
 **Status**: 🔴 Known Issue
 **Severity**: High (Server telemetry)
-**Affected Components**: `hybrid/telemetry.py`, `hybrid/systems/sensors/active.py`, ship configs
+**Affected Components**: `hybrid/systems/power/management.py`, ship configs
 
 **Description:**
 Running `python -m server.run_server` logs repeated telemetry errors:
-- `Error getting state ... 'ActiveSensor' object is not subscriptable`
 - `Error loading system power_management: 'float' object has no attribute 'get'`
 
 **Impact:**
@@ -61,7 +60,6 @@ Running `python -m server.run_server` logs repeated telemetry errors:
 Use the station-aware server (`python -m server.station_server`) for multi-crew workflows and avoid telemetry polling when running the legacy server.
 
 **Resolution Plan:**
-- Normalize sensor telemetry serialization for `ActiveSensor`
 - Validate power management config structure in ship definitions before load
 
 ---

--- a/hybrid/telemetry.py
+++ b/hybrid/telemetry.py
@@ -148,19 +148,27 @@ def get_sensor_contacts(ship) -> Dict[str, Any]:
 
     contacts_list = []
 
+    def contact_value(contact: Any, key: str, default: Any = None) -> Any:
+        if isinstance(contact, dict):
+            if key == "last_update":
+                return contact.get("last_update", contact.get("last_updated", default))
+            return contact.get(key, default)
+        return getattr(contact, key, default)
+
     # Get passive contacts
     if hasattr(sensors, "passive") and hasattr(sensors.passive, "contacts"):
         for contact_id, contact in sensors.passive.contacts.items():
-            distance = calculate_distance(ship.position, contact.get("position", ship.position))
-            bearing = calculate_bearing(ship.position, contact.get("position", ship.position))
+            position = contact_value(contact, "position", ship.position)
+            distance = calculate_distance(ship.position, position)
+            bearing = calculate_bearing(ship.position, position)
 
             contacts_list.append({
                 "id": contact_id,
                 "distance": distance,
                 "bearing": bearing,
-                "confidence": contact.get("confidence", 0.5),
-                "last_update": contact.get("last_updated", 0),
-                "detection_method": contact.get("detection_method", "passive")
+                "confidence": contact_value(contact, "confidence", 0.5),
+                "last_update": contact_value(contact, "last_update", 0),
+                "detection_method": contact_value(contact, "detection_method", "passive")
             })
 
     # Get active contacts
@@ -170,16 +178,17 @@ def get_sensor_contacts(ship) -> Dict[str, Any]:
             if any(c["id"] == contact_id for c in contacts_list):
                 continue
 
-            distance = calculate_distance(ship.position, contact.get("position", ship.position))
-            bearing = calculate_bearing(ship.position, contact.get("position", ship.position))
+            position = contact_value(contact, "position", ship.position)
+            distance = calculate_distance(ship.position, position)
+            bearing = calculate_bearing(ship.position, position)
 
             contacts_list.append({
                 "id": contact_id,
                 "distance": distance,
                 "bearing": bearing,
-                "confidence": contact.get("confidence", 0.9),
-                "last_update": contact.get("last_updated", 0),
-                "detection_method": contact.get("detection_method", "active")
+                "confidence": contact_value(contact, "confidence", 0.9),
+                "last_update": contact_value(contact, "last_update", 0),
+                "detection_method": contact_value(contact, "detection_method", "active")
             })
 
     # Sort by distance

--- a/hybrid_runner.py
+++ b/hybrid_runner.py
@@ -139,8 +139,11 @@ class HybridRunner:
                             sensor_system.config = {}
                             
                         # Check active sensor fields
-                        if not hasattr(sensor_system.active, "last_ping_time") or sensor_system.active["last_ping_time"] is None:
-                            sensor_system.active["last_ping_time"] = 0
+                        if (
+                            not hasattr(sensor_system.active, "last_ping_time")
+                            or sensor_system.active.last_ping_time is None
+                        ):
+                            sensor_system.active.last_ping_time = 0
                             
                         # Ensure contacts list exists
                         if "contacts" not in sensor_system.config:

--- a/tests/core/test_runner_state_cache.py
+++ b/tests/core/test_runner_state_cache.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+
+from hybrid_runner import HybridRunner
+
+
+class DummyShip:
+    def __init__(self, sensors):
+        self.systems = {"sensors": sensors}
+
+    def get_state(self):
+        return {"systems": {}}
+
+
+def test_update_state_cache_handles_active_sensor_object():
+    sensors = SimpleNamespace(
+        active=SimpleNamespace(last_ping_time=None),
+        passive=SimpleNamespace(),
+        config={},
+    )
+    ship = DummyShip(sensors)
+    runner = HybridRunner(dt=0.1)
+    runner.simulator = SimpleNamespace(ships={"ship": ship})
+
+    runner._update_state_cache()
+
+    assert sensors.active.last_ping_time == 0
+    assert "ship" in runner.state_cache

--- a/tests/core/test_telemetry_contacts.py
+++ b/tests/core/test_telemetry_contacts.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+
+from hybrid.systems.sensors.contact import ContactData
+from hybrid.telemetry import get_sensor_contacts
+
+
+def test_sensor_contacts_support_dataclass_entries():
+    passive_contact = ContactData(
+        id="C001",
+        position={"x": 100.0, "y": 0.0, "z": 0.0},
+        velocity={"x": 0.0, "y": 0.0, "z": 0.0},
+        confidence=0.7,
+        last_update=1.0,
+        detection_method="passive",
+    )
+    active_contact = ContactData(
+        id="C002",
+        position={"x": 200.0, "y": 0.0, "z": 0.0},
+        velocity={"x": 0.0, "y": 0.0, "z": 0.0},
+        confidence=0.9,
+        last_update=2.0,
+        detection_method="active",
+    )
+
+    sensors = SimpleNamespace(
+        passive=SimpleNamespace(contacts={"C001": passive_contact}),
+        active=SimpleNamespace(contacts={"C002": active_contact}),
+    )
+    ship = SimpleNamespace(position={"x": 0.0, "y": 0.0, "z": 0.0}, systems={"sensors": sensors})
+
+    result = get_sensor_contacts(ship)
+
+    assert result["available"] is True
+    assert result["count"] == 2
+    contact_map = {contact["id"]: contact for contact in result["contacts"]}
+    assert contact_map["C001"]["last_update"] == 1.0
+    assert contact_map["C002"]["last_update"] == 2.0


### PR DESCRIPTION
### Motivation
- Resolve telemetry crashes when sensor contact entries are dataclass/objects (e.g. `ContactData`) so `get_state`/legacy server snapshotting no longer hits subscript errors. 
- Prevent the state-cache refresh in the runner from treating `ActiveSensor` as a dict and subscripting it, which caused repeated errors during server telemetry collection. 

### Description
- Add a safe `contact_value` accessor in `hybrid/telemetry.py` to read contact fields from either `dict` or object/dataclass entries and normalize `last_update`/`last_updated` keys. 
- Update `hybrid_runner.py` to initialize `last_ping_time` using attribute access on `sensor_system.active` objects instead of subscripting. 
- Add unit tests `tests/core/test_telemetry_contacts.py` and `tests/core/test_runner_state_cache.py` to cover dataclass contact telemetry and the runner state-cache handling. 
- Update `docs/HANDOFF.md` and `docs/KNOWN_ISSUES.md` to reflect the fix for the ActiveSensor subscript issue and note the remaining `power_management` config load warning. 

### Testing
- Ran the full test suite with `python -m pytest -q`, resulting in `134 passed` (includes the two new tests). 
- Performed a desktop server smoke probe by starting `python -m server.run_server --port 8765` and issuing a `get_state` request, which shows the ActiveSensor subscript errors are resolved but the legacy server still logs `Error loading system power_management: 'float' object has no attribute 'get'`. 
- Noted an environment probe artifact where an inline multi-line shell probe reported `/bin/bash: line 1: python: command not found` in this runner environment; this is unrelated to the fix and only affected the inline probe execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fc94ba94c8324a21fa3195b047120)