### PR TITLE
Update quickstart GUI command to use Tkinter client

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ python -m server.station_server --fleet-dir hybrid_fleet --dt 0.1 --port 8765
 # Minimal server (no stations / simplest behavior)
 # python -m server.run_server --fleet-dir hybrid_fleet --dt 0.1 --port 8765
 
-# Terminal 2: HUD
-python hybrid/gui/gui.py
+# Terminal 2: GUI client (Tkinter)
+python hybrid/gui/run_gui.py --config ships_config.json
 ```
 
 ## Web GUI Quickstart


### PR DESCRIPTION
### Motivation
- Replace an outdated HUD invocation with the supported Tkinter GUI launcher and show a sample `--config` usage for clarity.

### Description
- Update `README.md` quickstart: replace `python hybrid/gui/gui.py` with `python hybrid/gui/run_gui.py --config ships_config.json`.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977425eefd08324a4145b565cb878d7)