### PR TITLE
Automatic repair and weapon resupply when docking to stations

### DIFF
--- a/hybrid/systems/weapons/weapon_system.py
+++ b/hybrid/systems/weapons/weapon_system.py
@@ -13,6 +13,7 @@ class Weapon:
         self.base_max_heat = max_heat
         self.enabled = True
         self.ammo = ammo_count
+        self.ammo_capacity = ammo_count
         self.damage = damage  # D6: Damage per hit
         self.base_damage = damage
         self.heat = 0.0
@@ -89,6 +90,19 @@ class Weapon:
         # Passive cooldown proportional to max_heat
         self.heat = max(0.0, self.heat - dt * (self.max_heat / 10))
 
+    def resupply(self):
+        if self.ammo_capacity is None:
+            return {"ok": False, "reason": "no_ammo", "weapon": self.name}
+        previous = self.ammo
+        self.ammo = self.ammo_capacity
+        return {
+            "ok": True,
+            "weapon": self.name,
+            "previous_ammo": previous,
+            "ammo": self.ammo,
+            "capacity": self.ammo_capacity,
+        }
+
 class WeaponSystem:
     def __init__(self, config):
         # config is a dict with a "weapons" list of dicts
@@ -125,6 +139,15 @@ class WeaponSystem:
 
         for weapon in self.weapons.values():
             weapon.cool_down(dt)
+
+    def resupply(self):
+        results = []
+        for weapon in self.weapons.values():
+            results.append(weapon.resupply())
+        return {
+            "ok": True,
+            "weapons": results,
+        }
 
     def fire_weapon(self, weapon_name, power_manager, target):
         weapon = self.weapons.get(weapon_name)


### PR DESCRIPTION
### Motivation
- Ensure ships receive repairs and supplies immediately when docking to a station for a smoother gameplay flow and UI feedback.
- Use the existing damage model API (`ship.damage_model.repair_subsystem`) and hull state (`ship.hull_integrity` / `max_hull_integrity`) to perform repairs rather than duplicating logic.
- Provide a weapon resupply hook so ammunition can be restored during docking and surfaced to the UI.

### Description
- Add `ammo_capacity` to `Weapon` and implement `Weapon.resupply()` to restore `ammo` to capacity and return a resupply report.
- Add `WeaponSystem.resupply()` to resupply all weapons and return aggregated results.
- Call a new `_handle_station_dock()` from `DockingSystem.tick()` when a dock completes and the `target_ship.class_type == "station"` to trigger station services.
- `_handle_station_dock()` restores `ship.hull_integrity` to `max_hull_integrity`, iterates `ship.damage_model.subsystems` and calls `repair_subsystem(...)` to top up subsystem health, invokes the weapons resupply helper, and emits `repair_complete` and `weapon_rearmed` events on the `event_bus` for UI feedback.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977235b9d0c8324ac4ac042a4db573f)