### PR TITLE
feat(demo): add desktop smoke test script and update demo docs

### DIFF
--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -28,6 +28,12 @@ print(s.recv(4096).decode("utf-8", "replace"))
 PY
    ```
 
+4. Or run the scripted desktop smoke test (starts server + connects client):
+
+   ```bash
+   python tools/desktop_demo_smoke.py
+   ```
+
 ## Android / Pydroid Demo (Parity Smoke Test)
 
 > Goal: verify core imports + sim tick work on Android (no GUI deps).

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,11 +1,12 @@
 # HANDOFF
 ## Demo Slice Status
-- D1–D6: Not validated this session (legacy server telemetry improved; power_management error still logs).
-- Platform parity: Desktop ⚠️ (legacy server still logs power_management load error), Android ⚠️ (on-device run pending).
+- D1–D6: Not validated this session (legacy server telemetry still logs power_management error).
+- Platform parity: Desktop ⚠️ (legacy server telemetry error), Android ⚠️ (on-device run pending).
 ## What Works (exact commands)
 - `python -m pytest -q`
-- `python tools/android_socket_smoke.py`
+- `python tools/desktop_demo_smoke.py`
 - `python tools/android_smoke.py`
+- `python tools/android_socket_smoke.py`
 ## What’s Broken (max 3)
 - `server.run_server` still logs `Error loading system power_management: 'float' object has no attribute 'get'` (known issue in `docs/KNOWN_ISSUES.md`).
 - Inline socket probe in validation script reported `/bin/bash: line 1: python: command not found` when run in a multi-line command block.

--- a/docs/NEXT_SPRINT.md
+++ b/docs/NEXT_SPRINT.md
@@ -25,9 +25,9 @@ Sprint S3 focuses on replacing the Euler angle orientation system with quaternio
 - Added physics update documentation (`docs/PHYSICS_UPDATE.md`).
 
 **Demo Slice Short-Term Actions (next 1-3)**
-1. Run `python tools/android_smoke.py` on a real Android/Pydroid device and record output for parity.
-2. Run `python tools/android_socket_smoke.py` on-device to confirm loopback socket connectivity.
-3. Attempt optional loopback server smoke (`python -m server.run_server --host 127.0.0.1 --port 8765`) on-device if feasible.
+1. Run `python tools/desktop_demo_smoke.py` on desktop to confirm server + client loopback.
+2. Run `python tools/android_smoke.py` on a real Android/Pydroid device and record output for parity.
+3. Run `python tools/android_socket_smoke.py` on-device to confirm loopback socket connectivity.
 
 ---
 

--- a/tools/desktop_demo_smoke.py
+++ b/tools/desktop_demo_smoke.py
@@ -1,0 +1,78 @@
+"""Desktop demo smoke test for the TCP server.
+
+Starts the server, connects a client, and prints the get_state response.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import subprocess
+import sys
+import time
+
+
+def _probe_server(host: str, port: int, timeout: float) -> str:
+    with socket.create_connection((host, port), timeout) as sock:
+        payload = json.dumps({"cmd": "get_state"}) + "\n"
+        sock.sendall(payload.encode("utf-8"))
+        return sock.recv(4096).decode("utf-8", "replace").strip()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Desktop demo smoke test.")
+    parser.add_argument("--host", default="127.0.0.1", help="Server host")
+    parser.add_argument("--port", type=int, default=8765, help="Server port")
+    parser.add_argument(
+        "--startup-wait",
+        type=float,
+        default=1.5,
+        help="Seconds to wait for the server to start",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Socket timeout in seconds",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "server.run_server",
+            "--host",
+            args.host,
+            "--port",
+            str(args.port),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        time.sleep(args.startup_wait)
+        response = _probe_server(args.host, args.port, args.timeout)
+        print(
+            json.dumps(
+                {"ok": True, "host": args.host, "port": args.port, "response": response},
+                indent=2,
+            )
+        )
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=3)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a minimal, repeatable desktop loopback smoke test to validate the TCP server `get_state` path without manual multi-step commands. 
- Make the demo runbook and sprint/handoff notes explicitly reference a scripted desktop check to improve reproducibility. 
- Keep Android parity and core-only constraints visible while preserving a small, desktop-safe verification path. 

### Description
- Add `tools/desktop_demo_smoke.py`, a script that starts `server.run_server`, probes `get_state`, and prints the response. 
- Document the scripted desktop smoke test in `docs/DEMO.md` and add it as the first short-term demo action in `docs/NEXT_SPRINT.md`. 
- Update `docs/HANDOFF.md` to reflect the new desktop loopback check and current demo status. 
- No changes to core simulation code; the change is limited to a new test tool and documentation updates. 

### Testing
- Ran the test suite with `python -m pytest -q` which completed successfully with `134 passed`. 
- Executed the new desktop smoke script with `python tools/desktop_demo_smoke.py` which started the server, connected a client, and returned an `{"ok": true, ...}` response. 
- Performed a quick grep for UI libs with `rg -n "(tkinter|pygame|PyQt)" --glob "*.py" server utils` which returned no matches. 
- Performed an inline server probe run which exposed a shell environment limitation in one multi-line invocation (reported `/bin/bash: line 1: python: command not found`) but the scripted smoke test itself succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fcc8e9e2483248f2c8cf338f672d4)