### PR TITLE
Harden TCP JSON serialization and add nav/helm validation assets

### DIFF
--- a/docs/NAV_HELM_GUI_TEST_PLAN.md
+++ b/docs/NAV_HELM_GUI_TEST_PLAN.md
@@ -1,0 +1,87 @@
+# Navigation + Helm GUI Test Plan
+
+This plan captures repeatable GUI checks and supporting scripts for validating navigation and helm flows, with a focus on the intercept tutorial scenario (`scenarios/01_tutorial_intercept.yaml`).
+
+## Prerequisites
+- Start the GUI stack: `python tools/start_gui_stack.py`
+- Open the GUI: http://localhost:3000/
+- Ensure the scenario is loaded from the scenario panel (Tutorial: Intercept and Approach).
+
+## Manual GUI Test Cases
+
+### NAV-HEL-01: Scenario load + telemetry sanity
+**Goal:** Confirm the nav/helm stations receive telemetry without crashing.
+
+1. Open the Scenario panel and load **Tutorial: Intercept and Approach**.
+2. Switch to the **Helm** station.
+3. Confirm Navigation panel shows position/velocity/heading data.
+4. Switch to **Navigation** station and confirm the contacts list is populated after a sensors ping.
+
+**Expected:**
+- No server disconnects or JSON serialization errors.
+- Navigation panel updates at least once per second.
+
+---
+
+### NAV-HEL-02: Autopilot intercept (C001)
+**Goal:** Engage intercept autopilot on the tutorial contact.
+
+1. In Navigation station, click **Ping Sensors**.
+2. Select the contact `C001` (Tycho Station) from the contacts list.
+3. Switch to Helm station.
+4. Engage autopilot with program **Intercept**.
+5. Observe autopilot status updates (Intercept → Approach → Match).
+
+**Expected:**
+- Autopilot engages without crashing the server.
+- Navigation display shows target range closing.
+- Autopilot phase changes appear in the event log.
+
+---
+
+### NAV-HEL-03: Manual helm override + recovery
+**Goal:** Validate manual overrides don't break autopilot or JSON telemetry.
+
+1. With autopilot engaged, use **Manual Thrust** to adjust throttle.
+2. Rotate heading using Helm controls.
+3. Wait for autopilot to resume (manual override timeout).
+
+**Expected:**
+- Manual input triggers override and then returns to autopilot.
+- No disconnects or UI freeze during transition.
+
+---
+
+### NAV-HEL-04: Autopilot disengage
+**Goal:** Verify the "off" command safely disables autopilot.
+
+1. With autopilot engaged, send **Autopilot Off** from Helm.
+2. Verify the ship returns to manual mode.
+
+**Expected:**
+- Autopilot status shows disabled.
+- Helm controls regain manual authority with no crash.
+
+---
+
+### NAV-HEL-05: Station switching stress
+**Goal:** Ensure switching between Helm and Navigation panels does not break telemetry.
+
+1. Rapidly switch between Helm and Navigation stations 10 times.
+2. Keep the ship in motion and verify the telemetry continues updating.
+
+**Expected:**
+- No station claim errors.
+- Telemetry updates continue without server disconnects.
+
+## Scripted Checks (Optional but Recommended)
+
+Run the CLI-based validation script to confirm that navigation/helm commands respond with JSON-safe payloads while the GUI is open:
+
+```bash
+python tools/validate_nav_helm.py --scenario 01_tutorial_intercept.yaml
+```
+
+**Expected:**
+- Script reports success for sensor ping and autopilot intercept.
+- No `TypeError: Object of type bool is not JSON serializable` in server output.

--- a/tests/utils/test_json_serialization.py
+++ b/tests/utils/test_json_serialization.py
@@ -1,0 +1,35 @@
+import json
+
+import pytest
+
+from server.run_server import _json_default
+
+
+def test_json_default_handles_sets_and_tuples():
+    payload = {
+        "tuple": (1, 2, 3),
+        "set": {"a", "b"}
+    }
+
+    encoded = json.dumps(payload, default=_json_default)
+    decoded = json.loads(encoded)
+
+    assert decoded["tuple"] == [1, 2, 3]
+    assert sorted(decoded["set"]) == ["a", "b"]
+
+
+def test_json_default_handles_numpy_scalars_and_arrays():
+    np = pytest.importorskip("numpy")
+
+    payload = {
+        "flag": np.bool_(True),
+        "count": np.int64(5),
+        "values": np.array([1, 2, 3])
+    }
+
+    encoded = json.dumps(payload, default=_json_default)
+    decoded = json.loads(encoded)
+
+    assert decoded["flag"] is True
+    assert decoded["count"] == 5
+    assert decoded["values"] == [1, 2, 3]

