### PR TITLE
Add live autopilot range/ETA and closing speed to navigation display

### DIFF
--- a/gui/js/state-manager.js
+++ b/gui/js/state-manager.js
@@ -393,12 +393,16 @@ class StateManager extends EventTarget {
     let autopilot = null;
     if (ship?.systems?.navigation) {
       const nav = ship.systems.navigation;
+      const autopilotState = nav.autopilot_state || nav.autopilotState || null;
       autopilot = {
         mode: nav.mode || "manual",
         enabled: nav.autopilot_enabled || false,
         target: nav.target || null,
         phase: nav.phase || null,
-        range: nav.target_range || null,
+        range: autopilotState?.distance ?? nav.target_range ?? null,
+        distance: autopilotState?.distance ?? null,
+        closingSpeed: autopilotState?.closing_speed ?? null,
+        eta: autopilotState?.eta ?? null,
       };
     } else if (ship?.autopilot) {
       autopilot = ship.autopilot;


### PR DESCRIPTION
### Motivation
- Surface live autopilot telemetry (distance/time-to-target) in the GUI so users see an active program's range and ETA. 
- Reuse `autopilot_state` produced by `NavigationController.get_state()` to avoid duplicating logic and provide authoritative telemetry.

### Description
- Map `ship.systems.navigation.autopilot_state` into the front-end state in `gui/js/state-manager.js` by adding `distance`, `closingSpeed`, and `eta` to the `autopilot` object returned by `getNavigation()`.
- Update `gui/components/navigation-display.js` to render live autopilot Range, ETA, and Closing Speed when an autopilot program is active and to prefer `autopilot_state.distance` where available.
- Add helpers `_formatRangeDistance`, `_calculateEtaSeconds`, and `_formatDuration` to format ranges and compute or display ETA from `distance` and `closingSpeed` (with fallback to an `eta` field if provided by the backend).
- Keep existing displays intact and only show the extra autopilot details when an autopilot mode is active.

### Testing
- Launched a local static server with `python -m http.server` and loaded `gui/index.html` with a Playwright script to verify the UI renders; a screenshot artifact was produced successfully. 
- No unit tests were added or run as this is a UI-only enhancement; manual/visual verification via the screenshot succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69773a8e7ec883249f231d7e883bdd7d)