### PR TITLE
Add flight plan data structures, navigation `set_plan` command, and GUI plan queue + trigger countdowns

### DIFF
--- a/hybrid/command_handler.py
+++ b/hybrid/command_handler.py
@@ -30,6 +30,7 @@ system_commands = {
     # Navigation and autopilot
     "set_course": ("navigation", "set_course"),
     "autopilot": ("navigation", "set_autopilot"),
+    "set_plan": ("navigation", "set_plan"),
     "helm_override": ("helm", "set_mode"),
     "queue_helm_command": ("helm", "queue_command"),
     "queue_helm_commands": ("helm", "queue_commands"),

--- a/hybrid/commands/navigation_commands.py
+++ b/hybrid/commands/navigation_commands.py
@@ -30,6 +30,13 @@ def cmd_set_course(navigation, ship, params):
 
     return error_dict("NOT_IMPLEMENTED", "Course setting not yet implemented")
 
+def cmd_set_plan(navigation, ship, params):
+    """Set a queued flight plan."""
+    if navigation and hasattr(navigation, "command"):
+        return navigation.command("set_plan", params)
+
+    return error_dict("NOT_IMPLEMENTED", "Flight plan setting not yet implemented")
+
 def register_commands(dispatcher):
     """Register all navigation commands with the dispatcher."""
 
@@ -66,5 +73,15 @@ def register_commands(dispatcher):
                     description="Extra distance buffer for braking"),
         ],
         help_text="Set navigation course to destination",
+        system="navigation"
+    ))
+
+    dispatcher.register("set_plan", CommandSpec(
+        handler=cmd_set_plan,
+        args=[
+            ArgSpec("plan", "dict", required=True,
+                    description="Flight plan payload"),
+        ],
+        help_text="Queue a navigation flight plan",
         system="navigation"
     ))

--- a/hybrid/navigation/__init__.py
+++ b/hybrid/navigation/__init__.py
@@ -3,6 +3,15 @@
 
 from .relative_motion import *
 from .navigation_controller import NavigationController
+from .plan import FlightPlan, FlightPlanStep, PlanTrigger
 from .autopilot import *
 
-__all__ = ['relative_motion', 'navigation_controller', 'autopilot']
+__all__ = [
+    'relative_motion',
+    'navigation_controller',
+    'autopilot',
+    'plan',
+    'FlightPlan',
+    'FlightPlanStep',
+    'PlanTrigger',
+]

--- a/hybrid/navigation/navigation_controller.py
+++ b/hybrid/navigation/navigation_controller.py
@@ -23,6 +23,7 @@ class NavigationController:
         self.last_manual_input = 0.0
         self.autopilot_program_name = None
         self.target_id = None
+        self.flight_plan = None
 
     def set_manual_input(self, sim_time: float):
         """Record manual input from pilot.
@@ -148,6 +149,9 @@ class NavigationController:
             "target_id": self.target_id
         }
 
+        if self.flight_plan:
+            state["flight_plan"] = self.flight_plan.to_dict()
+
         # Add autopilot state if active
         if self.autopilot and hasattr(self.autopilot, 'get_state'):
             state["autopilot_state"] = self.autopilot.get_state()
@@ -160,6 +164,14 @@ class NavigationController:
             ) if hasattr(self.ship, 'sim_time') else self.manual_override_timeout
 
         return state
+
+    def set_flight_plan(self, plan) -> Dict:
+        """Set the active flight plan for the ship."""
+        self.flight_plan = plan
+        return success_dict(
+            "Flight plan loaded",
+            plan=self.flight_plan.to_dict() if self.flight_plan else None
+        )
 
     def calculate_intercept_solution(self, target_id: Optional[str] = None, target_position: Optional[Dict] = None) -> Optional[Dict]:
         """Calculate intercept solution for manual control assistance.