--- a/tools/validate_nav_helm.py
+++ b/tools/validate_nav_helm.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Validate navigation + helm flows against the TCP server used by the GUI stack.
+
+This script is intended to be run while `server.run_server` is active (e.g.
+via `python tools/start_gui_stack.py`).
+"""
+
+import argparse
+import json
+import socket
+import sys
+import time
+from typing import Any, Dict, Optional
+
+
+class TcpClient:
+    def __init__(self, host: str, port: int):
+        self.host = host
+        self.port = port
+        self.socket: Optional[socket.socket] = None
+
+    def connect(self) -> None:
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.socket.settimeout(5.0)
+        self.socket.connect((self.host, self.port))
+
+    def close(self) -> None:
+        if self.socket:
+            self.socket.close()
+            self.socket = None
+
+    def send(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self.socket:
+            raise ConnectionError("TCP client not connected.")
+
+        self.socket.sendall((json.dumps(payload) + "\n").encode("utf-8"))
+        return self._read_response()
+
+    def _read_response(self) -> Dict[str, Any]:
+        if not self.socket:
+            raise ConnectionError("TCP client not connected.")
+
+        buf = b""
+        while b"\n" not in buf:
+            data = self.socket.recv(4096)
+            if not data:
+                raise ConnectionError("Connection closed by server.")
+            buf += data
+        line, _ = buf.split(b"\n", 1)
+        return json.loads(line.decode("utf-8"))
+
+
+def _select_ship(state_payload: Dict[str, Any], preferred_ship: Optional[str]) -> Optional[str]:
+    if preferred_ship:
+        return preferred_ship
+
+    ships = state_payload.get("ships", [])
+    for ship in ships:
+        if ship.get("id") == "player":
+            return "player"
+    if ships:
+        return ships[0].get("id")
+    return None
+
+
+def _extract_contact_id(state_payload: Dict[str, Any], ship_id: str) -> Optional[str]:
+    ship_state = state_payload.get("state", {})
+    sensors = ship_state.get("systems", {}).get("sensors", {})
+    contacts = sensors.get("contacts", [])
+    for contact in contacts:
+        contact_id = contact.get("id")
+        if contact_id:
+            return contact_id
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate nav/helm GUI flows.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--scenario", default="01_tutorial_intercept.yaml")
+    parser.add_argument("--ship")
+    parser.add_argument("--target")
+    parser.add_argument("--skip-scenario", action="store_true")
+    args = parser.parse_args()
+
+    client = TcpClient(args.host, args.port)
+
+    try:
+        client.connect()
+
+        if not args.skip_scenario:
+            resp = client.send({"cmd": "load_scenario", "scenario": args.scenario})
+            if not resp.get("ok"):
+                print(f"[error] Failed to load scenario: {resp}")
+                return 1
+            print(f"[ok] Scenario loaded: {resp.get('scenario')}")
+
+        state = client.send({"cmd": "get_state"})
+        if not state.get("ok"):
+            print(f"[error] Failed to get state: {state}")
+            return 1
+
+        ship_id = _select_ship(state, args.ship)
+        if not ship_id:
+            print("[error] Could not determine ship id.")
+            return 1
+        print(f"[ok] Using ship: {ship_id}")
+
+        ping = client.send({"cmd": "ping_sensors", "ship": ship_id})
+        if not ping.get("ok"):
+            print(f"[error] Sensor ping failed: {ping}")
+            return 1
+        print("[ok] Sensors pinged.")
+
+        time.sleep(0.5)
+        ship_state = client.send({"cmd": "get_state", "ship": ship_id})
+        if not ship_state.get("ok"):
+            print(f"[error] Failed to get ship state: {ship_state}")
+            return 1
+
+        target_id = args.target or _extract_contact_id(ship_state, ship_id) or "C001"
+        print(f"[ok] Using target: {target_id}")
+
+        autopilot = client.send({
+            "cmd": "autopilot",
+            "ship": ship_id,
+            "program": "intercept",
+            "target": target_id
+        })
+        if not autopilot.get("ok"):
+            print(f"[error] Autopilot intercept failed: {autopilot}")
+            return 1
+        print("[ok] Autopilot intercept engaged.")
+
+        follow_up = client.send({"cmd": "get_state", "ship": ship_id})
+        if not follow_up.get("ok"):
+            print(f"[error] Failed to confirm state: {follow_up}")
+            return 1
+        print("[ok] State returned after autopilot command.")
+
+        return 0
+    except Exception as exc:
+        print(f"[error] Validation failed: {exc}")
+        return 1
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- The TCP JSON responses from `server/run_server.py` could include non-JSON-native values (NumPy scalars/arrays, sets, tuples, bytes, or system objects) which caused the server to crash during nav/helm GUI flows. 
- Provide a robust, central serializer so GUI and CLI clients don't trigger `TypeError` when payloads contain non-serializable types. 
- Add reproducible test and validation assets to exercise the nav/helm intercept flows and prevent regressions.

### Description
- Added `_json_default` and `_json_dumps` helpers to `server/run_server.py` to convert common non-JSON types (sets/tuples, `bytes`, NumPy scalars/arrays, objects exposing `to_dict` or `__dict__`) into serializable forms and fall back to `str` when needed. 
- Replaced direct `json.dumps(...)` calls used for TCP replies with `_json_dumps(...)` so all server responses are emitted through the safe serializer. 
- Added a focused GUI test plan `docs/NAV_HELM_GUI_TEST_PLAN.md` documenting manual steps and expectations for navigation/helm intercept scenarios. 
- Added a CLI validation script `tools/validate_nav_helm.py` to exercise scenario loading, sensor ping, and engaging the `intercept` autopilot via the TCP API. 
- Added unit tests `tests/utils/test_json_serialization.py` to verify `_json_default` handles tuples/sets and NumPy scalars/arrays correctly.

### Testing
- Ran `pytest tests/utils/test_json_serialization.py` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976f92e39248324850c6a5289c4baa3)