### PR TITLE
Fix helm request autopilot command wiring

### DIFF
--- a/gui/components/helm-requests.js
+++ b/gui/components/helm-requests.js
@@ -308,24 +308,29 @@ class HelmRequestsPanel extends HTMLElement {
     if (!request || request.status !== 'pending') return;
 
     try {
+      let response;
       // Execute based on request type
       if (request.type === 'point_at' || request.type === 'set_heading') {
-        await wsClient.sendShipCommand("set_orientation", {
+        response = await wsClient.sendShipCommand("set_orientation", {
           pitch: request.params.pitch || 0,
           yaw: request.params.yaw || 0,
           roll: request.params.roll || 0
         });
       } else if (request.type === 'intercept') {
         // Could trigger autopilot intercept mode
-        await wsClient.sendShipCommand("set_autopilot", {
-          mode: "intercept",
+        response = await wsClient.sendShipCommand("autopilot", {
+          program: "intercept",
           target: request.targetId
         });
       } else if (request.type === 'match_velocity') {
-        await wsClient.sendShipCommand("set_autopilot", {
-          mode: "match",
+        response = await wsClient.sendShipCommand("autopilot", {
+          program: "match",
           target: request.targetId
         });
+      }
+
+      if (response && response.error) {
+        throw new Error(response.error);
       }
 
       // Mark as executed


### PR DESCRIPTION
### Motivation
- Ensure intercept/match helm requests actually engage the backend autopilot by sending the expected `autopilot` command with a `program` argument and surface any server-side errors to the operator.

### Description
- Update `gui/components/helm-requests.js` to call `wsClient.sendShipCommand("autopilot", { program: "intercept"|"match", target })`, capture the `response` (also for `set_orientation`), and throw on `response.error` so the UI shows execution failures.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697728650584832480b9e016e8914aa3)