### PR TITLE
Improve GUI panel sizing and layout

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -92,102 +92,118 @@
       }
     }
 
+    :root {
+      --panel-height-sm: clamp(220px, 26vh, 360px);
+      --panel-height-md: clamp(260px, 32vh, 440px);
+      --panel-height-lg: clamp(320px, 42vh, 560px);
+    }
+
     /* Phase 5 panels */
     .scenario-panel {
       grid-column: span 3;
-      min-height: 300px;
+      min-height: var(--panel-height-sm);
     }
 
     .mission-panel {
       grid-column: span 3;
-      min-height: 300px;
+      min-height: var(--panel-height-sm);
     }
 
     /* Phase 2 panels */
     .event-log-panel {
       grid-column: span 4;
       grid-row: span 2;
-      min-height: 300px;
-      height: clamp(300px, 45vh, 520px);
-      max-height: 520px;
+      min-height: var(--panel-height-lg);
+      height: clamp(320px, 48vh, 560px);
+      max-height: 560px;
       overflow: hidden;
     }
 
     .command-panel {
       grid-column: span 4;
-      min-height: 120px;
+      min-height: clamp(120px, 18vh, 200px);
     }
 
     /* Phase 3 panels */
     .status-panel {
       grid-column: span 3;
-      min-height: 280px;
+      min-height: var(--panel-height-sm);
     }
 
     .nav-panel {
       grid-column: span 3;
-      min-height: 280px;
+      min-height: var(--panel-height-sm);
     }
 
     .sensors-panel {
       grid-column: span 3;
-      min-height: 280px;
+      min-height: var(--panel-height-sm);
     }
 
     .tactical-panel {
       grid-column: span 4;
-      min-height: 350px;
+      min-height: var(--panel-height-md);
     }
 
     .targeting-panel {
       grid-column: span 3;
-      min-height: 250px;
+      min-height: var(--panel-height-sm);
     }
 
     .weapons-panel {
       grid-column: span 3;
-      min-height: 250px;
+      min-height: var(--panel-height-sm);
     }
 
     /* Phase 4 panels */
     .thrust-input-panel {
       grid-column: span 3;
-      min-height: 380px;
+      min-height: var(--panel-height-md);
     }
 
     .throttle-panel {
       grid-column: span 2;
-      min-height: 380px;
+      min-height: var(--panel-height-md);
     }
 
     .heading-panel {
       grid-column: span 2;
-      min-height: 300px;
+      min-height: var(--panel-height-sm);
+    }
+
+    .position-heading-panel {
+      grid-column: span 3;
+      min-height: var(--panel-height-sm);
+    }
+
+    .micro-rcs-panel {
+      grid-column: span 2;
+      min-height: var(--panel-height-sm);
     }
 
     .rcs-panel {
       grid-column: span 3;
-      min-height: 400px;
+      min-height: var(--panel-height-md);
     }
 
     .autopilot-panel {
       grid-column: span 2;
-      min-height: 280px;
+      min-height: var(--panel-height-sm);
     }
 
     .flight-computer-panel {
       grid-column: span 3;
-      min-height: 450px;
+      min-height: var(--panel-height-md);
     }
 
     .weapon-ctrl-panel {
       grid-column: span 3;
-      min-height: 320px;
+      min-height: var(--panel-height-sm);
     }
 
     .systems-panel {
       grid-column: span 3;
-      min-height: 250px;
+      min-height: var(--panel-height-sm);
     }
 
     /* Placeholder panels */
@@ -229,7 +245,9 @@
       .thrust-input-panel,
       .throttle-panel,
       .heading-panel,
+      .position-heading-panel,
       .rcs-panel,
+      .micro-rcs-panel,
       .autopilot-panel,
       .flight-computer-panel,
       .weapon-ctrl-panel,
@@ -254,7 +272,9 @@
       .thrust-input-panel,
       .throttle-panel,
       .heading-panel,
+      .position-heading-panel,
       .rcs-panel,
+      .micro-rcs-panel,
       .autopilot-panel,
       .flight-computer-panel,
       .weapon-ctrl-panel,
@@ -306,8 +326,45 @@
         <ship-status></ship-status>
       </flaxos-panel>
 
+      <flaxos-panel title="Systems" collapsible class="systems-panel">
+        <system-toggles></system-toggles>
+      </flaxos-panel>
+
       <flaxos-panel title="Navigation" collapsible class="nav-panel">
         <navigation-display></navigation-display>
