### PR TITLE
Add Power Management GUI and Reactor Fuel/Thermal Modeling

### DIFF
--- a/gui/components/power-management.js
+++ b/gui/components/power-management.js
@@ -1,0 +1,376 @@
+/**
+ * Power Management Panel
+ * Allocation sliders + reactor meters.
+ */
+
+import { stateManager } from "../js/state-manager.js";
+import { wsClient } from "../js/ws-client.js";
+
+const DEFAULT_ALLOCATION = {
+  primary: 0.5,
+  secondary: 0.3,
+  tertiary: 0.2,
+};
+
+class PowerManagement extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._unsubscribe = null;
+  }
+
+  connectedCallback() {
+    this.render();
+    this._subscribe();
+  }
+
+  disconnectedCallback() {
+    if (this._unsubscribe) {
+      this._unsubscribe();
+    }
+  }
+
+  _subscribe() {
+    this._unsubscribe = stateManager.subscribe("*", () => {
+      this._updateDisplay();
+    });
+  }
+
+  render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          padding: 16px;
+          font-family: var(--font-sans, "Inter", sans-serif);
+          color: var(--text-primary, #e0e0e0);
+        }
+
+        .section {
+          margin-bottom: 16px;
+        }
+
+        .section-title {
+          font-size: 0.85rem;
+          text-transform: uppercase;
+          letter-spacing: 0.08em;
+          color: var(--text-dim, #889);
+          margin-bottom: 8px;
+        }
+
+        .allocation-row {
+          display: grid;
+          grid-template-columns: 120px 1fr 50px;
+          gap: 10px;
+          align-items: center;
+          background: var(--bg-input, #1a1a24);
+          padding: 10px 12px;
+          border-radius: 10px;
+          margin-bottom: 8px;
+        }
+
+        .allocation-label {
+          font-size: 0.85rem;
+          text-transform: capitalize;
+        }
+
+        input[type="range"] {
+          width: 100%;
+          accent-color: var(--status-nominal, #00ff88);
+        }
+
+        .allocation-value {
+          font-size: 0.85rem;
+          text-align: right;
+          color: var(--text-secondary, #bbb);
+        }
+
+        .allocation-footer {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          margin-top: 8px;
+          font-size: 0.8rem;
+          color: var(--text-secondary, #888);
+        }
+
+        .apply-btn {
+          padding: 8px 14px;
+          border-radius: 8px;
+          border: none;
+          background: var(--status-info, #4aa3ff);
+          color: #0a0a0f;
+          font-weight: 600;
+          cursor: pointer;
+        }
+
+        .apply-btn:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+
+        .reactor-card {
+          background: var(--bg-input, #1a1a24);
+          border-radius: 10px;
+          padding: 12px;
+          margin-bottom: 8px;
+        }
+
+        .reactor-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          margin-bottom: 8px;
+        }
+
+        .reactor-name {
+          text-transform: capitalize;
+          font-size: 0.9rem;
+          font-weight: 600;
+        }
+
+        .reactor-status {
+          font-size: 0.75rem;
+          text-transform: uppercase;
+          padding: 2px 6px;
+          border-radius: 6px;
+          background: rgba(0, 255, 136, 0.2);
+          color: var(--status-nominal, #00ff88);
+        }
+
+        .reactor-status.warning {
+          background: rgba(255, 170, 0, 0.2);
+          color: var(--status-warning, #ffaa00);
+        }
+
+        .reactor-status.error {
+          background: rgba(255, 68, 68, 0.2);
+          color: var(--status-critical, #ff4444);
+        }
+
+        .meter {
+          height: 8px;
+          border-radius: 999px;
+          background: var(--bg-primary, #0a0a0f);
+          overflow: hidden;
+          margin-bottom: 6px;
+        }
+
+        .meter-fill {
+          height: 100%;
+          background: var(--status-nominal, #00ff88);
+          width: 0%;
+          transition: width 0.2s ease;
+        }
+
+        .meter-fill.warning {
+          background: var(--status-warning, #ffaa00);
+        }
+
+        .meter-fill.error {
+          background: var(--status-critical, #ff4444);
+        }
+
+        .meter-label {
+          display: flex;
+          justify-content: space-between;
+          font-size: 0.75rem;
+          color: var(--text-secondary, #aaa);
+          margin-bottom: 8px;
+        }
+
+        .reactor-detail {
+          display: flex;
+          justify-content: space-between;
+          font-size: 0.75rem;
+          color: var(--text-secondary, #999);
+        }
+      </style>
+
+      <div class="section">
+        <div class="section-title">Power Allocation</div>
+        <div id="allocation-list"></div>
+        <div class="allocation-footer">
+          <span id="allocation-total">Total: 0%</span>
+          <button class="apply-btn" id="apply-btn">Apply Allocation</button>
+        </div>
+      </div>
+
+      <div class="section">
+        <div class="section-title">Reactors</div>
+        <div id="reactor-list"></div>
+      </div>
+    `;
+
+    this._renderAllocation();
+    this._renderReactors();
+    this._attachHandlers();
+  }
+
+  _attachHandlers() {
+    const applyBtn = this.shadowRoot.getElementById("apply-btn");
+    applyBtn.addEventListener("click", () => this._applyAllocation());
+  }
+
+  _renderAllocation() {
+    const allocation = this._getAllocation();
+    const busKeys = Object.keys(allocation);
+    const list = this.shadowRoot.getElementById("allocation-list");
+
+    list.innerHTML = busKeys.map((bus) => {
+      const value = Math.round((allocation[bus] || 0) * 100);
+      return `
+        <div class="allocation-row">
+          <div class="allocation-label">${bus}</div>
+          <input type="range" min="0" max="100" value="${value}" data-bus="${bus}" />
+          <div class="allocation-value" data-value="${bus}">${value}%</div>
+        </div>
+      `;
+    }).join("");
+
+    list.querySelectorAll("input[type='range']").forEach((input) => {
+      input.addEventListener("input", () => {
+        const bus = input.dataset.bus;
+        const valueEl = this.shadowRoot.querySelector(`[data-value="${bus}"]`);
+        if (valueEl) {
+          valueEl.textContent = `${input.value}%`;
+        }
+        this._updateTotal();
+      });
+    });
+
+    this._updateTotal();
+  }
+
+  _renderReactors() {
+    const list = this.shadowRoot.getElementById("reactor-list");
+    const reactors = this._getReactors();
+    const reactorEntries = Object.values(reactors);
+
+    if (!reactorEntries.length) {
+      list.innerHTML = `<div class="reactor-card">No reactor data.</div>`;
+      return;
+    }
+
+    list.innerHTML = reactorEntries.map((reactor) => {
+      const capacity = reactor.capacity || 0;
+      const available = reactor.available || 0;
+      const availabilityPercent = capacity > 0 ? (available / capacity) * 100 : 0;
+      const temp = reactor.temperature ?? 0;
+      const thermal = reactor.thermal_limit ?? 0;
+      const tempPercent = thermal > 0 ? (temp / thermal) * 100 : 0;
+      const fuelPercent = reactor.fuel_percent ?? null;
+
+      return `
+        <div class="reactor-card">
+          <div class="reactor-header">
+            <div class="reactor-name">${reactor.name || "reactor"}</div>
+            <div class="reactor-status ${this._statusClass(reactor.status)}">${reactor.status || "nominal"}</div>
+          </div>
+          <div class="meter">
+            <div class="meter-fill ${this._meterClass(availabilityPercent)}" style="width:${availabilityPercent}%"></div>
+          </div>
+          <div class="meter-label">
+            <span>Available</span>
+            <span>${this._formatKw(available)} / ${this._formatKw(capacity)}</span>
+          </div>
+          <div class="meter">
+            <div class="meter-fill ${this._meterClass(tempPercent)}" style="width:${Math.min(100, tempPercent)}%"></div>
+          </div>
+          <div class="meter-label">
+            <span>Temperature</span>
+            <span>${temp.toFixed(1)}° / ${thermal.toFixed(1)}°</span>
+          </div>
+          <div class="reactor-detail">
+            <span>Fuel</span>
+            <span>${fuelPercent === null ? "—" : `${fuelPercent.toFixed(1)}%`}</span>
+          </div>
+        </div>
+      `;
+    }).join("");
+  }
+
+  _updateTotal() {
+    const totalEl = this.shadowRoot.getElementById("allocation-total");
+    const applyBtn = this.shadowRoot.getElementById("apply-btn");
+    const total = this._getAllocationInputs().reduce((sum, value) => sum + value, 0);
+    totalEl.textContent = `Total: ${total}%`;
+    applyBtn.disabled = total <= 0;
+  }
+
+  _getAllocationInputs() {
+    const inputs = Array.from(this.shadowRoot.querySelectorAll("input[type='range']"));
+    return inputs.map((input) => Number(input.value || 0));
+  }
+
+  _applyAllocation() {
+    const inputs = Array.from(this.shadowRoot.querySelectorAll("input[type='range']"));
+    const raw = {};
+    let total = 0;
+    inputs.forEach((input) => {
+      const value = Number(input.value || 0);
+      raw[input.dataset.bus] = value;
+      total += value;
+    });
+
+    if (total <= 0) {
+      return;
+    }
+
+    const allocation = {};
+    Object.keys(raw).forEach((bus) => {
+      allocation[bus] = (raw[bus] || 0) / total;
+    });
+
+    wsClient.sendShipCommand("set_power_allocation", { allocation }).catch((error) => {
+      console.error("Failed to set power allocation:", error);
+    });
+  }
+
+  _getAllocation() {
+    const power = this._getPowerState();
+    const allocation = power.power_allocation;
+    if (allocation && Object.keys(allocation).length > 0) {
+      return allocation;
+    }
+    return DEFAULT_ALLOCATION;
+  }
+
+  _getReactors() {
+    const power = this._getPowerState();
+    return power.reactors || {};
+  }
+
+  _getPowerState() {
+    const systems = stateManager.getSystems();
+    return systems.power_management || systems.power || stateManager.getPower() || {};
+  }
+
+  _formatKw(value) {
+    if (!Number.isFinite(value)) {
+      return "0 kW";
+    }
+    return `${value.toFixed(1)} kW`;
+  }
+
+  _statusClass(status) {
+    const s = (status || "").toLowerCase();
+    if (["overheated", "warning", "degraded"].includes(s)) return "warning";
+    if (["depleted", "error", "failed"].includes(s)) return "error";
+    return "";
+  }
+
+  _meterClass(percent) {
+    if (percent >= 90) return "error";
+    if (percent >= 75) return "warning";
+    return "";
+  }
+
+  _updateDisplay() {
+    this._renderAllocation();
+    this._renderReactors();
+  }
+}
+
+customElements.define("power-management", PowerManagement);
+export { PowerManagement };

--- a/gui/index.html
+++ b/gui/index.html
@@ -211,6 +211,11 @@
       min-height: var(--panel-height-sm);
     }
 
+    .power-panel {
+      grid-column: span 3;
+      min-height: var(--panel-height-sm);
+    }
+
     /* Placeholder panels */
     .placeholder-panel {
       grid-column: span 3;
@@ -258,6 +263,7 @@
       .helm-requests-panel,
       .weapon-ctrl-panel,
       .systems-panel,
+      .power-panel,
       .placeholder-panel {
         grid-column: span 6;
       }
@@ -286,6 +292,7 @@
       .helm-requests-panel,
       .weapon-ctrl-panel,
       .systems-panel,
+      .power-panel,
       .placeholder-panel {
         grid-column: span 12;
       }
@@ -335,6 +342,10 @@
 
       <flaxos-panel title="Systems" collapsible class="systems-panel">
         <system-toggles></system-toggles>
+      </flaxos-panel>
+
+      <flaxos-panel title="Power Management" collapsible class="power-panel">
+        <power-management></power-management>
       </flaxos-panel>
 
       <flaxos-panel title="Navigation" collapsible class="nav-panel">

--- a/gui/js/main.js
+++ b/gui/js/main.js
@@ -27,6 +27,7 @@ import "../components/position-heading-calculator.js";
 import "../components/autopilot-control.js";
 import "../components/weapon-controls.js";
 import "../components/system-toggles.js";
+import "../components/power-management.js";
 import "../components/quick-actions.js";
 import "../components/manual-thrust.js";
 import "../components/tactical-map.js";

--- a/hybrid/ship.py
+++ b/hybrid/ship.py
@@ -112,6 +112,10 @@ class Ship:
             "request_power": self._cmd_request_power,
             "reroute_power": self._cmd_reroute_power,
             "get_power_state": self._cmd_get_power_state,
+            "set_power_allocation": self._cmd_set_power_allocation,
+            "set_power_profile": self._cmd_set_power_profile,
+            "get_power_profiles": self._cmd_get_power_profiles,
+            "set_overdrive_limits": self._cmd_set_overdrive_limits,
             "get_subsystem_health": self._cmd_get_subsystem_health,
             "repair_subsystem": self._cmd_repair_subsystem,
         }
@@ -667,6 +671,49 @@ class Ship:
         if not pm:
             return {"error": "Power management system not available"}
         return pm.get_state()
+
+    def _cmd_set_power_allocation(self, params):
+        """Set power allocation ratios for the power management system."""
+        pm = self.systems.get("power_management")
+        if not pm:
+            return {"error": "Power management system not available"}
+        allocation = params.get("allocation", {})
+        if not allocation:
+            allocation = {
+                key: params.get(key)
+                for key in ("primary", "secondary", "tertiary")
+                if params.get(key) is not None
+            }
+        if not allocation:
+            return {"error": "Missing allocation values"}
+        return pm.set_power_allocation(allocation)
+
+    def _cmd_set_power_profile(self, params):
+        """Apply a named power profile."""
+        pm = self.systems.get("power_management")
+        if not pm:
+            return {"error": "Power management system not available"}
+        profile = params.get("profile") or params.get("mode")
+        if not profile:
+            return {"error": "Missing profile parameter"}
+        return pm.apply_profile(profile, ship=self)
+
+    def _cmd_get_power_profiles(self, params):
+        """Return available power profiles."""
+        pm = self.systems.get("power_management")
+        if not pm:
+            return {"error": "Power management system not available"}
+        return pm.get_profiles()
+
+    def _cmd_set_overdrive_limits(self, params):
+        """Set overdrive limits for power buses."""
+        pm = self.systems.get("power_management")
+        if not pm:
+            return {"error": "Power management system not available"}
+        limits = params.get("limits", params)
+        if not limits:
+            return {"error": "Missing limits"}
+        return pm.set_overdrive_limits(limits)
 
     def enable_ai(self, behavior=None, params=None):
         """

--- a/hybrid/systems/power/management.py
+++ b/hybrid/systems/power/management.py
@@ -80,7 +80,14 @@ class PowerManagementSystem:
                 name=layer_name,
                 capacity=capacity,
                 output_rate=params.get("output_rate", base.output_rate),
-                thermal_limit=params.get("thermal_limit", base.thermal_limit)
+                thermal_limit=params.get("thermal_limit", base.thermal_limit),
+                fuel_capacity=params.get("fuel_capacity"),
+                fuel_level=params.get("fuel_level"),
+                fuel_consumption_rate=params.get("fuel_consumption_rate", 0.0),
+                cooling_rate=params.get("cooling_rate", 1.5),
+                heat_rate=params.get("heat_rate", 0.05),
+                heat_per_kw=params.get("heat_per_kw", 0.1),
+                overheat_output_factor=params.get("overheat_output_factor", 0.5),
             )
         self._base_reactors = {
             name: {
@@ -192,8 +199,17 @@ class PowerManagementSystem:
                 "available": getattr(reactor, 'available', reactor.capacity),
                 "output_rate": reactor.output_rate,
                 "thermal_limit": reactor.thermal_limit,
+                "temperature": getattr(reactor, "temperature", 0.0),
+                "fuel_capacity": getattr(reactor, "fuel_capacity", None),
+                "fuel_level": getattr(reactor, "fuel_level", None),
                 "status": getattr(reactor, 'status', 'nominal'),
             }
+            if reactor_state["fuel_capacity"]:
+                reactor_state["fuel_percent"] = (
+                    reactor_state["fuel_level"] / reactor_state["fuel_capacity"] * 100
+                    if reactor_state["fuel_capacity"] > 0 and reactor_state["fuel_level"] is not None
+                    else 0.0
+                )
             state["reactors"][name] = reactor_state
             state["total_capacity"] += reactor.capacity
             state["total_available"] += reactor_state["available"]

--- a/hybrid/systems/power/reactor.py
+++ b/hybrid/systems/power/reactor.py
@@ -4,7 +4,10 @@ from hybrid.core.constants import DEFAULT_REACTOR_OUTPUT, DEFAULT_OUTPUT_RATE, D
 
 class Reactor:
     def __init__(self, name, capacity=DEFAULT_REACTOR_OUTPUT,
-                 output_rate=DEFAULT_OUTPUT_RATE, thermal_limit=DEFAULT_THERMAL_LIMIT):
+                 output_rate=DEFAULT_OUTPUT_RATE, thermal_limit=DEFAULT_THERMAL_LIMIT,
+                 fuel_capacity=None, fuel_level=None, fuel_consumption_rate=0.0,
+                 cooling_rate=1.5, heat_rate=0.05, heat_per_kw=0.1,
+                 overheat_output_factor=0.5):
         self.name = name
         self.capacity = capacity
         self.available = 0.0
@@ -12,19 +15,91 @@ class Reactor:
         self.thermal_limit = thermal_limit
         self.temperature = 25.0  # ambient start
         self.status = "nominal"
+        self.fuel_capacity = self._normalize_fuel(fuel_capacity)
+        self.fuel_level = self._normalize_fuel(fuel_level)
+        if self.fuel_capacity is not None and self.fuel_level is None:
+            self.fuel_level = self.fuel_capacity
+        self.fuel_consumption_rate = float(fuel_consumption_rate or 0.0)
+        self.cooling_rate = float(cooling_rate or 0.0)
+        self.heat_rate = float(heat_rate or 0.0)
+        self.heat_per_kw = float(heat_per_kw or 0.0)
+        self.overheat_output_factor = float(overheat_output_factor or 0.5)
+
+    def _normalize_fuel(self, value):
+        if value is None:
+            return None
+        value = float(value)
+        return value if value > 0 else None
 
     def tick(self, dt):
+        self._cool(dt)
+
+        if self._is_depleted():
+            self.available = 0.0
+            self.status = "depleted"
+            return
+
         # Ramp available power toward capacity
         if self.available < self.capacity:
-            self.available = min(self.capacity, self.available + self.output_rate * dt)
+            generated = min(self.capacity - self.available, self.output_rate * dt)
+            generated = self._consume_fuel_for_output(generated)
+            if generated > 0:
+                self.available = min(self.capacity, self.available + generated)
+
+        self._apply_heat_from_output(dt)
+
         # If overheated, mark status and throttle output
         if self.temperature > self.thermal_limit:
             self.status = "overheated"
-            self.available *= 0.5
+            self.available = min(self.available, self.capacity * self.overheat_output_factor)
+        elif self.status == "overheated" and self.temperature <= self.thermal_limit * 0.9:
+            self.status = "nominal"
+        elif self.status == "nominal":
+            self.status = "nominal"
 
     def draw_power(self, amount):
         if self.available >= amount:
             self.available -= amount
-            self.temperature += amount * 0.1  # simple heat addition
+            self.temperature += amount * self.heat_per_kw
             return True
         return False
+
+    def _consume_fuel_for_output(self, generated):
+        if generated <= 0:
+            return 0.0
+        if self.fuel_capacity is None:
+            return generated
+        if self.fuel_consumption_rate <= 0:
+            return generated
+        if self.fuel_level is None:
+            return generated
+        fuel_needed = generated * self.fuel_consumption_rate
+        if fuel_needed <= self.fuel_level:
+            self.fuel_level -= fuel_needed
+            return generated
+        if self.fuel_level <= 0:
+            self.fuel_level = 0.0
+            return 0.0
+        output_limited = self.fuel_level / self.fuel_consumption_rate
+        self.fuel_level = 0.0
+        return output_limited
+
+    def _apply_heat_from_output(self, dt):
+        if self.capacity <= 0:
+            return
+        output_ratio = max(0.0, min(1.0, self.available / self.capacity))
+        if output_ratio <= 0:
+            return
+        self.temperature += (self.heat_rate * output_ratio) * dt
+
+    def _cool(self, dt):
+        if self.cooling_rate <= 0:
+            return
+        self.temperature = max(0.0, self.temperature - self.cooling_rate * dt)
+
+    def _is_depleted(self):
+        if self.fuel_capacity is None:
+            return False
+        if self.fuel_level is None:
+            return False
+        return self.fuel_level <= 0.0


### PR DESCRIPTION
### Motivation
- Implement the next two TODOs from the power management plan: GUI integration (allocation sliders, meters) and reactor fuel/thermal modeling so the simulator can represent fuel-limited reactors and overheating behavior.
- Provide a UI-friendly surface for changing allocation and profiles and expose the necessary ship commands so the GUI and CLI can drive live ship state.

### Description
- Added a new Power Management panel component with allocation sliders and reactor meters and wired it into the main GUI layout and boot sequence (`gui/components/power-management.js`, `gui/index.html`, `gui/js/main.js`).
- Extended the Reactor model with optional fuel capacity/level, fuel consumption, cooling and heat behaviour, and overheat output throttling, and surfaced temperature/fuel fields in the power state (`hybrid/systems/power/reactor.py`, `hybrid/systems/power/management.py`).
- Exposed ship command handlers to let clients set allocations, apply engineering profiles, retrieve available profiles, and set overdrive limits (`hybrid/ship.py`).
- Kept backward compatibility with existing config keys (supports `output` alias for capacity and optional fuel/thermal config parameters) and normalized power allocation input.

### Testing
- Launched a static GUI server with `python -m http.server 8000 --directory gui` and used a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a screenshot to `artifacts/power-management.png`, which completed successfully.
- No unit test suite was added or run as part of this change; runtime smoke test was the GUI load/screenshot above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774c7e0fbc8324806f42418d705a5c)