### PR TITLE
fix(navigation): prevent autopilot heading updates from triggering manual override

### DIFF
--- a/hybrid/systems/helm_system.py
+++ b/hybrid/systems/helm_system.py
@@ -145,7 +145,8 @@ class HelmSystem(BaseSystem):
             self.attitude_target = {"pitch": pitch, "yaw": yaw, "roll": roll}
             
             # Record manual input for navigation system (if nav computer is online)
-            if ship:
+            record_manual_input = params.get("manual_input", True)
+            if ship and record_manual_input:
                 nav_system = ship.systems.get("navigation")
                 if nav_system and hasattr(nav_system, "controller") and nav_system.controller:
                     nav_system.controller.set_manual_input(getattr(ship, "sim_time", 0.0))

--- a/hybrid/systems/navigation/navigation.py
+++ b/hybrid/systems/navigation/navigation.py
@@ -93,6 +93,7 @@ class NavigationSystem(BaseSystem):
                     "pitch": heading.get("pitch", ship.orientation.get("pitch", 0)),
                     "yaw": heading.get("yaw", ship.orientation.get("yaw", 0)),
                     "roll": heading.get("roll", ship.orientation.get("roll", 0)),
+                    "manual_input": False,
                     "_ship": ship,
                     "ship": ship
                 })


### PR DESCRIPTION
### Motivation
- Autopilot heading updates routed through the helm were being recorded as manual input, which flipped the navigation controller into `manual_override` and suppressed subsequent autopilot commands.

### Description
- Add a `manual_input` flag to `HelmSystem._cmd_set_orientation_target` (default `True`) and only call `nav_system.controller.set_manual_input(...)` when `manual_input` is `True` (file: `hybrid/systems/helm_system.py`).
- When navigation autopilot issues heading updates, pass `"manual_input": False` to `HelmSystem._cmd_set_orientation_target` so autopilot-driven updates do not count as manual input (file: `hybrid/systems/navigation/navigation.py`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697729a97d848324b8a5ae6ac83f259d)