### PR TITLE
Waypoint UI: add manual/autopilot toggle and send `set_course` payload; accept course params in navigation

### DIFF
--- a/hybrid/commands/navigation_commands.py
+++ b/hybrid/commands/navigation_commands.py
@@ -53,7 +53,17 @@ def register_commands(dispatcher):
             ArgSpec("y", "float", required=True, description="Destination Y coordinate"),
             ArgSpec("z", "float", required=True, description="Destination Z coordinate"),
             ArgSpec("stop", "bool", required=False, default=True,
-                    description="Stop at destination (default true)")
+                    description="Stop at destination (default true)"),
+            ArgSpec("tolerance", "float", required=False,
+                    description="Arrival tolerance in meters"),
+            ArgSpec("max_thrust", "float", required=False,
+                    description="Maximum thrust scalar (0..1)"),
+            ArgSpec("coast_speed", "float", required=False,
+                    description="Coast speed target for cruise"),
+            ArgSpec("max_speed", "float", required=False,
+                    description="Maximum speed during course"),
+            ArgSpec("brake_buffer", "float", required=False,
+                    description="Extra distance buffer for braking"),
         ],
         help_text="Set navigation course to destination",
         system="navigation"

--- a/hybrid/systems/navigation/navigation.py
+++ b/hybrid/systems/navigation/navigation.py
@@ -274,12 +274,32 @@ class NavigationSystem(BaseSystem):
         except (TypeError, ValueError):
             return error_dict("INVALID_COORDINATES", "Course requires numeric x, y, z values")
 
-        stop = bool(params.get("stop", True))
-        tolerance = params.get("tolerance", 50.0)
-        max_thrust = params.get("max_thrust")
-        coast_speed = params.get("coast_speed")
-        max_speed = params.get("max_speed")
-        brake_buffer = params.get("brake_buffer")
+        stop_value = params.get("stop", True)
+        if isinstance(stop_value, str):
+            stop = stop_value.strip().lower() in {"1", "true", "yes", "on"}
+        else:
+            stop = bool(stop_value)
+
+        try:
+            tolerance = float(params.get("tolerance", 50.0))
+        except (TypeError, ValueError):
+            return error_dict("INVALID_TOLERANCE", "Tolerance must be a number")
+
+        def _parse_optional_float(value, label):
+            if value is None:
+                return None
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                raise ValueError(f"{label} must be a number")
+
+        try:
+            max_thrust = _parse_optional_float(params.get("max_thrust"), "Max thrust")
+            coast_speed = _parse_optional_float(params.get("coast_speed"), "Coast speed")
+            max_speed = _parse_optional_float(params.get("max_speed"), "Max speed")
+            brake_buffer = _parse_optional_float(params.get("brake_buffer"), "Brake buffer")
+        except ValueError as exc:
+            return error_dict("INVALID_COURSE_PARAM", str(exc))
 
         autopilot_params = {
             "x": x,


### PR DESCRIPTION
### Motivation

- Provide a way for waypoint execution to either "point at" a target or command the ship to "fly to" a waypoint using the autopilot, including optional course parameters such as `stop`, `tolerance`, and `max_thrust`.
- Ensure the GUI and backend navigation command handlers accept and act on the same payload shape so the UI can reliably trigger autopilot behavior.

### Description

- Added a manual vs autopilot toggle to the waypoint UI in `gui/components/flight-computer.js` and UI inputs for `stop`, `tolerance`, and `max_thrust`, plus wiring to recompute when the toggle changes.
- Included the waypoint execution mode and course options in the computed solution command payload (`executionMode`, `stop`, `tolerance`, `max_thrust`) from the flight computer and send either `point_at` (manual) or `set_course` (autopilot) in `_execute()` depending on the toggle.
- Extended `set_course` command registration in `hybrid/commands/navigation_commands.py` to accept `tolerance`, `max_thrust`, `coast_speed`, `max_speed`, and `brake_buffer` arguments.
- Hardened parsing and validation in `hybrid/systems/navigation/navigation.py` `_cmd_set_course` to accept string/boolean `stop` values and to validate optional numeric parameters before passing them into the autopilot controller as `goto_position` parameters.

### Testing

- Performed a GUI smoke test by serving `gui/index.html` and capturing a screenshot via an automated Playwright script; the page rendered and the screenshot was produced successfully.
- Verified code changes staged and committed locally with `git` (commit succeeded).
- No unit/integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697735ddef00832484ab92fe62f937a1)