--- a/hybrid/navigation/plan.py
+++ b/hybrid/navigation/plan.py
@@ -1,0 +1,127 @@
+# hybrid/navigation/plan.py
+"""Flight plan data structures for navigation sequencing."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+def _parse_optional_float(value: Any, label: str) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be a number") from exc
+
+
+@dataclass
+class PlanTrigger:
+    """Trigger conditions for a flight plan step."""
+
+    distance_remaining: Optional[float] = None
+    time_to_target: Optional[float] = None
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> Optional["PlanTrigger"]:
+        if not data:
+            return None
+
+        distance_remaining = _parse_optional_float(
+            data.get("distance_remaining"),
+            "distance_remaining",
+        )
+        time_to_target = _parse_optional_float(
+            data.get("time_to_target"),
+            "time_to_target",
+        )
+
+        return cls(distance_remaining=distance_remaining, time_to_target=time_to_target)
+
+    def to_dict(self) -> Dict[str, float]:
+        payload: Dict[str, float] = {}
+        if self.distance_remaining is not None:
+            payload["distance_remaining"] = self.distance_remaining
+        if self.time_to_target is not None:
+            payload["time_to_target"] = self.time_to_target
+        return payload
+
+
+@dataclass
+class FlightPlanStep:
+    """A single flight plan step with optional trigger conditions."""
+
+    action: str
+    detail: str = ""
+    trigger: Optional[PlanTrigger] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "FlightPlanStep":
+        if not isinstance(data, dict):
+            raise ValueError("Plan step must be a dict")
+
+        action = data.get("action")
+        if not action:
+            raise ValueError("Plan step missing action")
+
+        detail = data.get("detail", "")
+        trigger = PlanTrigger.from_dict(data.get("trigger"))
+        return cls(action=str(action), detail=str(detail or ""), trigger=trigger)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = {
+            "action": self.action,
+            "detail": self.detail,
+        }
+        if self.trigger:
+            trigger_payload = self.trigger.to_dict()
+            if trigger_payload:
+                payload["trigger"] = trigger_payload
+        return payload
+
+
+@dataclass
+class FlightPlan:
+    """Ordered flight plan with trigger-aware steps."""
+
+    steps: List[FlightPlanStep] = field(default_factory=list)
+    name: Optional[str] = None
+    plan_type: Optional[str] = None
+    target: Optional[Dict[str, Any]] = None
+    source: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "FlightPlan":
+        if not isinstance(data, dict):
+            raise ValueError("Plan payload must be a dict")
+
+        steps_data = data.get("steps")
+        if not isinstance(steps_data, list) or not steps_data:
+            raise ValueError("Plan requires a non-empty steps list")
+
+        steps = [FlightPlanStep.from_dict(step) for step in steps_data]
+        name = data.get("name")
+        plan_type = data.get("type") or data.get("plan_type")
+        target = data.get("target")
+        source = data.get("source")
+
+        return cls(
+            steps=steps,
+            name=str(name) if name else None,
+            plan_type=str(plan_type) if plan_type else None,
+            target=target,
+            source=str(source) if source else None,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = {
+            "steps": [step.to_dict() for step in self.steps],
+        }
+        if self.name:
+            payload["name"] = self.name
+        if self.plan_type:
+            payload["type"] = self.plan_type
+        if self.target is not None:
+            payload["target"] = self.target
+        if self.source:
+            payload["source"] = self.source
+        return payload


### PR DESCRIPTION
### Motivation
- Provide a lightweight flight-plan representation so the navigation stack can accept ordered steps with trigger conditions (distance/time) for queued execution. 
- Allow the GUI flight computer to optionally submit computed maneuver plans to the ship and display live per-step trigger countdowns using telemetry. 

### Description
- Add `hybrid/navigation/plan.py` containing `FlightPlan`, `FlightPlanStep`, and `PlanTrigger` dataclasses with `from_dict`/`to_dict` helpers for safe parsing and serialization. 
- Expose plan classes in `hybrid/navigation/__init__.py` and add `flight_plan` storage plus `set_flight_plan` on `NavigationController` so active plans are surfaced via `get_state()`. 
- Add a `set_plan` command path through `hybrid/command_handler.py`, `hybrid/commands/navigation_commands.py` (new `cmd_set_plan` and dispatcher registration), and `NavigationSystem._cmd_set_plan` which parses and forwards a `FlightPlan` to the controller. 
- Extend `gui/components/flight-computer.js` to: build a queueable `plan` for waypoint / intercept / flip_burn computations, add a "Queue plan" checkbox, send `set_plan` via the websocket client when requested, and render per-step trigger countdowns computed from live telemetry with small UI/CSS additions. 

### Testing
- Launched a static GUI server with `python -m http.server` and executed a Playwright script to capture a screenshot of the updated flight computer, which completed successfully. 
- No automated unit test suite was executed for these changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69773bfae4f48324b59518e2e4a56bda)