### PR TITLE
Add weapon selection UI and tighten power allocation command parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ python -m server.station_server --fleet-dir hybrid_fleet --dt 0.1 --port 8765
 # Minimal server (no stations / simplest behavior)
 # python -m server.run_server --fleet-dir hybrid_fleet --dt 0.1 --port 8765
 
-# Terminal 2: HUD
-python hybrid/gui/gui.py
+# Terminal 2: GUI client (Tkinter)
+python hybrid/gui/run_gui.py --config ships_config.json
 ```
 
 ## Web GUI Quickstart

--- a/hybrid/gui/run_gui.py
+++ b/hybrid/gui/run_gui.py
@@ -106,6 +106,7 @@ class ShipGUI(tk.Tk):
         self.current_ship = tk.StringVar(value=list(self.ships.keys())[0])
         self.connection_state = tk.StringVar()
         self.last_server_error = None
+        self.weapon_var = tk.StringVar()
 
         # Build GUI
         self.create_widgets()
@@ -146,6 +147,7 @@ class ShipGUI(tk.Tk):
         ship_combo = ttk.Combobox(top, values=list(self.ships.keys()), textvariable=self.current_ship, state="readonly")
         ship_combo.pack(side='left', padx=5)
         ship_combo.current(0)
+        ship_combo.bind("<<ComboboxSelected>>", self.on_ship_changed)
         ttk.Button(top, text="Test Server", command=self.test_server_connection).pack(side='left', padx=5)
         self.status_label = ttk.Label(top, text="")
         self.status_label.pack(side='left', padx=20)
@@ -237,8 +239,12 @@ class ShipGUI(tk.Tk):
 
     def create_weapons_tab(self, parent):
         frame = ttk.LabelFrame(parent, text="Weapons Systems"); frame.pack(fill='both', expand=True, padx=8, pady=8)
+        ttk.Label(frame, text="Weapon:").pack(anchor='w')
+        self.weapon_combo = ttk.Combobox(frame, textvariable=self.weapon_var, state="readonly")
+        self.weapon_combo.pack(anchor='w', pady=2)
+        self._update_weapon_options()
         ttk.Button(frame, text="Fire Weapon", command=self.on_weapon_fire).pack(anchor='w')
-        ttk.Label(frame, text="(Future: Add weapon selector/payload)").pack(anchor='w')
+        ttk.Label(frame, text="(Uses weapon selected above)").pack(anchor='w')
 
     def create_map_tab(self, parent):
         frame = ttk.Frame(parent); frame.pack(fill='both', expand=True, padx=8, pady=8)
@@ -304,11 +310,39 @@ class ShipGUI(tk.Tk):
         self.power_state.set(json.dumps(data))
 
     def on_weapon_fire(self):
-        payload = {"ship": self.current_ship.get(), "target": self.target_ship_var.get()}
+        weapon_name = self.weapon_var.get()
+        if not weapon_name:
+            messagebox.showerror("Weapon", "No weapon available for this ship")
+            return
+        payload = {
+            "ship": self.current_ship.get(),
+            "target": self.target_ship_var.get(),
+            "weapon": weapon_name,
+        }
         resp = send_command_to_server(self.host, self.port, "fire_weapon", payload)
         self.log_debug(f">> fire_weapon {payload}\n<< {resp}")
         data = self._parse_response(resp)
         messagebox.showinfo("Weapon", json.dumps(data))
+
+    def on_ship_changed(self, event=None):
+        self._update_weapon_options()
+
+    def _update_weapon_options(self):
+        weapons = self._get_weapon_names(self.current_ship.get())
+        self.weapon_combo["values"] = weapons
+        if weapons:
+            self.weapon_var.set(weapons[0])
+            self.weapon_combo.current(0)
+        else:
+            self.weapon_var.set("")
+
+    def _get_weapon_names(self, ship_id):
+        ship = self.ships.get(ship_id, {})
+        systems = ship.get("systems", {})
+        weapons_cfg = systems.get("weapons", {})
+        entries = weapons_cfg.get("weapons", [])
+        names = [weapon.get("name") for weapon in entries if weapon.get("name")]
+        return names
 
     def on_draw_map(self):
         # Get all ship positions and draw them

--- a/hybrid/systems/power/management.py
+++ b/hybrid/systems/power/management.py
@@ -304,7 +304,12 @@ class PowerManagementSystem:
         if action == "get_power_profiles":
             return self.get_profiles()
         if action == "set_power_allocation":
-            allocation = params.get("allocation", params)
+            allocation = params.get("allocation")
+            if allocation is None:
+                valid_layers = set(self.reactors.keys()) or set(DEFAULT_POWER_ALLOCATION.keys())
+                allocation = {key: value for key, value in params.items() if key in valid_layers}
+            if not allocation:
+                return {"error": "Missing allocation values"}
             return self.set_power_allocation(allocation)
         if action == "set_overdrive_limits":
             limits = params.get("limits", params)


### PR DESCRIPTION
### Motivation
- Fix an issue where the Tkinter GUI fired weapons without a selectable weapon, making `fire_weapon` requests incomplete for ships with multiple weapons. 
- Prevent accidental inclusion of unrelated params (e.g. `ship`) when calling `set_power_allocation` which caused invalid allocation payloads. 
- Improve UX by refreshing available weapons when the selected ship changes so the GUI reflects the loaded ship configuration.

### Description
- Add a weapon selector to the Tkinter client by introducing `weapon_var`, a `Combobox`, and wiring `ship_combo.bind("<<ComboboxSelected>>", ...)` so options refresh on ship change in `hybrid/gui/run_gui.py`.
- Populate the weapon list from the loaded ship config with a new helper `_get_weapon_names` and `_update_weapon_options`, and default-select the first weapon when present.
- Include the selected `weapon` in the `fire_weapon` payload and show an error dialog if no weapon is available, by updating the `on_weapon_fire` handler to validate and send the `weapon` field.
- Harden `PowerManagementSystem.command` in `hybrid/systems/power/management.py` so `set_power_allocation` accepts an explicit `allocation` object or infers allocation keys from valid reactor/bus layers, and returns a clear error when no allocation values are provided.

### Testing
- No automated tests were run against these changes (`pytest` not executed). 
- Changes were limited to GUI behavior and command-routing logic; manual runtime validation is recommended (start server and run `python hybrid/gui/run_gui.py --config ships_config.json`) to verify weapon dropdown population and that `set_power_allocation` calls accept both `{"allocation": {...}}` and direct layer-keyed params.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977425eefd08324a4145b565cb878d7)