+      </flaxos-panel>
+
+      <flaxos-panel title="Position → Heading" collapsible class="position-heading-panel">
+        <position-heading-calculator></position-heading-calculator>
+      </flaxos-panel>
+
+      <flaxos-panel title="Heading" collapsible class="heading-panel">
+        <heading-control></heading-control>
+      </flaxos-panel>
+
+      <flaxos-panel title="Autopilot" collapsible class="autopilot-panel">
+        <autopilot-control></autopilot-control>
+      </flaxos-panel>
+
+      <flaxos-panel title="Flight Computer" collapsible class="flight-computer-panel">
+        <flight-computer></flight-computer>
+      </flaxos-panel>
+
+      <!-- Phase 4: Visual Controls -->
+      <flaxos-panel title="Throttle" collapsible class="throttle-panel">
+        <throttle-control></throttle-control>
+      </flaxos-panel>
+
+      <flaxos-panel title="RCS / Attitude" collapsible class="rcs-panel">
+        <rcs-controls></rcs-controls>
+      </flaxos-panel>
+
+      <flaxos-panel title="Micro RCS" collapsible class="micro-rcs-panel">
+        <micro-rcs-control></micro-rcs-control>
+      </flaxos-panel>
+
+      <flaxos-panel title="Debug: Vector Thrust" collapsible class="thrust-input-panel">
+        <manual-thrust></manual-thrust>
       </flaxos-panel>
 
       <flaxos-panel title="Sensors" collapsible class="sensors-panel">
@@ -326,45 +383,8 @@
         <weapons-status></weapons-status>
       </flaxos-panel>
 
-      <!-- Phase 4: Visual Controls -->
-      <flaxos-panel title="Throttle" collapsible class="throttle-panel">
-        <throttle-control></throttle-control>
-      </flaxos-panel>
-
-      <flaxos-panel title="RCS / Attitude" collapsible class="rcs-panel">
-        <rcs-controls></rcs-controls>
-      </flaxos-panel>
-
-      <flaxos-panel title="Micro RCS" collapsible class="micro-rcs-panel">
-        <micro-rcs-control></micro-rcs-control>
-      </flaxos-panel>
-
-      <flaxos-panel title="Position → Heading" collapsible class="position-heading-panel">
-        <position-heading-calculator></position-heading-calculator>
-      </flaxos-panel>
-
-      <flaxos-panel title="Flight Computer" collapsible class="flight-computer-panel">
-        <flight-computer></flight-computer>
-      </flaxos-panel>
-
-      <flaxos-panel title="Heading" collapsible class="heading-panel">
-        <heading-control></heading-control>
-      </flaxos-panel>
-
-      <flaxos-panel title="Autopilot" collapsible class="autopilot-panel">
-        <autopilot-control></autopilot-control>
-      </flaxos-panel>
-
-      <flaxos-panel title="Debug: Vector Thrust" collapsible class="thrust-input-panel">
-        <manual-thrust></manual-thrust>
-      </flaxos-panel>
-
       <flaxos-panel title="Fire Control" collapsible class="weapon-ctrl-panel">
         <weapon-controls></weapon-controls>
-      </flaxos-panel>
-
-      <flaxos-panel title="Systems" collapsible class="systems-panel">
-        <system-toggles></system-toggles>
       </flaxos-panel>
     </main>
 

--- a/gui/styles/main.css
+++ b/gui/styles/main.css
@@ -125,7 +125,7 @@ h3 { font-size: var(--font-size-base); }
   gap: var(--space-sm);
   padding: var(--space-sm);
   grid-template-columns: repeat(12, 1fr);
-  grid-auto-rows: minmax(100px, auto);
+  grid-auto-rows: minmax(clamp(140px, 18vh, 240px), auto);
 }
 
 /* Panel component base */


### PR DESCRIPTION
### Motivation
- Fix panels and heading tiles that were not sizing dynamically by making panel heights viewport-aware to improve UI/UX across screen sizes. 
- Group related tiles (systems/status, navigation/heading/throttle, tactical/sensors/weapons) so the interface reads in a more logical flow. 
- Reduce layout issues on tablet/phone breakpoints by replacing many hardcoded heights with responsive clamps.

### Description
- Added viewport-aware CSS variables `--panel-height-sm`, `--panel-height-md`, and `--panel-height-lg` in `gui/index.html` to drive panel min-heights. 
- Replaced hardcoded `min-height` values and updated `grid-auto-rows` in `gui/styles/main.css` to use `clamp()`-based sizes so panels scale with the browser viewport. 
- Introduced `position-heading-panel` and `micro-rcs-panel` sizing rules and included them in tablet/mobile breakpoints. 
- Reordered panels in `gui/index.html` to cluster `systems`, navigation/propulsion controls, and tactical sections for clearer grouping.

### Testing
- Launched a local static server with `python -m http.server` and ran a Playwright script to capture a screenshot at `1400x900` to visually validate the responsive layout, which completed successfully. 
- No automated unit tests or linters were executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976c594c61083248f410ee839dc543b)