### PR TITLE
Normalize power system key to `power_management`; robust allocation handling; GUI weapon selector and power toggle guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,9 +46,10 @@ This document helps AI agents (e.g. Codex, ChatGPT) understand project structure
   - Tracks draw/supply and toggled systems
 
 ### Tick Integration
-Invoke each frame via the simulator:
+The simulator tick loop already calls `tick()` on each system, so no manual
+call is required from the caller.
 ```python
-ship.power_system.tick()
+# handled inside Ship.tick()
 ```
 
 ---
@@ -56,10 +57,10 @@ ship.power_system.tick()
 🧪 CLI Commands (via `hybrid.cli`)
 
 ```bash
-python -m hybrid.cli --ship test_ship_001 --command '{"command": "reactor_start"}'
-python -m hybrid.cli --ship test_ship_001 --command '{"command": "get_power_status"}'
-python -m hybrid.cli --ship test_ship_001 --command '{"command": "toggle_system", "system": "railgun", "state": 0}'
-python -m hybrid.cli --ship test_ship_001 --command '{"command": "set_power_allocation", "primary": 0.5, "secondary": 0.3, "tertiary": 0.2}'
+python -m hybrid.cli --ship test_ship_001 --command '{"command": "get_power_state"}'
+python -m hybrid.cli --ship test_ship_001 --command '{"command": "set_power_profile", "profile": "offensive"}'
+python -m hybrid.cli --ship test_ship_001 --command '{"command": "get_power_profiles"}'
+python -m hybrid.cli --ship test_ship_001 --command '{"command": "set_power_allocation", "allocation": {"primary": 0.5, "secondary": 0.3, "tertiary": 0.2}}'
 ```
 
 All commands update the live ship state through the power system.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ python -m server.station_server --fleet-dir hybrid_fleet --dt 0.1 --port 8765
 # Minimal server (no stations / simplest behavior)
 # python -m server.run_server --fleet-dir hybrid_fleet --dt 0.1 --port 8765
 
-# Terminal 2: HUD
-python hybrid/gui/gui.py
+# Terminal 2: GUI client (Tkinter)
+python hybrid/gui/run_gui.py --config ships_config.json
 ```
 
 ## Web GUI Quickstart

--- a/hybrid/ship_factory.py
+++ b/hybrid/ship_factory.py
@@ -8,7 +8,9 @@ from hybrid.systems.sensors.sensor_system import SensorSystem
 
 
 def build_ship_systems(config):
-    power = PowerManagementSystem(config.get("power", {}))
+    power_management = PowerManagementSystem(
+        config.get("power_management", config.get("power", {}))
+    )
     weapon_cfg = config.get("weapons", {})
     weapon_system = WeaponSystem(weapon_cfg)
     hardpoints = []
@@ -29,7 +31,7 @@ def build_ship_systems(config):
     navigation = NavigationSystem(config.get("navigation", {}))
     sensors = SensorSystem(config.get("sensors", {}))
     return {
-        "power": power,
+        "power_management": power_management,
         "weapons": weapon_system,
         "hardpoints": hardpoints,
         "navigation": navigation,

--- a/hybrid/systems/power/management.py
+++ b/hybrid/systems/power/management.py
@@ -304,7 +304,12 @@ class PowerManagementSystem:
         if action == "get_power_profiles":
             return self.get_profiles()
         if action == "set_power_allocation":
-            allocation = params.get("allocation", params)
+            allocation = params.get("allocation")
+            if allocation is None:
+                valid_layers = set(self.reactors.keys()) or set(DEFAULT_POWER_ALLOCATION.keys())
+                allocation = {key: value for key, value in params.items() if key in valid_layers}
+            if not allocation:
+                return {"error": "Missing allocation values"}
             return self.set_power_allocation(allocation)
         if action == "set_overdrive_limits":
             limits = params.get("limits", params)

--- a/tests/hybrid_tests/test_ship_initialization.py
+++ b/tests/hybrid_tests/test_ship_initialization.py
@@ -22,7 +22,7 @@ def test_create_simple_ship(tmp_path):
     # Load and create ship
     ship_defs = json.loads(file_path.read_text())
     ship = create_ship(ship_defs["testship"])
-    assert ship["power"] is not None
+    assert ship["power_management"] is not None
     assert ship["weapons"] is not None
     assert ship["navigation"] is not None
     assert ship["sensors"] is not None


### PR DESCRIPTION
### Motivation
- Align runtime naming for the power subsystem to avoid mismatches between factory output, GUI, and tests.  
- Make the power management command handler more forgiving for allocation inputs.  
- Improve weapons UX in the GUI and prevent legacy power toggle calls from erroring on ships without a legacy `power` entry.  

### Description
- `hybrid/ship_factory.py`: create and expose the power system under the `power_management` key and fall back to reading legacy `power` config when present.  
- `hybrid/systems/power/management.py`: make the `command` handler for `set_power_allocation` accept either an `allocation` dict or flattened allocation keys, and return an error when allocation values are missing.  
- `hybrid/gui/run_gui.py`: add a weapon selector (`weapon_var`, `Combobox`, `_update_weapon_options`, `_get_weapon_names`, `on_ship_changed`), include selected `weapon` in `fire_weapon` payloads, and guard `on_power_toggle` so it shows an error if the selected ship lacks a legacy `power` system.  
- Docs: update `AGENTS.md` and `README.md` to reflect current CLI commands and GUI invocation.  
- Tests: update `tests/hybrid_tests/test_ship_initialization.py` to assert the presence of `power_management` instead of `power`.  

### Testing
- Unit test updated: `tests/hybrid_tests/test_ship_initialization.py` now asserts `ship["power_management"]` is present.  
- No automated test suite was executed in this change; automated test status is therefore unverified.  
- Local file inspections and small static checks were performed during the change process and revealed no runtime errors in the edited files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977425eefd08324a4145b565cb878d7)