### PR TITLE
Add engineering power profiles and station/CLI commands

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -12,6 +12,7 @@
 - [Ship Control Commands](#ship-control-commands)
 - [Navigation & Autopilot](#navigation--autopilot)
 - [Sensors & Targeting](#sensors--targeting)
+- [Engineering & Power Management](#engineering--power-management)
 - [Weapons & Combat](#weapons--combat)
 - [Fleet Commands](#fleet-commands)
 - [Crew Management](#crew-management)
@@ -607,6 +608,93 @@ Get filtered events for your station.
   "station": "ops",
   "total_events": 0,
   "filtered_count": 0
+}
+```
+
+---
+
+## Engineering & Power Management
+
+### set_power_profile
+Apply a predefined engineering power profile (offensive/defensive) to update power allocation, overdrive limits, and weapon/system enablement.
+
+**Station:** ENGINEERING
+
+**Request:**
+```json
+{
+  "cmd": "set_power_profile",
+  "ship": "player_ship",
+  "profile": "offensive"
+}
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "message": "Power profile 'offensive' applied",
+  "response": {
+    "status": "power_profile_applied",
+    "profile": "offensive",
+    "power_allocation": {
+      "primary": 0.6,
+      "secondary": 0.25,
+      "tertiary": 0.15
+    },
+    "overdrive_limits": {
+      "primary": 1.2,
+      "secondary": 1.0,
+      "tertiary": 1.0
+    }
+  }
+}
+```
+
+---
+
+### get_power_profiles
+List available engineering profiles and the current active profile.
+
+**Station:** ENGINEERING
+
+**Request:**
+```json
+{
+  "cmd": "get_power_profiles",
+  "ship": "player_ship"
+}
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "message": "Power profiles retrieved",
+  "response": {
+    "profiles": ["defensive", "offensive"],
+    "active_profile": "offensive",
+    "definitions": {
+      "offensive": {
+        "power_allocation": {
+          "primary": 0.6,
+          "secondary": 0.25,
+          "tertiary": 0.15
+        },
+        "overdrive_limits": {
+          "primary": 1.2,
+          "secondary": 1.0,
+          "tertiary": 1.0
+        },
+        "systems": {
+          "railgun": {"enabled": true, "power_draw": 60.0},
+          "pdc": {"enabled": true, "power_draw": 18.0},
+          "ecm": {"enabled": false, "power_draw": 0.0},
+          "eccm": {"enabled": false, "power_draw": 0.0}
+        }
+      }
+    }
+  }
 }
 ```
 

--- a/hybrid/cli.py
+++ b/hybrid/cli.py
@@ -159,10 +159,11 @@ def run_cli(fleet_dir="hybrid_fleet", dt=0.1):
             print("3. Set course")
             print("4. Toggle autopilot")
             print("5. Ping sensors")
-            print("6. Custom command")
-            print("7. Switch ship")
-            print("8. Save states")
-            print("9. Exit")
+            print("6. Set power profile")
+            print("7. Custom command")
+            print("8. Switch ship")
+            print("9. Save states")
+            print("10. Exit")
             
             try:
                 choice = input("\nEnter command: ")
@@ -203,6 +204,18 @@ def run_cli(fleet_dir="hybrid_fleet", dt=0.1):
                     print("Result:", json.dumps(result, indent=2))
                     
                 elif choice == "6":
+                    profile = input("Power profile (offensive/defensive): ").strip()
+                    if not profile:
+                        print("Profile name required")
+                        continue
+                    result = runner.send_command(
+                        selected_ship,
+                        "set_power_profile",
+                        {"profile": profile}
+                    )
+                    print("Result:", json.dumps(result, indent=2))
+
+                elif choice == "7":
                     # Custom command
                     cmd = input("Command: ")
                     args_str = input("Args (JSON): ")
@@ -214,7 +227,7 @@ def run_cli(fleet_dir="hybrid_fleet", dt=0.1):
                     except json.JSONDecodeError:
                         print("Invalid JSON args")
                         
-                elif choice == "7":
+                elif choice == "8":
                     # Switch ship
                     print("\nAvailable ships:")
                     for i, ship_id in enumerate(ship_ids):
@@ -230,12 +243,12 @@ def run_cli(fleet_dir="hybrid_fleet", dt=0.1):
                     except ValueError:
                         print("Invalid input, please enter a number")
                         
-                elif choice == "8":
+                elif choice == "9":
                     # Save states
                     result = runner.save_states()
                     print("Result:", json.dumps(result, indent=2))
                     
-                elif choice == "9":
+                elif choice == "10":
                     # Exit
                     print("Exiting...")
                     break

--- a/server/stations/station_types.py
+++ b/server/stations/station_types.py
@@ -114,6 +114,8 @@ STATION_DEFINITIONS: Dict[StationType, StationDefinition] = {
         commands={
             # Implemented engineering commands (registered with dispatcher)
             "override_bio_monitor",
+            "set_power_profile",
+            "get_power_profiles",
         },
         displays={
             "power_grid", "reactor_status", "system_status",


### PR DESCRIPTION
### Motivation
- Add engineering control profiles to quickly switch ship power behavior between offensive and defensive modes. 
- Allow profiles to modify power allocation ratios, reactor overdrive limits, and toggle/adjust weapon/system power in kW so station crews can reconfigure power for tactical needs. 
- Expose this capability to crew stations and the CLI so engineering crews can command profiles at runtime. 

### Description
- Implemented engineering profiles and profile application in `hybrid/systems/power/management.py` including `_normalize_allocation`, `apply_profile`, `set_power_allocation`, `set_overdrive_limits`, and profile definitions (offensive/defensive); overdrive limits are applied to reactor capacity and output in `tick`. 
- Profiles can toggle systems and wire directly into the weapons subsystem by updating per-weapon `enabled` and `power_cost` (kW) via `_apply_system_profile`, and the power manager caches base system/weapon state before applying changes. 
- Added `enabled` state to `Weapon` and prevented firing when disabled, and surface `enabled` in `WeaponSystem.get_state` in `hybrid/systems/weapons/weapon_system.py`. 
- Exposed new server-side station commands `set_power_profile` and `get_power_profiles` in `server/stations/station_commands.py` and registered them for the ENGINEERING station; updated `server/stations/station_types.py` to include the commands. 
- Added a CLI menu option to apply power profiles from `hybrid/cli.py` and documented the new endpoints in `docs/API_REFERENCE.md` under "Engineering & Power Management." 

### Testing
- No automated tests were executed as part of this change; existing unit tests were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69770569cdec83248963cf29690085d6)