### PR TITLE
Sprint B: Navigation loop with set_course autopilot and helm control authority

### DIFF
--- a/gui/components/autopilot-status.js
+++ b/gui/components/autopilot-status.js
@@ -1,0 +1,499 @@
+/**
+ * Autopilot Status Display - Sprint B
+ * Shows current autopilot state, phase, and navigation information.
+ *
+ * Features:
+ * - Current autopilot program display
+ * - Phase progress indicator (ACCELERATE → COAST → BRAKE → HOLD)
+ * - Distance, closing speed, ETA
+ * - Quick autopilot controls
+ */
+
+import { stateManager } from "../js/state-manager.js";
+import { wsClient } from "../js/ws-client.js";
+
+// Autopilot phases for GoToPosition
+const PHASES = ["ACCELERATE", "COAST", "BRAKE", "HOLD"];
+
+class AutopilotStatus extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._unsubscribe = null;
+    this._program = null;
+    this._phase = null;
+    this._status = null;
+    this._mode = "manual";
+    this._courseInfo = null;
+  }
+
+  connectedCallback() {
+    this.render();
+    this._subscribe();
+  }
+
+  disconnectedCallback() {
+    if (this._unsubscribe) {
+      this._unsubscribe();
+    }
+  }
+
+  _subscribe() {
+    this._unsubscribe = stateManager.subscribe("*", () => {
+      this._updateFromState();
+    });
+  }
+
+  render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          font-family: var(--font-sans, "Inter", sans-serif);
+        }
+
+        .autopilot-panel {
+          background: var(--bg-secondary, #12121a);
+          border: 1px solid var(--border-default, #2a2a3a);
+          border-radius: 8px;
+          padding: 12px;
+        }
+
+        .header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          margin-bottom: 12px;
+        }
+
+        .title {
+          font-size: 0.75rem;
+          font-weight: 600;
+          color: var(--text-secondary, #888899);
+          text-transform: uppercase;
+        }
+
+        .mode-badge {
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+          font-size: 0.7rem;
+          font-weight: 600;
+          padding: 3px 8px;
+          border-radius: 4px;
+        }
+
+        .mode-badge.manual {
+          background: var(--status-info, #00aaff);
+          color: var(--bg-primary, #0a0a0f);
+        }
+
+        .mode-badge.autopilot {
+          background: var(--status-nominal, #00ff88);
+          color: var(--bg-primary, #0a0a0f);
+        }
+
+        .mode-badge.override {
+          background: var(--status-warning, #ffaa00);
+          color: var(--bg-primary, #0a0a0f);
+        }
+
+        /* Program Display */
+        .program-display {
+          text-align: center;
+          margin-bottom: 12px;
+        }
+
+        .program-name {
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+          font-size: 1.1rem;
+          font-weight: 600;
+          color: var(--text-primary, #e0e0e0);
+          margin-bottom: 4px;
+        }
+
+        .program-status {
+          font-size: 0.7rem;
+          color: var(--text-secondary, #888899);
+        }
+
+        .no-autopilot {
+          text-align: center;
+          color: var(--text-dim, #555566);
+          font-size: 0.8rem;
+          padding: 16px 0;
+        }
+
+        /* Phase Progress */
+        .phase-progress {
+          margin-bottom: 12px;
+        }
+
+        .phase-bar {
+          display: flex;
+          gap: 4px;
+          margin-bottom: 4px;
+        }
+
+        .phase-segment {
+          flex: 1;
+          height: 6px;
+          background: var(--bg-primary, #0a0a0f);
+          border-radius: 3px;
+          transition: background 0.3s ease;
+        }
+
+        .phase-segment.active {
+          background: var(--status-info, #00aaff);
+        }
+
+        .phase-segment.completed {
+          background: var(--status-nominal, #00ff88);
+        }
+
+        .phase-segment.accelerate.active { background: var(--status-warning, #ffaa00); }
+        .phase-segment.coast.active { background: var(--status-info, #00aaff); }
+        .phase-segment.brake.active { background: var(--status-critical, #ff4444); }
+        .phase-segment.hold.active { background: var(--status-nominal, #00ff88); }
+
+        .phase-labels {
+          display: flex;
+          justify-content: space-between;
+        }
+
+        .phase-label {
+          font-size: 0.55rem;
+          color: var(--text-dim, #555566);
+          text-transform: uppercase;
+        }
+
+        .phase-label.active {
+          color: var(--text-primary, #e0e0e0);
+          font-weight: 600;
+        }
+
+        /* Info Grid */
+        .info-grid {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: 8px;
+          margin-bottom: 12px;
+        }
+
+        .info-item {
+          background: var(--bg-input, #1a1a24);
+          border-radius: 4px;
+          padding: 8px;
+          text-align: center;
+        }
+
+        .info-label {
+          font-size: 0.6rem;
+          color: var(--text-dim, #555566);
+          text-transform: uppercase;
+          margin-bottom: 2px;
+        }
+
+        .info-value {
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+          font-size: 0.85rem;
+          color: var(--text-primary, #e0e0e0);
+        }
+
+        /* Quick Controls */
+        .quick-controls {
+          display: flex;
+          gap: 8px;
+        }
+
+        .quick-btn {
+          flex: 1;
+          padding: 8px;
+          background: var(--bg-input, #1a1a24);
+          border: 1px solid var(--border-default, #2a2a3a);
+          border-radius: 4px;
+          color: var(--text-secondary, #888899);
+          font-size: 0.7rem;
+          cursor: pointer;
+        }
+
+        .quick-btn:hover {
+          background: var(--bg-hover, #22222e);
+          color: var(--text-primary, #e0e0e0);
+        }
+
+        .quick-btn.disengage {
+          border-color: var(--status-critical, #ff4444);
+          color: var(--status-critical, #ff4444);
+        }
+
+        .quick-btn.disengage:hover {
+          background: var(--status-critical, #ff4444);
+          color: var(--bg-primary, #0a0a0f);
+        }
+      </style>
+
+      <div class="autopilot-panel">
+        <div class="header">
+          <span class="title">Autopilot</span>
+          <span class="mode-badge manual" id="mode-badge">MANUAL</span>
+        </div>
+
+        <div id="autopilot-content">
+          <div class="no-autopilot" id="no-autopilot">
+            No autopilot program active<br>
+            <small>Use Set Course or select a target</small>
+          </div>
+
+          <div id="autopilot-active" style="display: none;">
+            <div class="program-display">
+              <div class="program-name" id="program-name">--</div>
+              <div class="program-status" id="program-status">--</div>
+            </div>
+
+            <div class="phase-progress" id="phase-progress">
+              <div class="phase-bar">
+                <div class="phase-segment accelerate" data-phase="ACCELERATE"></div>
+                <div class="phase-segment coast" data-phase="COAST"></div>
+                <div class="phase-segment brake" data-phase="BRAKE"></div>
+                <div class="phase-segment hold" data-phase="HOLD"></div>
+              </div>
+              <div class="phase-labels">
+                <span class="phase-label" data-phase="ACCELERATE">Accel</span>
+                <span class="phase-label" data-phase="COAST">Coast</span>
+                <span class="phase-label" data-phase="BRAKE">Brake</span>
+                <span class="phase-label" data-phase="HOLD">Hold</span>
+              </div>
+            </div>
+
+            <div class="info-grid">
+              <div class="info-item">
+                <div class="info-label">Distance</div>
+                <div class="info-value" id="info-distance">--</div>
+              </div>
+              <div class="info-item">
+                <div class="info-label">Closing</div>
+                <div class="info-value" id="info-closing">--</div>
+              </div>
+              <div class="info-item">
+                <div class="info-label">Braking Dist</div>
+                <div class="info-value" id="info-braking">--</div>
+              </div>
+              <div class="info-item">
+                <div class="info-label">Target</div>
+                <div class="info-value" id="info-target">--</div>
+              </div>
+            </div>
+
+            <div class="quick-controls">
+              <button class="quick-btn" id="hold-btn">HOLD POSITION</button>
+              <button class="quick-btn disengage" id="disengage-btn">DISENGAGE</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    this._setupControls();
+  }
+
+  _setupControls() {
+    const holdBtn = this.shadowRoot.getElementById("hold-btn");
+    const disengageBtn = this.shadowRoot.getElementById("disengage-btn");
+
+    holdBtn?.addEventListener("click", () => this._engageHold());
+    disengageBtn?.addEventListener("click", () => this._disengage());
+  }
+
+  _updateFromState() {
+    const ship = stateManager.getShipState();
+    const navigation = ship?.systems?.navigation || {};
+    const helm = ship?.systems?.helm || {};
+
+    this._mode = navigation.mode || helm.mode || "manual";
+    this._program = navigation.current_program || helm.autopilot_program || null;
+    this._status = navigation.autopilot_state?.status || null;
+
+    // Get course info
+    this._courseInfo = navigation.course || navigation.autopilot_state || null;
+    if (this._courseInfo) {
+      this._phase = this._courseInfo.phase || null;
+    }
+
+    this._updateDisplay();
+  }
+
+  _updateDisplay() {
+    const modeBadge = this.shadowRoot.getElementById("mode-badge");
+    const noAutopilot = this.shadowRoot.getElementById("no-autopilot");
+    const autopilotActive = this.shadowRoot.getElementById("autopilot-active");
+    const programName = this.shadowRoot.getElementById("program-name");
+    const programStatus = this.shadowRoot.getElementById("program-status");
+
+    // Update mode badge
+    if (modeBadge) {
+      modeBadge.classList.remove("manual", "autopilot", "override");
+      if (this._mode === "autopilot" || this._program) {
+        modeBadge.textContent = "AUTOPILOT";
+        modeBadge.classList.add("autopilot");
+      } else if (this._mode === "manual_override") {
+        modeBadge.textContent = "OVERRIDE";
+        modeBadge.classList.add("override");
+      } else {
+        modeBadge.textContent = "MANUAL";
+        modeBadge.classList.add("manual");
+      }
+    }
+
+    // Show/hide autopilot content
+    if (this._program) {
+      noAutopilot.style.display = "none";
+      autopilotActive.style.display = "block";
+
+      // Update program name
+      if (programName) {
+        programName.textContent = this._formatProgramName(this._program);
+      }
+
+      // Update status
+      if (programStatus) {
+        programStatus.textContent = this._status || "Active";
+      }
+
+      // Update phase progress
+      this._updatePhaseProgress();
+
+      // Update info grid
+      this._updateInfoGrid();
+    } else {
+      noAutopilot.style.display = "block";
+      autopilotActive.style.display = "none";
+    }
+  }
+
+  _formatProgramName(program) {
+    if (!program) return "--";
+    return program.toUpperCase().replace(/_/g, " ");
+  }
+
+  _updatePhaseProgress() {
+    const segments = this.shadowRoot.querySelectorAll(".phase-segment");
+    const labels = this.shadowRoot.querySelectorAll(".phase-label");
+    const currentPhase = this._phase?.toUpperCase() || null;
+    const currentIndex = PHASES.indexOf(currentPhase);
+
+    segments.forEach((segment, index) => {
+      segment.classList.remove("active", "completed");
+      if (index < currentIndex) {
+        segment.classList.add("completed");
+      } else if (index === currentIndex) {
+        segment.classList.add("active");
+      }
+    });
+
+    labels.forEach((label, index) => {
+      label.classList.remove("active");
+      if (index === currentIndex) {
+        label.classList.add("active");
+      }
+    });
+  }
+
+  _updateInfoGrid() {
+    const distanceEl = this.shadowRoot.getElementById("info-distance");
+    const closingEl = this.shadowRoot.getElementById("info-closing");
+    const brakingEl = this.shadowRoot.getElementById("info-braking");
+    const targetEl = this.shadowRoot.getElementById("info-target");
+
+    if (this._courseInfo) {
+      // Distance
+      if (distanceEl) {
+        const dist = this._courseInfo.distance;
+        if (dist !== null && dist !== undefined) {
+          if (dist > 1000) {
+            distanceEl.textContent = `${(dist / 1000).toFixed(2)} km`;
+          } else {
+            distanceEl.textContent = `${dist.toFixed(1)} m`;
+          }
+        } else {
+          distanceEl.textContent = "--";
+        }
+      }
+
+      // Closing speed
+      if (closingEl) {
+        const closing = this._courseInfo.closing_speed;
+        if (closing !== null && closing !== undefined) {
+          closingEl.textContent = `${closing.toFixed(1)} m/s`;
+        } else {
+          closingEl.textContent = "--";
+        }
+      }
+
+      // Braking distance
+      if (brakingEl) {
+        const braking = this._courseInfo.braking_distance;
+        if (braking !== null && braking !== undefined) {
+          if (braking > 1000) {
+            brakingEl.textContent = `${(braking / 1000).toFixed(2)} km`;
+          } else {
+            brakingEl.textContent = `${braking.toFixed(1)} m`;
+          }
+        } else {
+          brakingEl.textContent = "--";
+        }
+      }
+
+      // Target/destination
+      if (targetEl) {
+        const dest = this._courseInfo.destination;
+        if (dest) {
+          const x = dest.x?.toFixed(0) || 0;
+          const y = dest.y?.toFixed(0) || 0;
+          const z = dest.z?.toFixed(0) || 0;
+          targetEl.textContent = `(${x}, ${y}, ${z})`;
+        } else {
+          targetEl.textContent = "--";
+        }
+      }
+    }
+  }
+
+  async _engageHold() {
+    try {
+      const response = await wsClient.sendShipCommand("autopilot", {
+        program: "hold"
+      });
+      if (response?.ok) {
+        this._showMessage("Hold position engaged", "success");
+      } else {
+        this._showMessage(response?.error || "Failed to engage hold", "error");
+      }
+    } catch (error) {
+      this._showMessage(`Hold failed: ${error.message}`, "error");
+    }
+  }
+
+  async _disengage() {
+    try {
+      const response = await wsClient.sendShipCommand("autopilot", {
+        program: "off"
+      });
+      if (response?.ok) {
+        this._showMessage("Autopilot disengaged", "success");
+      } else {
+        this._showMessage(response?.error || "Failed to disengage", "error");
+      }
+    } catch (error) {
+      this._showMessage(`Disengage failed: ${error.message}`, "error");
+    }
+  }
+
+  _showMessage(text, type) {
+    const systemMessages = document.getElementById("system-messages");
+    if (systemMessages?.show) {
+      systemMessages.show({ type, text });
+    }
+  }
+}
+
+customElements.define("autopilot-status", AutopilotStatus);
+export { AutopilotStatus };

--- a/gui/components/set-course-control.js
+++ b/gui/components/set-course-control.js
@@ -1,0 +1,491 @@
+/**
+ * Set Course Control - Sprint B
+ * Navigation component for setting course destinations with GoToPosition autopilot.
+ *
+ * Features:
+ * - Coordinate input (X, Y, Z)
+ * - Stop at destination toggle
+ * - Tolerance and speed settings
+ * - Course status display with phase tracking
+ */
+
+import { stateManager } from "../js/state-manager.js";
+import { wsClient } from "../js/ws-client.js";
+
+class SetCourseControl extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._unsubscribe = null;
+    this._courseActive = false;
+    this._coursePhase = null;
+    this._destination = null;
+    this._distance = null;
+    this._closingSpeed = null;
+  }
+
+  connectedCallback() {
+    this.render();
+    this._subscribe();
+    this._setupInteraction();
+  }
+
+  disconnectedCallback() {
+    if (this._unsubscribe) {
+      this._unsubscribe();
+    }
+  }
+
+  _subscribe() {
+    this._unsubscribe = stateManager.subscribe("*", () => {
+      this._updateFromState();
+    });
+  }
+
+  render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: flex;
+          flex-direction: column;
+          padding: 16px;
+          font-family: var(--font-sans, "Inter", sans-serif);
+        }
+
+        .section-title {
+          font-size: 0.75rem;
+          font-weight: 600;
+          color: var(--text-secondary, #888899);
+          text-transform: uppercase;
+          margin-bottom: 12px;
+        }
+
+        /* Course Status */
+        .course-status {
+          background: var(--bg-input, #1a1a24);
+          border-radius: 8px;
+          padding: 12px;
+          margin-bottom: 16px;
+        }
+
+        .status-row {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          margin-bottom: 8px;
+        }
+
+        .status-row:last-child {
+          margin-bottom: 0;
+        }
+
+        .status-label {
+          font-size: 0.7rem;
+          color: var(--text-dim, #555566);
+          text-transform: uppercase;
+        }
+
+        .status-value {
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+          font-size: 0.8rem;
+          color: var(--text-primary, #e0e0e0);
+        }
+
+        .status-value.phase {
+          font-weight: 600;
+          padding: 2px 8px;
+          border-radius: 4px;
+          background: var(--bg-primary, #0a0a0f);
+        }
+
+        .phase-accelerate { color: var(--status-warning, #ffaa00); }
+        .phase-coast { color: var(--status-info, #00aaff); }
+        .phase-brake { color: var(--status-critical, #ff4444); }
+        .phase-hold { color: var(--status-nominal, #00ff88); }
+
+        .no-course {
+          text-align: center;
+          color: var(--text-dim, #555566);
+          font-size: 0.8rem;
+          padding: 8px;
+        }
+
+        /* Coordinate Inputs */
+        .coord-inputs {
+          display: grid;
+          grid-template-columns: 1fr 1fr 1fr;
+          gap: 8px;
+          margin-bottom: 12px;
+        }
+
+        .coord-group {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+        }
+
+        .coord-label {
+          font-size: 0.65rem;
+          color: var(--text-dim, #555566);
+          text-transform: uppercase;
+        }
+
+        .coord-input {
+          padding: 8px;
+          background: var(--bg-primary, #0a0a0f);
+          border: 1px solid var(--border-default, #2a2a3a);
+          border-radius: 4px;
+          color: var(--text-primary, #e0e0e0);
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+          font-size: 0.85rem;
+          text-align: center;
+        }
+
+        .coord-input:focus {
+          outline: none;
+          border-color: var(--status-info, #00aaff);
+        }
+
+        /* Options */
+        .options-row {
+          display: flex;
+          gap: 16px;
+          margin-bottom: 12px;
+          align-items: center;
+        }
+
+        .option-group {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
+
+        .option-label {
+          font-size: 0.7rem;
+          color: var(--text-secondary, #888899);
+        }
+
+        .option-checkbox {
+          width: 18px;
+          height: 18px;
+          accent-color: var(--status-info, #00aaff);
+        }
+
+        .option-input {
+          width: 60px;
+          padding: 4px 8px;
+          background: var(--bg-primary, #0a0a0f);
+          border: 1px solid var(--border-default, #2a2a3a);
+          border-radius: 4px;
+          color: var(--text-primary, #e0e0e0);
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+          font-size: 0.75rem;
+          text-align: center;
+        }
+
+        /* Buttons */
+        .button-row {
+          display: flex;
+          gap: 8px;
+        }
+
+        .set-course-btn {
+          flex: 1;
+          padding: 12px 16px;
+          background: var(--status-info, #00aaff);
+          border: none;
+          border-radius: 6px;
+          color: var(--bg-primary, #0a0a0f);
+          font-weight: 600;
+          font-size: 0.85rem;
+          cursor: pointer;
+        }
+
+        .set-course-btn:hover {
+          filter: brightness(1.1);
+        }
+
+        .set-course-btn:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+
+        .cancel-btn {
+          padding: 12px 16px;
+          background: var(--status-critical, #ff4444);
+          border: none;
+          border-radius: 6px;
+          color: var(--text-bright, #ffffff);
+          font-weight: 600;
+          font-size: 0.85rem;
+          cursor: pointer;
+        }
+
+        .cancel-btn:hover {
+          filter: brightness(1.1);
+        }
+
+        .cancel-btn.hidden {
+          display: none;
+        }
+
+        /* Quick Destinations */
+        .quick-section {
+          margin-top: 16px;
+          padding-top: 16px;
+          border-top: 1px solid var(--border-default, #2a2a3a);
+        }
+
+        .quick-destinations {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+        }
+
+        .quick-btn {
+          padding: 6px 12px;
+          background: var(--bg-input, #1a1a24);
+          border: 1px solid var(--border-default, #2a2a3a);
+          border-radius: 4px;
+          color: var(--text-secondary, #888899);
+          font-size: 0.7rem;
+          cursor: pointer;
+        }
+
+        .quick-btn:hover {
+          background: var(--bg-hover, #22222e);
+          color: var(--text-primary, #e0e0e0);
+        }
+      </style>
+
+      <div class="section-title">Set Course</div>
+
+      <!-- Course Status -->
+      <div class="course-status" id="course-status">
+        <div class="no-course" id="no-course">No active course</div>
+        <div id="active-course" style="display: none;">
+          <div class="status-row">
+            <span class="status-label">Phase</span>
+            <span class="status-value phase" id="course-phase">--</span>
+          </div>
+          <div class="status-row">
+            <span class="status-label">Distance</span>
+            <span class="status-value" id="course-distance">-- m</span>
+          </div>
+          <div class="status-row">
+            <span class="status-label">Closing</span>
+            <span class="status-value" id="course-closing">-- m/s</span>
+          </div>
+          <div class="status-row">
+            <span class="status-label">Destination</span>
+            <span class="status-value" id="course-dest">--</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Coordinate Inputs -->
+      <div class="coord-inputs">
+        <div class="coord-group">
+          <label class="coord-label">X</label>
+          <input type="number" class="coord-input" id="coord-x" value="0" step="100" />
+        </div>
+        <div class="coord-group">
+          <label class="coord-label">Y</label>
+          <input type="number" class="coord-input" id="coord-y" value="0" step="100" />
+        </div>
+        <div class="coord-group">
+          <label class="coord-label">Z</label>
+          <input type="number" class="coord-input" id="coord-z" value="0" step="100" />
+        </div>
+      </div>
+
+      <!-- Options -->
+      <div class="options-row">
+        <div class="option-group">
+          <input type="checkbox" class="option-checkbox" id="stop-at-target" checked />
+          <label class="option-label" for="stop-at-target">Stop at target</label>
+        </div>
+        <div class="option-group">
+          <label class="option-label">Tolerance</label>
+          <input type="number" class="option-input" id="tolerance" value="50" min="1" step="10" />
+          <span class="option-label">m</span>
+        </div>
+      </div>
+
+      <!-- Buttons -->
+      <div class="button-row">
+        <button class="set-course-btn" id="set-course-btn">SET COURSE</button>
+        <button class="cancel-btn hidden" id="cancel-btn">CANCEL</button>
+      </div>
+
+      <!-- Quick Destinations -->
+      <div class="quick-section">
+        <div class="section-title">Quick Destinations</div>
+        <div class="quick-destinations">
+          <button class="quick-btn" data-x="1000" data-y="0" data-z="0">+1km X</button>
+          <button class="quick-btn" data-x="0" data-y="1000" data-z="0">+1km Y</button>
+          <button class="quick-btn" data-x="0" data-y="0" data-z="1000">+1km Z</button>
+          <button class="quick-btn" data-x="10000" data-y="0" data-z="0">+10km X</button>
+          <button class="quick-btn" data-x="0" data-y="0" data-z="0">Origin</button>
+        </div>
+      </div>
+    `;
+  }
+
+  _setupInteraction() {
+    const setCourseBtn = this.shadowRoot.getElementById("set-course-btn");
+    const cancelBtn = this.shadowRoot.getElementById("cancel-btn");
+    const quickBtns = this.shadowRoot.querySelectorAll(".quick-btn");
+
+    setCourseBtn.addEventListener("click", () => this._setCourse());
+    cancelBtn.addEventListener("click", () => this._cancelCourse());
+
+    // Quick destination buttons
+    quickBtns.forEach(btn => {
+      btn.addEventListener("click", () => {
+        const x = parseFloat(btn.dataset.x) || 0;
+        const y = parseFloat(btn.dataset.y) || 0;
+        const z = parseFloat(btn.dataset.z) || 0;
+        this.shadowRoot.getElementById("coord-x").value = x;
+        this.shadowRoot.getElementById("coord-y").value = y;
+        this.shadowRoot.getElementById("coord-z").value = z;
+      });
+    });
+
+    // Enter key to set course
+    const coordInputs = this.shadowRoot.querySelectorAll(".coord-input");
+    coordInputs.forEach(input => {
+      input.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") {
+          this._setCourse();
+        }
+      });
+    });
+  }
+
+  _updateFromState() {
+    const ship = stateManager.getShipState();
+    const navigation = ship?.systems?.navigation || {};
+    const course = navigation.course || {};
+
+    this._courseActive = course.active || false;
+    this._coursePhase = course.phase || null;
+    this._destination = course.destination || null;
+    this._distance = course.distance || null;
+    this._closingSpeed = course.closing_speed || null;
+
+    this._updateCourseDisplay();
+  }
+
+  _updateCourseDisplay() {
+    const noCourse = this.shadowRoot.getElementById("no-course");
+    const activeCourse = this.shadowRoot.getElementById("active-course");
+    const cancelBtn = this.shadowRoot.getElementById("cancel-btn");
+    const phaseEl = this.shadowRoot.getElementById("course-phase");
+    const distanceEl = this.shadowRoot.getElementById("course-distance");
+    const closingEl = this.shadowRoot.getElementById("course-closing");
+    const destEl = this.shadowRoot.getElementById("course-dest");
+
+    if (this._courseActive) {
+      noCourse.style.display = "none";
+      activeCourse.style.display = "block";
+      cancelBtn.classList.remove("hidden");
+
+      // Update phase with color coding
+      if (phaseEl && this._coursePhase) {
+        phaseEl.textContent = this._coursePhase;
+        phaseEl.className = "status-value phase";
+        const phaseLower = this._coursePhase.toLowerCase();
+        if (phaseLower.includes("accelerate")) {
+          phaseEl.classList.add("phase-accelerate");
+        } else if (phaseLower.includes("coast")) {
+          phaseEl.classList.add("phase-coast");
+        } else if (phaseLower.includes("brake")) {
+          phaseEl.classList.add("phase-brake");
+        } else if (phaseLower.includes("hold")) {
+          phaseEl.classList.add("phase-hold");
+        }
+      }
+
+      // Update distance
+      if (distanceEl && this._distance !== null) {
+        if (this._distance > 1000) {
+          distanceEl.textContent = `${(this._distance / 1000).toFixed(2)} km`;
+        } else {
+          distanceEl.textContent = `${this._distance.toFixed(1)} m`;
+        }
+      }
+
+      // Update closing speed
+      if (closingEl && this._closingSpeed !== null) {
+        closingEl.textContent = `${this._closingSpeed.toFixed(1)} m/s`;
+      }
+
+      // Update destination
+      if (destEl && this._destination) {
+        const x = this._destination.x?.toFixed(0) || 0;
+        const y = this._destination.y?.toFixed(0) || 0;
+        const z = this._destination.z?.toFixed(0) || 0;
+        destEl.textContent = `(${x}, ${y}, ${z})`;
+      }
+    } else {
+      noCourse.style.display = "block";
+      activeCourse.style.display = "none";
+      cancelBtn.classList.add("hidden");
+    }
+  }
+
+  async _setCourse() {
+    const x = parseFloat(this.shadowRoot.getElementById("coord-x").value) || 0;
+    const y = parseFloat(this.shadowRoot.getElementById("coord-y").value) || 0;
+    const z = parseFloat(this.shadowRoot.getElementById("coord-z").value) || 0;
+    const stop = this.shadowRoot.getElementById("stop-at-target").checked;
+    const tolerance = parseFloat(this.shadowRoot.getElementById("tolerance").value) || 50;
+
+    try {
+      console.log(`Setting course to (${x}, ${y}, ${z}), stop=${stop}, tolerance=${tolerance}`);
+      const response = await wsClient.sendShipCommand("set_course", {
+        x, y, z, stop, tolerance
+      });
+      console.log("Set course response:", response);
+
+      if (response?.ok) {
+        this._showMessage(`Course set to (${x}, ${y}, ${z})`, "success");
+      } else {
+        this._showMessage(response?.error || "Failed to set course", "error");
+      }
+    } catch (error) {
+      console.error("Set course failed:", error);
+      this._showMessage(`Set course failed: ${error.message}`, "error");
+    }
+  }
+
+  async _cancelCourse() {
+    try {
+      console.log("Canceling course (disengaging autopilot)...");
+      const response = await wsClient.sendShipCommand("autopilot", {
+        program: "off"
+      });
+      console.log("Cancel course response:", response);
+
+      if (response?.ok) {
+        this._showMessage("Course canceled", "success");
+      } else {
+        this._showMessage(response?.error || "Failed to cancel course", "error");
+      }
+    } catch (error) {
+      console.error("Cancel course failed:", error);
+      this._showMessage(`Cancel failed: ${error.message}`, "error");
+    }
+  }
+
+  _showMessage(text, type) {
+    const systemMessages = document.getElementById("system-messages");
+    if (systemMessages?.show) {
+      systemMessages.show({ type, text });
+    }
+  }
+}
+
+customElements.define("set-course-control", SetCourseControl);
+export { SetCourseControl };

--- a/gui/index.html
+++ b/gui/index.html
@@ -364,6 +364,14 @@
         <autopilot-control></autopilot-control>
       </flaxos-panel>
 
+      <flaxos-panel title="Autopilot Status" collapsible class="autopilot-panel">
+        <autopilot-status></autopilot-status>
+      </flaxos-panel>
+
+      <flaxos-panel title="Set Course" collapsible class="nav-panel">
+        <set-course-control></set-course-control>
+      </flaxos-panel>
+
       <flaxos-panel title="Flight Computer" collapsible class="flight-computer-panel">
         <flight-computer></flight-computer>
       </flaxos-panel>

--- a/gui/js/main.js
+++ b/gui/js/main.js
@@ -45,6 +45,9 @@ import { stationManager } from "./station-manager.js";
 // Phase 8: Inter-Station Communication
 import "../components/helm-requests.js";
 import { helmRequests } from "./helm-requests.js";
+// Sprint B: Navigation loop - set_course and autopilot
+import "../components/set-course-control.js";
+import "../components/autopilot-status.js";
 
 // App state
 const app = {

--- a/hybrid/command_handler.py
+++ b/hybrid/command_handler.py
@@ -31,7 +31,11 @@ system_commands = {
     "set_course": ("navigation", "set_course"),
     "autopilot": ("navigation", "set_autopilot"),
     "set_plan": ("navigation", "set_plan"),
+    # Helm control authority
     "helm_override": ("helm", "set_mode"),
+    "take_manual_control": ("helm", "take_manual_control"),
+    "release_to_autopilot": ("helm", "release_to_autopilot"),
+    # Helm command queue
     "queue_helm_command": ("helm", "queue_command"),
     "queue_helm_commands": ("helm", "queue_commands"),
     "clear_helm_queue": ("helm", "clear_queue"),


### PR DESCRIPTION
- HelmSystem: Add explicit control authority tracking (manual, nav_autopilot, queue)
  - New take_manual_control and release_to_autopilot commands
  - Manual inputs trigger automatic override of autopilot
  - Resume-to-autopilot timeout (configurable)
  - Track autopilot program and phase for GUI display

- NavigationSystem: Enhanced state reporting with course info
  - Comprehensive course object with phase, distance, closing speed, etc.
  - GoToPosition autopilot phases: ACCELERATE → COAST → BRAKE → HOLD

- ThrottleControl (GUI): Authoritative state display
  - Shows control authority badge (MANUAL, AUTOPILOT, QUEUE)
  - Autopilot program and phase display
  - Take Manual Control / Release to Autopilot button
  - Pending command indicator during server roundtrip
  - Uses propulsion.throttle as authoritative value

- New SetCourseControl component: Set navigation courses
  - Coordinate input (X, Y, Z)
  - Stop-at-target toggle
  - Tolerance setting
  - Course status with phase coloring
  - Quick destination buttons

- New AutopilotStatus component: Autopilot monitoring
  - Visual phase progress bar
  - Distance, closing speed, braking distance display
  - Quick controls (Hold, Disengage)

https://claude.ai/code/session_01M2PGwXcVZ96Ebvd8sZBK2v