### PR TITLE
Sprint A: Consolidate server into single entrypoint with Protocol v1

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -1,0 +1,109 @@
+"""
+Canonical configuration for Flaxos Spaceship Sim server.
+
+This module defines all default ports, hosts, and configuration values
+used across the server stack. Import from here to ensure consistency.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+import os
+
+
+class ServerMode(Enum):
+    """Server operation mode."""
+    MINIMAL = "minimal"   # Basic server, no station management
+    STATION = "station"   # Full multi-crew station-based control
+
+
+# Default port assignments
+DEFAULT_TCP_PORT = 8765      # Main simulation server
+DEFAULT_WS_PORT = 8080       # WebSocket bridge
+DEFAULT_HTTP_PORT = 3000     # GUI static file server
+DEFAULT_MOBILE_PORT = 5000   # Mobile UI (Flask)
+
+# Default host bindings
+DEFAULT_HOST = "127.0.0.1"           # Localhost only (secure default)
+DEFAULT_LAN_HOST = "0.0.0.0"         # All interfaces (for LAN play)
+
+# Simulation defaults
+DEFAULT_DT = 0.1                     # 100ms simulation timestep
+DEFAULT_FLEET_DIR = "hybrid_fleet"   # Ship definitions directory
+
+# Protocol version
+PROTOCOL_VERSION = "1.0"
+
+
+@dataclass
+class ServerConfig:
+    """
+    Server configuration container.
+
+    Provides a single source of truth for all server settings.
+    Can be constructed from CLI args, environment, or config file.
+    """
+
+    # Server mode
+    mode: ServerMode = ServerMode.STATION
+
+    # Network settings
+    host: str = DEFAULT_HOST
+    tcp_port: int = DEFAULT_TCP_PORT
+    ws_port: int = DEFAULT_WS_PORT
+    http_port: int = DEFAULT_HTTP_PORT
+
+    # Simulation settings
+    dt: float = DEFAULT_DT
+    fleet_dir: str = DEFAULT_FLEET_DIR
+
+    # Optional overrides
+    log_file: Optional[str] = None
+    lan_mode: bool = False
+
+    def __post_init__(self):
+        """Apply LAN mode settings if enabled."""
+        if self.lan_mode and self.host == DEFAULT_HOST:
+            self.host = DEFAULT_LAN_HOST
+
+    @classmethod
+    def from_env(cls) -> "ServerConfig":
+        """Create config from environment variables."""
+        return cls(
+            mode=ServerMode(os.environ.get("FLAXOS_MODE", "station")),
+            host=os.environ.get("FLAXOS_HOST", DEFAULT_HOST),
+            tcp_port=int(os.environ.get("FLAXOS_TCP_PORT", DEFAULT_TCP_PORT)),
+            ws_port=int(os.environ.get("FLAXOS_WS_PORT", DEFAULT_WS_PORT)),
+            http_port=int(os.environ.get("FLAXOS_HTTP_PORT", DEFAULT_HTTP_PORT)),
+            dt=float(os.environ.get("FLAXOS_DT", DEFAULT_DT)),
+            fleet_dir=os.environ.get("FLAXOS_FLEET_DIR", DEFAULT_FLEET_DIR),
+            log_file=os.environ.get("FLAXOS_LOG_FILE"),
+            lan_mode=os.environ.get("FLAXOS_LAN", "").lower() in ("1", "true", "yes"),
+        )
+
+    def to_discovery_info(self) -> dict:
+        """
+        Generate discovery information for GUI autodiscovery.
+
+        Returns:
+            Dictionary with connection info for clients
+        """
+        return {
+            "version": PROTOCOL_VERSION,
+            "mode": self.mode.value,
+            "endpoints": {
+                "tcp": {"host": self.host, "port": self.tcp_port},
+                "ws": {"host": self.host, "port": self.ws_port},
+                "http": {"host": self.host, "port": self.http_port},
+            },
+            "features": {
+                "stations": self.mode == ServerMode.STATION,
+                "multi_crew": self.mode == ServerMode.STATION,
+                "fleet_commands": True,
+            },
+        }
+
+
+def get_default_config() -> ServerConfig:
+    """Get the default server configuration."""
+    return ServerConfig()

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,661 @@
+#!/usr/bin/env python3
+"""
+Flaxos Spaceship Sim - Unified Server Entrypoint.
+
+This is the canonical server entrypoint. Use --mode to select operation mode:
+
+  --mode minimal   Basic server, no station management (backwards compat)
+  --mode station   Full multi-crew station-based control (default)
+
+Examples:
+  python -m server.main                     # Station mode, localhost
+  python -m server.main --mode minimal      # Minimal mode for testing
+  python -m server.main --lan               # Station mode, LAN accessible
+  python -m server.main --port 9000         # Custom port
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import socket
+import sys
+import threading
+from typing import Dict, Optional, Callable
+
+# Ensure project root is on sys.path
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from server.config import (
+    ServerConfig,
+    ServerMode,
+    DEFAULT_TCP_PORT,
+    DEFAULT_HOST,
+    DEFAULT_DT,
+    DEFAULT_FLEET_DIR,
+    PROTOCOL_VERSION,
+)
+from server.protocol import (
+    Response,
+    ErrorCode,
+    _json_default,
+    parse_request,
+    make_error_response,
+)
+from hybrid_runner import HybridRunner
+from utils.logger import setup_logging
+
+logger = logging.getLogger(__name__)
+
+
+class UnifiedServer:
+    """
+    Unified TCP server for Flaxos Spaceship Sim.
+
+    Supports two operation modes:
+    - MINIMAL: Basic command dispatch, no station management
+    - STATION: Full multi-crew support with station permissions
+    """
+
+    def __init__(self, config: ServerConfig):
+        self.config = config
+        self.running = False
+
+        # Initialize simulation
+        self.runner = HybridRunner(fleet_dir=config.fleet_dir, dt=config.dt)
+
+        # Station system (only initialized in STATION mode)
+        self.station_manager = None
+        self.crew_manager = None
+        self.dispatcher = None
+        self.telemetry_filter = None
+
+        # Client tracking
+        self.clients: Dict[str, socket.socket] = {}
+        self.client_lock = threading.Lock()
+        self.server_socket: Optional[socket.socket] = None
+
+    def initialize(self) -> None:
+        """Initialize server and load simulation."""
+        logger.info(f"Initializing server in {self.config.mode.value} mode...")
+
+        # Load ships
+        self.runner.load_ships()
+        self.runner.start()
+        logger.info(f"Loaded {len(self.runner.simulator.ships)} ships")
+
+        if self.config.mode == ServerMode.STATION:
+            self._init_station_mode()
+
+        logger.info(f"Server initialized (protocol v{PROTOCOL_VERSION})")
+
+    def _init_station_mode(self) -> None:
+        """Initialize station-based multi-crew system."""
+        from server.stations import StationManager
+        from server.stations.station_dispatch import (
+            StationAwareDispatcher,
+            register_legacy_commands,
+        )
+        from server.stations.station_commands import register_station_commands
+        from server.stations.helm_commands import register_helm_commands
+        from server.stations.fleet_commands import register_fleet_commands
+        from server.telemetry.station_filter import StationTelemetryFilter
+        from server.stations.crew_system import CrewManager
+
+        self.station_manager = StationManager()
+        self.crew_manager = CrewManager()
+        self.dispatcher = StationAwareDispatcher(self.station_manager)
+        self.telemetry_filter = StationTelemetryFilter(self.station_manager)
+
+        # Register commands
+        register_station_commands(
+            self.dispatcher,
+            self.station_manager,
+            self.crew_manager,
+            ship_provider=lambda: self.runner.simulator.ships,
+        )
+        register_helm_commands(
+            self.dispatcher,
+            ship_provider=lambda: self.runner.simulator.ships,
+        )
+        register_legacy_commands(self.dispatcher, self.runner)
+        register_fleet_commands(
+            self.dispatcher,
+            self.station_manager,
+            self.runner.simulator.fleet_manager,
+        )
+
+        logger.info("Station system initialized with multi-crew support")
+
+    def dispatch(self, client_id: str, req: dict) -> dict:
+        """
+        Route a command to the appropriate handler.
+
+        Args:
+            client_id: Client identifier (used in station mode)
+            req: Request dictionary with 'cmd' and parameters
+
+        Returns:
+            Response dictionary
+        """
+        cmd = req.get("cmd") or req.get("command")
+        if not cmd:
+            return Response.error("missing cmd", ErrorCode.MISSING_PARAM).to_dict()
+
+        # Handle discover command (protocol v1)
+        if cmd == "_discover":
+            return {
+                "ok": True,
+                **self.config.to_discovery_info(),
+            }
+
+        if self.config.mode == ServerMode.STATION:
+            return self._dispatch_station(client_id, cmd, req)
+        else:
+            return self._dispatch_minimal(cmd, req)
+
+    def _dispatch_minimal(self, cmd: str, req: dict) -> dict:
+        """
+        Dispatch command in minimal mode (no station checks).
+
+        This preserves the original run_server.py behavior.
+        """
+        from hybrid.command_handler import route_command
+
+        if cmd == "get_state":
+            return self._handle_get_state_minimal(req)
+
+        if cmd == "get_events":
+            return self._handle_get_events(req)
+
+        if cmd == "list_scenarios":
+            return {"ok": True, "scenarios": self.runner.list_scenarios()}
+
+        if cmd == "load_scenario":
+            return self._handle_load_scenario(req)
+
+        if cmd == "get_mission":
+            return {"ok": True, "mission": self.runner.get_mission_status()}
+
+        if cmd == "get_mission_hints":
+            clear = bool(req.get("clear", False))
+            return {"ok": True, "hints": self.runner.get_mission_hints(clear=clear)}
+
+        if cmd == "pause":
+            on = bool(req.get("on", True))
+            if on:
+                self.runner.stop()
+            else:
+                self.runner.start()
+            return {"ok": True, "paused": on}
+
+        # Ship-specific commands
+        ship_id = req.get("ship")
+        if not ship_id:
+            return Response.error("missing ship", ErrorCode.MISSING_PARAM).to_dict()
+
+        ship = self.runner.simulator.ships.get(ship_id)
+        if not ship:
+            return Response.error(f"ship {ship_id} not found", ErrorCode.SHIP_NOT_FOUND).to_dict()
+
+        # Normalize set_thrust command
+        if cmd == "set_thrust":
+            has_vector = any(k in req for k in ("x", "y", "z"))
+            has_scalar = "thrust" in req
+            if has_vector and not has_scalar:
+                cmd = "set_thrust_vector"
+            elif not has_scalar and not has_vector:
+                req["thrust"] = 0.0
+
+        command_data = {"command": cmd, "ship": ship_id, **req}
+        command_data.pop("cmd", None)
+        result = route_command(ship, command_data, self.runner.simulator.ships)
+
+        if isinstance(result, dict) and "error" in result:
+            return {"ok": False, "error": result["error"], "response": result}
+        return {"ok": True, "response": result}
+
+    def _dispatch_station(self, client_id: str, cmd: str, req: dict) -> dict:
+        """
+        Dispatch command in station mode (with permission checks).
+
+        This provides the full multi-crew experience.
+        """
+        from server.stations.station_types import PermissionLevel
+
+        session = self.station_manager.get_session(client_id)
+
+        # Global commands (no station required)
+        if cmd == "get_state":
+            return self._handle_get_state_station(client_id, req)
+
+        if cmd == "get_events":
+            return self._handle_get_events_station(client_id, req)
+
+        if cmd == "list_scenarios":
+            return {"ok": True, "scenarios": self.runner.list_scenarios()}
+
+        if cmd == "load_scenario":
+            if not session or session.permission_level.value < PermissionLevel.CAPTAIN.value:
+                return Response.error("Only captain can load scenarios", ErrorCode.PERMISSION_DENIED).to_dict()
+            return self._handle_load_scenario(req)
+
+        if cmd == "get_mission":
+            return {"ok": True, "mission": self.runner.get_mission_status()}
+
+        if cmd == "get_mission_hints":
+            clear = bool(req.get("clear", False))
+            return {"ok": True, "hints": self.runner.get_mission_hints(clear=clear)}
+
+        if cmd == "pause":
+            if session and session.station and session.station.value == "captain":
+                on = bool(req.get("on", True))
+                if on:
+                    self.runner.stop()
+                else:
+                    self.runner.start()
+                return {"ok": True, "paused": on}
+            return Response.error("Only captain can pause simulation", ErrorCode.PERMISSION_DENIED).to_dict()
+
+        # Get ship_id from session or request
+        ship_id = req.get("ship")
+        metadata = self.dispatcher.command_metadata.get(cmd, {})
+        requires_ship = metadata.get("requires_ship", True)
+
+        if not ship_id and session and session.ship_id:
+            ship_id = session.ship_id
+
+        if requires_ship and not ship_id:
+            return Response.error("missing ship", ErrorCode.MISSING_PARAM).to_dict()
+
+        # Route through station-aware dispatcher
+        args = {k: v for k, v in req.items() if k not in ("cmd", "command")}
+        if ship_id:
+            args["ship"] = ship_id
+
+        result = self.dispatcher.dispatch(client_id, ship_id or "", cmd, args)
+        return result.to_dict()
+
+    def _handle_get_state_minimal(self, req: dict) -> dict:
+        """Handle get_state in minimal mode."""
+        ship_id = req.get("ship")
+        states = self.runner.get_all_ship_states()
+
+        payload = {
+            "ok": True,
+            "t": self.runner.simulator.time,
+            "ships": [self._format_ship_state(state) for state in states.values()],
+        }
+
+        if ship_id:
+            ship_state = self.runner.get_ship_state(ship_id)
+            payload["ship"] = ship_id
+            payload["state"] = ship_state
+            if isinstance(ship_state, dict) and "error" in ship_state:
+                payload["ok"] = False
+                payload["error"] = ship_state["error"]
+
+        return payload
+
+    def _handle_get_state_station(self, client_id: str, req: dict) -> dict:
+        """Handle get_state in station mode with telemetry filtering."""
+        from hybrid.telemetry import get_ship_telemetry, get_telemetry_snapshot
+
+        ship_id = req.get("ship")
+        session = self.station_manager.get_session(client_id)
+
+        if not session:
+            return Response.error("Client not registered", ErrorCode.NOT_REGISTERED).to_dict()
+
+        if not ship_id:
+            # Get all ships
+            full_telemetry = get_telemetry_snapshot(self.runner.simulator)
+            filtered = self.telemetry_filter.filter_telemetry_for_client(
+                client_id, full_telemetry
+            )
+            return {"ok": True, "t": self.runner.simulator.time, **filtered}
+
+        # Get specific ship
+        if not session.ship_id:
+            return Response.error("Not assigned to a ship", ErrorCode.NOT_ASSIGNED).to_dict()
+
+        if session.ship_id != ship_id:
+            return Response.error("Can only view assigned ship", ErrorCode.PERMISSION_DENIED).to_dict()
+
+        ship = self.runner.simulator.ships.get(ship_id)
+        if not ship:
+            return Response.error(f"Ship {ship_id} not found", ErrorCode.SHIP_NOT_FOUND).to_dict()
+
+        ship_telemetry = get_ship_telemetry(ship, self.runner.simulator.time)
+        filtered = self.telemetry_filter.filter_ship_state_for_client(
+            client_id, ship_id, ship_telemetry
+        )
+
+        return {"ok": True, "ship": ship_id, "state": filtered, "t": self.runner.simulator.time}
+
+    def _handle_get_events(self, req: dict) -> dict:
+        """Handle get_events command (minimal mode)."""
+        limit = int(req.get("limit", 100))
+        events = self._get_events(limit)
+        return {"ok": True, "events": events, "total_events": len(events)}
+
+    def _handle_get_events_station(self, client_id: str, req: dict) -> dict:
+        """Handle get_events with station-based filtering."""
+        session = self.station_manager.get_session(client_id)
+
+        if not session:
+            return Response.error("Client not registered", ErrorCode.NOT_REGISTERED).to_dict()
+
+        limit = int(req.get("limit", 100))
+        all_events = self._get_events(limit)
+
+        if not session.station:
+            return {"ok": True, "events": [], "message": "Claim a station to view events"}
+
+        # Import filter function from station_server
+        from server.stations.station_types import StationType, get_station_displays
+
+        filtered = self._filter_events_for_station(
+            all_events, session.station, session.ship_id
+        )
+
+        return {
+            "ok": True,
+            "events": filtered,
+            "station": session.station.value,
+            "total_events": len(all_events),
+            "filtered_count": len(filtered),
+        }
+
+    def _get_events(self, limit: int) -> list:
+        """Get recent events from simulator."""
+        if hasattr(self.runner.simulator, "get_recent_events"):
+            return self.runner.simulator.get_recent_events(limit=limit)
+        elif hasattr(self.runner.simulator, "event_log"):
+            return list(self.runner.simulator.event_log)[-limit:]
+        elif hasattr(self.runner.simulator, "recent_events"):
+            return self.runner.simulator.recent_events[-limit:]
+        return []
+
+    def _filter_events_for_station(self, events: list, station, ship_id: str) -> list:
+        """Filter events based on station permissions."""
+        from server.stations.station_types import StationType, get_station_displays
+
+        if station == StationType.CAPTAIN:
+            return events
+
+        allowed_displays = get_station_displays(station)
+
+        event_categories = {
+            "autopilot": ["nav_status", "autopilot_status"],
+            "navigation": ["nav_status", "position", "velocity"],
+            "propulsion": ["propulsion_status", "helm_status"],
+            "weapon": ["weapons_status", "ammunition", "hardpoints"],
+            "target": ["target_info", "targeting_status"],
+            "sensor": ["sensor_status", "contacts"],
+            "contact": ["contacts", "contact_details"],
+            "power": ["power_grid", "power_management_status"],
+            "reactor": ["reactor_status", "power_grid"],
+            "damage": ["damage_report", "hull_integrity"],
+            "comm": ["comm_log", "message_queue"],
+            "fleet": ["fleet_status"],
+            "critical": ["all"],
+            "alert": ["all"],
+            "mission": ["all"],
+        }
+
+        filtered = []
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+
+            event_type = event.get("type", "")
+            event_ship = event.get("ship_id", "")
+
+            if event_ship and event_ship != ship_id:
+                continue
+
+            should_include = False
+            for category, required_displays in event_categories.items():
+                if category in event_type.lower():
+                    if "all" in required_displays:
+                        should_include = True
+                        break
+                    if any(display in allowed_displays for display in required_displays):
+                        should_include = True
+                        break
+
+            if not should_include:
+                if any(kw in event_type.lower() for kw in ["critical", "alert", "warning", "mission"]):
+                    should_include = True
+
+            if should_include:
+                filtered.append(event)
+
+        return filtered
+
+    def _handle_load_scenario(self, req: dict) -> dict:
+        """Handle load_scenario command."""
+        scenario_name = req.get("scenario") or req.get("name") or req.get("file")
+        if not scenario_name:
+            return Response.error("missing scenario", ErrorCode.MISSING_PARAM).to_dict()
+
+        loaded = self.runner.load_scenario(scenario_name)
+        if loaded <= 0:
+            return Response.error(
+                f"Failed to load scenario {scenario_name}",
+                ErrorCode.INTERNAL_ERROR
+            ).to_dict()
+
+        return {
+            "ok": True,
+            "scenario": scenario_name,
+            "ships_loaded": loaded,
+            "player_ship_id": self.runner.player_ship_id,
+            "mission": self.runner.get_mission_status(),
+        }
+
+    @staticmethod
+    def _format_ship_state(state: dict) -> dict:
+        """Format ship state for API response."""
+        return {
+            "id": state.get("id"),
+            "name": state.get("name", state.get("id")),
+            "pos": state.get("position", {}),
+            "vel": state.get("velocity", {}),
+            "attitude": state.get("orientation", {}),
+            "systems": state.get("systems", {}),
+        }
+
+    def handle_connection(self, conn: socket.socket, addr: tuple) -> None:
+        """Handle a client connection."""
+        client_id = f"client_{id(conn)}"
+
+        if self.config.mode == ServerMode.STATION:
+            client_id = self.station_manager.generate_client_id()
+            player_name = f"Player_{client_id}"
+            self.station_manager.register_client(client_id, player_name)
+
+        with self.client_lock:
+            self.clients[client_id] = conn
+
+        logger.info(f"Client connected: {client_id} from {addr}")
+
+        # Send welcome message (station mode only)
+        if self.config.mode == ServerMode.STATION:
+            welcome = {
+                "ok": True,
+                "message": "Connected to Flaxos Spaceship Sim",
+                "client_id": client_id,
+                "mode": self.config.mode.value,
+                "version": PROTOCOL_VERSION,
+                "instructions": {
+                    "assign_ship": "Use assign_ship command to join a ship",
+                    "claim_station": "Use claim_station command to claim a station",
+                    "help": "Use my_status to see your current status",
+                },
+            }
+            try:
+                conn.sendall((json.dumps(welcome) + "\n").encode("utf-8"))
+            except (OSError, BrokenPipeError):
+                pass
+
+        # Handle commands
+        buf = b""
+        try:
+            while self.running:
+                try:
+                    if self.config.mode == ServerMode.STATION:
+                        conn.settimeout(1.0)
+                    data = conn.recv(4096)
+                    if not data:
+                        break
+
+                    buf += data
+                    while b"\n" in buf:
+                        line, buf = buf.split(b"\n", 1)
+                        if not line.strip():
+                            continue
+
+                        try:
+                            req = json.loads(line.decode("utf-8"))
+                        except json.JSONDecodeError:
+                            err = json.dumps({"ok": False, "error": "bad json"}) + "\n"
+                            conn.sendall(err.encode("utf-8"))
+                            continue
+
+                        logger.debug(f"Request from {client_id}: {req}")
+                        resp = self.dispatch(client_id, req)
+                        conn.sendall(
+                            (json.dumps(resp, default=_json_default) + "\n").encode("utf-8")
+                        )
+
+                except socket.timeout:
+                    continue
+                except Exception as e:
+                    logger.error(f"Error handling request from {client_id}: {e}")
+                    break
+
+        finally:
+            logger.info(f"Client disconnected: {client_id}")
+            with self.client_lock:
+                self.clients.pop(client_id, None)
+            if self.config.mode == ServerMode.STATION and self.station_manager:
+                self.station_manager.unregister_client(client_id)
+            conn.close()
+
+    def start(self) -> None:
+        """Start the server."""
+        self.initialize()
+
+        self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.server_socket.bind((self.config.host, self.config.tcp_port))
+        self.server_socket.listen(8)
+        self.running = True
+
+        mode_str = "multi-crew" if self.config.mode == ServerMode.STATION else "minimal"
+        logger.info(
+            f"Server listening on {self.config.host}:{self.config.tcp_port} "
+            f"(mode={mode_str}, dt={self.config.dt})"
+        )
+
+        try:
+            while self.running:
+                try:
+                    client, addr = self.server_socket.accept()
+                    thread = threading.Thread(
+                        target=self.handle_connection,
+                        args=(client, addr),
+                        daemon=True,
+                    )
+                    thread.start()
+                except Exception as e:
+                    if self.running:
+                        logger.error(f"Error accepting connection: {e}")
+
+        except KeyboardInterrupt:
+            logger.info("Shutting down...")
+        finally:
+            self.stop()
+
+    def stop(self) -> None:
+        """Stop the server."""
+        self.running = False
+
+        with self.client_lock:
+            for client_id, conn in list(self.clients.items()):
+                try:
+                    conn.close()
+                except OSError:
+                    pass
+            self.clients.clear()
+
+        self.runner.stop()
+
+        if self.server_socket:
+            self.server_socket.close()
+
+        logger.info("Server stopped")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build CLI argument parser."""
+    ap = argparse.ArgumentParser(
+        description="Flaxos Spaceship Sim - Unified Server",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python -m server.main                     # Station mode, localhost
+  python -m server.main --mode minimal      # Minimal mode for testing
+  python -m server.main --lan               # Station mode, LAN accessible
+  python -m server.main --port 9000         # Custom port
+        """,
+    )
+    ap.add_argument(
+        "--mode",
+        choices=["minimal", "station"],
+        default="station",
+        help="Server mode: minimal (no stations) or station (multi-crew, default)",
+    )
+    ap.add_argument("--host", default=DEFAULT_HOST, help="Host to bind to")
+    ap.add_argument("--port", type=int, default=DEFAULT_TCP_PORT, help="Port to bind to")
+    ap.add_argument("--dt", type=float, default=DEFAULT_DT, help="Simulation timestep")
+    ap.add_argument("--fleet-dir", default=DEFAULT_FLEET_DIR, help="Fleet directory")
+    ap.add_argument("--lan", action="store_true", help="Enable LAN mode (bind to 0.0.0.0)")
+    ap.add_argument("--log-file", default=None, help="Log file path")
+    return ap
+
+
+def main() -> None:
+    """Main entry point."""
+    ap = build_arg_parser()
+    args = ap.parse_args()
+
+    # Setup logging
+    log_path = setup_logging(args.log_file)
+    if log_path:
+        logger.info(f"Logging to file: {log_path}")
+
+    # Build config
+    config = ServerConfig(
+        mode=ServerMode(args.mode),
+        host=args.host,
+        tcp_port=args.port,
+        dt=args.dt,
+        fleet_dir=args.fleet_dir,
+        log_file=args.log_file,
+        lan_mode=args.lan,
+    )
+
+    # Start server
+    server = UnifiedServer(config)
+    server.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/server/protocol.py
+++ b/server/protocol.py
@@ -1,0 +1,300 @@
+"""
+Flaxos Protocol v1 - Message Envelope Definitions.
+
+This module formalizes the wire protocol for client-server communication.
+All messages follow a consistent envelope format for reliable parsing
+and forward compatibility.
+
+Protocol: Newline-delimited JSON over TCP (NDJSON)
+Transport: TCP socket or WebSocket (via bridge)
+"""
+
+from dataclasses import dataclass, asdict
+from enum import Enum
+from typing import Any, Dict, Optional, Union
+import json
+import time
+
+
+# Protocol version identifier
+PROTOCOL_VERSION = "1.0"
+
+
+class MessageType(Enum):
+    """Types of messages in the protocol."""
+    REQUEST = "request"
+    RESPONSE = "response"
+    ERROR = "error"
+    EVENT = "event"
+    STATUS = "connection_status"
+    PONG = "pong"
+
+
+class ErrorCode(Enum):
+    """Standardized error codes for protocol responses."""
+    # Client errors (4xx equivalent)
+    BAD_REQUEST = "BAD_REQUEST"             # Malformed request
+    MISSING_PARAM = "MISSING_PARAM"         # Required parameter missing
+    INVALID_PARAM = "INVALID_PARAM"         # Parameter value invalid
+    UNKNOWN_COMMAND = "UNKNOWN_COMMAND"     # Command not recognized
+    PERMISSION_DENIED = "PERMISSION_DENIED" # Station/role doesn't allow command
+    NOT_REGISTERED = "NOT_REGISTERED"       # Client not registered
+    NOT_ASSIGNED = "NOT_ASSIGNED"           # Not assigned to ship
+    SHIP_NOT_FOUND = "SHIP_NOT_FOUND"       # Referenced ship doesn't exist
+    STATION_OCCUPIED = "STATION_OCCUPIED"   # Station already claimed
+
+    # Server errors (5xx equivalent)
+    INTERNAL_ERROR = "INTERNAL_ERROR"       # Unexpected server error
+    SIMULATION_ERROR = "SIMULATION_ERROR"   # Simulation engine error
+    TIMEOUT = "TIMEOUT"                     # Operation timed out
+
+
+@dataclass
+class ProtocolEnvelope:
+    """
+    Base envelope for all protocol messages.
+
+    Every message (request or response) is wrapped in this envelope
+    for consistent handling and versioning.
+    """
+    type: MessageType
+    version: str = PROTOCOL_VERSION
+    timestamp: Optional[float] = None
+
+    def __post_init__(self):
+        if self.timestamp is None:
+            self.timestamp = time.time()
+
+
+@dataclass
+class Request:
+    """
+    Client request envelope.
+
+    Requests from clients follow this format. The 'cmd' field identifies
+    the command, and additional parameters are command-specific.
+    """
+    cmd: str
+    params: Dict[str, Any] = None
+    request_id: Optional[str] = None  # Optional client-provided ID for correlation
+
+    def __post_init__(self):
+        if self.params is None:
+            self.params = {}
+
+    def to_wire(self) -> str:
+        """Serialize to wire format (JSON + newline)."""
+        data = {"cmd": self.cmd, **self.params}
+        if self.request_id:
+            data["_request_id"] = self.request_id
+        return json.dumps(data) + "\n"
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Request":
+        """Parse request from dictionary."""
+        cmd = data.get("cmd") or data.get("command")
+        request_id = data.pop("_request_id", None)
+        params = {k: v for k, v in data.items() if k not in ("cmd", "command")}
+        return cls(cmd=cmd, params=params, request_id=request_id)
+
+
+@dataclass
+class Response:
+    """
+    Server response envelope.
+
+    All server responses follow this format. The 'ok' field indicates
+    success/failure, and 'data' contains the response payload.
+    """
+    ok: bool
+    data: Optional[Dict[str, Any]] = None
+    message: Optional[str] = None
+    error_msg: Optional[str] = None  # Renamed to avoid conflict with classmethod
+    code: Optional[ErrorCode] = None
+    request_id: Optional[str] = None  # Echo back client's request ID if provided
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for serialization."""
+        result = {"ok": self.ok}
+        if self.message is not None:
+            result["message"] = self.message
+        if self.data is not None:
+            result["response"] = self.data
+        if self.error_msg is not None:
+            result["error"] = self.error_msg
+        if self.code is not None:
+            result["code"] = self.code.value if isinstance(self.code, ErrorCode) else self.code
+        if self.request_id is not None:
+            result["_request_id"] = self.request_id
+        return result
+
+    def to_wire(self) -> str:
+        """Serialize to wire format (JSON + newline)."""
+        return json.dumps(self.to_dict(), default=_json_default) + "\n"
+
+    @classmethod
+    def success(
+        cls,
+        data: Optional[Dict[str, Any]] = None,
+        message: Optional[str] = None,
+        request_id: Optional[str] = None
+    ) -> "Response":
+        """Create a success response."""
+        return cls(ok=True, data=data, message=message, request_id=request_id)
+
+    @classmethod
+    def error(
+        cls,
+        error: str,
+        code: ErrorCode = ErrorCode.INTERNAL_ERROR,
+        data: Optional[Dict[str, Any]] = None,
+        request_id: Optional[str] = None
+    ) -> "Response":
+        """Create an error response."""
+        return cls(ok=False, error_msg=error, code=code, data=data, request_id=request_id)
+
+
+@dataclass
+class WSEnvelope:
+    """
+    WebSocket bridge envelope.
+
+    The WS bridge wraps TCP responses in this envelope to add
+    message typing for the browser client.
+    """
+    type: MessageType
+    data: Dict[str, Any]
+    timestamp: Optional[float] = None
+
+    def __post_init__(self):
+        if self.timestamp is None:
+            self.timestamp = time.time()
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for serialization."""
+        return {
+            "type": self.type.value,
+            "data": self.data,
+            "timestamp": self.timestamp,
+            "version": PROTOCOL_VERSION,
+        }
+
+    def to_wire(self) -> str:
+        """Serialize to wire format (JSON)."""
+        return json.dumps(self.to_dict(), default=_json_default)
+
+    @classmethod
+    def response(cls, data: dict) -> "WSEnvelope":
+        """Wrap a TCP response for WebSocket delivery."""
+        return cls(type=MessageType.RESPONSE, data=data)
+
+    @classmethod
+    def error(cls, error: str, details: Optional[dict] = None) -> "WSEnvelope":
+        """Create an error envelope."""
+        data = {"error": error}
+        if details:
+            data.update(details)
+        return cls(type=MessageType.ERROR, data=data)
+
+    @classmethod
+    def status(cls, status: str, tcp_connected: bool, tcp_host: str, tcp_port: int) -> "WSEnvelope":
+        """Create a connection status envelope."""
+        return cls(
+            type=MessageType.STATUS,
+            data={
+                "status": status,
+                "tcp_host": tcp_host,
+                "tcp_port": tcp_port,
+                "tcp_connected": tcp_connected,
+            }
+        )
+
+    @classmethod
+    def pong(cls, client_timestamp: Optional[float] = None) -> "WSEnvelope":
+        """Create a pong response for latency measurement."""
+        return cls(
+            type=MessageType.PONG,
+            data={"timestamp": client_timestamp, "server_time": time.time()}
+        )
+
+
+def _json_default(value: Any) -> Any:
+    """
+    Default JSON serializer for complex types.
+
+    Handles numpy arrays, dataclasses, sets, and other common types.
+    """
+    if isinstance(value, (set, tuple)):
+        return list(value)
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, Enum):
+        return value.value
+    try:
+        import numpy as np
+        if isinstance(value, (np.integer, np.floating, np.bool_)):
+            return value.item()
+        if isinstance(value, np.ndarray):
+            return value.tolist()
+    except ImportError:
+        pass
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        return value.to_dict()
+    if hasattr(value, "__dict__"):
+        return value.__dict__
+    return str(value)
+
+
+def parse_request(line: bytes) -> Request:
+    """
+    Parse a request from wire format.
+
+    Args:
+        line: Raw bytes from TCP socket (without newline)
+
+    Returns:
+        Parsed Request object
+
+    Raises:
+        ValueError: If JSON is invalid or cmd is missing
+    """
+    try:
+        data = json.loads(line.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        raise ValueError(f"Invalid JSON: {e}")
+
+    cmd = data.get("cmd") or data.get("command")
+    if not cmd:
+        raise ValueError("Missing 'cmd' field")
+
+    return Request.from_dict(data)
+
+
+def make_error_response(error: str, code: ErrorCode = ErrorCode.BAD_REQUEST) -> str:
+    """
+    Create a wire-format error response.
+
+    Convenience function for quick error responses.
+    """
+    return Response.error(error, code).to_wire()
+
+
+# Compatibility layer for existing code
+def wrap_legacy_response(result: dict) -> Response:
+    """
+    Wrap a legacy response dict in a Response envelope.
+
+    This helps migrate existing handlers that return raw dicts.
+    """
+    if "ok" in result:
+        if result["ok"]:
+            data = {k: v for k, v in result.items() if k not in ("ok", "message")}
+            return Response.success(data=data, message=result.get("message"))
+        else:
+            return Response.error(
+                error=result.get("error", "Unknown error"),
+                code=ErrorCode.INTERNAL_ERROR,
+                data=result.get("response")
+            )
+    # Raw data without ok field
+    return Response.success(data=result)

--- a/tests/protocol/__init__.py
+++ b/tests/protocol/__init__.py
@@ -1,0 +1,1 @@
+# Protocol contract tests

--- a/tests/protocol/test_protocol_v1.py
+++ b/tests/protocol/test_protocol_v1.py
@@ -1,0 +1,322 @@
+"""
+Contract tests for Flaxos Protocol v1.
+
+These tests verify that the protocol envelope format is correct and stable.
+Any breaking changes to these tests indicate a protocol version bump is needed.
+"""
+
+import json
+import pytest
+import time
+
+from server.protocol import (
+    PROTOCOL_VERSION,
+    MessageType,
+    ErrorCode,
+    Request,
+    Response,
+    WSEnvelope,
+    parse_request,
+    make_error_response,
+    wrap_legacy_response,
+    _json_default,
+)
+from server.config import ServerConfig, ServerMode
+
+
+class TestProtocolVersion:
+    """Contract tests for protocol version."""
+
+    def test_protocol_version_is_1_0(self):
+        """Protocol version should be 1.0 for this implementation."""
+        assert PROTOCOL_VERSION == "1.0"
+
+
+class TestRequestEnvelope:
+    """Contract tests for Request envelope."""
+
+    def test_request_from_dict_basic(self):
+        """Request should parse basic command."""
+        req = Request.from_dict({"cmd": "get_state"})
+        assert req.cmd == "get_state"
+        assert req.params == {}
+        assert req.request_id is None
+
+    def test_request_from_dict_with_params(self):
+        """Request should extract params from dict."""
+        req = Request.from_dict({
+            "cmd": "set_thrust",
+            "ship": "alpha",
+            "thrust": 0.5
+        })
+        assert req.cmd == "set_thrust"
+        assert req.params["ship"] == "alpha"
+        assert req.params["thrust"] == 0.5
+
+    def test_request_from_dict_alternative_key(self):
+        """Request should accept 'command' as alternative to 'cmd'."""
+        req = Request.from_dict({"command": "get_state"})
+        assert req.cmd == "get_state"
+
+    def test_request_from_dict_with_request_id(self):
+        """Request should extract _request_id for correlation."""
+        req = Request.from_dict({
+            "cmd": "get_state",
+            "_request_id": "req-123"
+        })
+        assert req.cmd == "get_state"
+        assert req.request_id == "req-123"
+        # request_id should not be in params
+        assert "_request_id" not in req.params
+
+    def test_request_to_wire_format(self):
+        """Request.to_wire() should produce JSON with newline."""
+        req = Request(cmd="get_state", params={"ship": "alpha"})
+        wire = req.to_wire()
+        assert wire.endswith("\n")
+        data = json.loads(wire.strip())
+        assert data["cmd"] == "get_state"
+        assert data["ship"] == "alpha"
+
+    def test_request_to_wire_includes_request_id(self):
+        """Request.to_wire() should include _request_id if set."""
+        req = Request(cmd="get_state", request_id="req-456")
+        wire = req.to_wire()
+        data = json.loads(wire.strip())
+        assert data["_request_id"] == "req-456"
+
+
+class TestResponseEnvelope:
+    """Contract tests for Response envelope."""
+
+    def test_success_response_format(self):
+        """Success response should have ok=True."""
+        resp = Response.success(data={"value": 42}, message="Done")
+        d = resp.to_dict()
+        assert d["ok"] is True
+        assert d["message"] == "Done"
+        assert d["response"]["value"] == 42
+        assert "error" not in d
+
+    def test_error_response_format(self):
+        """Error response should have ok=False and error details."""
+        resp = Response.error("Not found", ErrorCode.SHIP_NOT_FOUND)
+        d = resp.to_dict()
+        assert d["ok"] is False
+        assert d["error"] == "Not found"
+        assert d["code"] == "SHIP_NOT_FOUND"
+
+    def test_response_includes_request_id(self):
+        """Response should echo back request_id if provided."""
+        resp = Response.success(data={}, request_id="req-789")
+        d = resp.to_dict()
+        assert d["_request_id"] == "req-789"
+
+    def test_response_to_wire_format(self):
+        """Response.to_wire() should produce JSON with newline."""
+        resp = Response.success(message="OK")
+        wire = resp.to_wire()
+        assert wire.endswith("\n")
+        data = json.loads(wire.strip())
+        assert data["ok"] is True
+
+
+class TestWSEnvelope:
+    """Contract tests for WebSocket envelope format."""
+
+    def test_response_envelope_format(self):
+        """WS response envelope should wrap data with type."""
+        env = WSEnvelope.response({"ok": True, "value": 123})
+        d = env.to_dict()
+        assert d["type"] == "response"
+        assert d["data"]["ok"] is True
+        assert d["data"]["value"] == 123
+        assert "version" in d
+        assert "timestamp" in d
+
+    def test_error_envelope_format(self):
+        """WS error envelope should have type=error."""
+        env = WSEnvelope.error("Connection failed", {"code": "TCP_ERROR"})
+        d = env.to_dict()
+        assert d["type"] == "error"
+        assert d["data"]["error"] == "Connection failed"
+        assert d["data"]["code"] == "TCP_ERROR"
+
+    def test_status_envelope_format(self):
+        """WS status envelope should contain connection info."""
+        env = WSEnvelope.status(
+            status="connected",
+            tcp_connected=True,
+            tcp_host="127.0.0.1",
+            tcp_port=8765
+        )
+        d = env.to_dict()
+        assert d["type"] == "connection_status"
+        assert d["data"]["status"] == "connected"
+        assert d["data"]["tcp_connected"] is True
+        assert d["data"]["tcp_host"] == "127.0.0.1"
+        assert d["data"]["tcp_port"] == 8765
+
+    def test_pong_envelope_format(self):
+        """WS pong envelope should contain timestamps."""
+        client_ts = time.time()
+        env = WSEnvelope.pong(client_ts)
+        d = env.to_dict()
+        assert d["type"] == "pong"
+        assert d["data"]["timestamp"] == client_ts
+        assert "server_time" in d["data"]
+
+    def test_to_wire_is_valid_json(self):
+        """WSEnvelope.to_wire() should produce valid JSON (no newline)."""
+        env = WSEnvelope.response({"ok": True})
+        wire = env.to_wire()
+        # WebSocket messages don't need newline delimiter
+        assert not wire.endswith("\n") or json.loads(wire) is not None
+        data = json.loads(wire)
+        assert data["type"] == "response"
+
+
+class TestErrorCodes:
+    """Contract tests for standardized error codes."""
+
+    def test_all_error_codes_are_strings(self):
+        """All error codes should serialize to strings."""
+        for code in ErrorCode:
+            assert isinstance(code.value, str)
+
+    def test_error_codes_required_set(self):
+        """These error codes must exist for protocol compliance."""
+        required_codes = [
+            "BAD_REQUEST",
+            "MISSING_PARAM",
+            "INVALID_PARAM",
+            "UNKNOWN_COMMAND",
+            "PERMISSION_DENIED",
+            "NOT_REGISTERED",
+            "NOT_ASSIGNED",
+            "SHIP_NOT_FOUND",
+            "STATION_OCCUPIED",
+            "INTERNAL_ERROR",
+            "SIMULATION_ERROR",
+            "TIMEOUT",
+        ]
+        actual_codes = [c.value for c in ErrorCode]
+        for code in required_codes:
+            assert code in actual_codes, f"Missing required error code: {code}"
+
+
+class TestParseRequest:
+    """Contract tests for request parsing."""
+
+    def test_parse_valid_request(self):
+        """Should parse valid JSON request."""
+        line = b'{"cmd": "get_state", "ship": "alpha"}'
+        req = parse_request(line)
+        assert req.cmd == "get_state"
+        assert req.params["ship"] == "alpha"
+
+    def test_parse_invalid_json_raises(self):
+        """Should raise ValueError for invalid JSON."""
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            parse_request(b"not json")
+
+    def test_parse_missing_cmd_raises(self):
+        """Should raise ValueError when cmd is missing."""
+        with pytest.raises(ValueError, match="Missing 'cmd'"):
+            parse_request(b'{"ship": "alpha"}')
+
+
+class TestLegacyCompatibility:
+    """Contract tests for backwards compatibility."""
+
+    def test_wrap_legacy_success_response(self):
+        """Should wrap legacy dict with ok=True."""
+        legacy = {"ok": True, "value": 42, "message": "Done"}
+        resp = wrap_legacy_response(legacy)
+        assert resp.ok is True
+        assert resp.message == "Done"
+        assert resp.data["value"] == 42
+
+    def test_wrap_legacy_error_response(self):
+        """Should wrap legacy dict with ok=False."""
+        legacy = {"ok": False, "error": "Ship not found"}
+        resp = wrap_legacy_response(legacy)
+        assert resp.ok is False
+        assert resp.error_msg == "Ship not found"
+
+    def test_wrap_legacy_raw_data(self):
+        """Should wrap raw data dict without ok field."""
+        legacy = {"ships": [{"id": "alpha"}]}
+        resp = wrap_legacy_response(legacy)
+        assert resp.ok is True
+        assert resp.data["ships"][0]["id"] == "alpha"
+
+
+class TestJsonDefault:
+    """Contract tests for JSON serialization of special types."""
+
+    def test_serialize_set(self):
+        """Sets should serialize to lists."""
+        assert _json_default({1, 2, 3}) == [1, 2, 3]
+
+    def test_serialize_tuple(self):
+        """Tuples should serialize to lists."""
+        assert _json_default((1, 2, 3)) == [1, 2, 3]
+
+    def test_serialize_bytes(self):
+        """Bytes should decode to string."""
+        assert _json_default(b"hello") == "hello"
+
+    def test_serialize_enum(self):
+        """Enums should serialize to their value."""
+        assert _json_default(MessageType.RESPONSE) == "response"
+
+
+class TestServerConfig:
+    """Contract tests for server configuration."""
+
+    def test_default_ports(self):
+        """Default ports should match documented values."""
+        from server.config import (
+            DEFAULT_TCP_PORT,
+            DEFAULT_WS_PORT,
+            DEFAULT_HTTP_PORT,
+        )
+        assert DEFAULT_TCP_PORT == 8765
+        assert DEFAULT_WS_PORT == 8080
+        assert DEFAULT_HTTP_PORT == 3000
+
+    def test_discovery_info_format(self):
+        """Discovery info should contain required fields."""
+        config = ServerConfig()
+        info = config.to_discovery_info()
+
+        assert "version" in info
+        assert "mode" in info
+        assert "endpoints" in info
+        assert "features" in info
+
+        # Endpoints structure
+        assert "tcp" in info["endpoints"]
+        assert "ws" in info["endpoints"]
+        assert "http" in info["endpoints"]
+
+        for endpoint in info["endpoints"].values():
+            assert "host" in endpoint
+            assert "port" in endpoint
+
+    def test_server_modes(self):
+        """Both server modes should be available."""
+        assert ServerMode.MINIMAL.value == "minimal"
+        assert ServerMode.STATION.value == "station"
+
+
+class TestMessageTypes:
+    """Contract tests for message types."""
+
+    def test_required_message_types(self):
+        """These message types must exist."""
+        required = ["request", "response", "error", "connection_status", "pong"]
+        actual = [t.value for t in MessageType]
+        for msg_type in required:
+            assert msg_type in actual, f"Missing message type: {msg_type}"


### PR DESCRIPTION
This implements the "Make it one game" sprint objective:

- Add server/main.py as unified entrypoint with --mode flag
  (station mode default, minimal mode for backwards compat)
- Add server/config.py with canonical port/host defaults
- Add server/protocol.py with formalized v1 envelope format
  (Request, Response, WSEnvelope, ErrorCode enums)
- Add autodiscovery via _discover command
- Update ws_bridge.py to use Protocol v1 envelopes
- Update start_gui_stack.py to use unified entrypoint
- Add contract tests for protocol stability
- Update API_REFERENCE.md and ARCHITECTURE.md

Usage:
  python -m server.main                    # station mode (default)
  python -m server.main --mode minimal     # backwards compat
  python -m server.main --lan              # LAN accessible
  python tools/start_gui_stack.py          # full stack

Closes #: consolidate server entrypoint issue