### PR TITLE
Use simulation time for mission status

### DIFF
--- a/hybrid/scenarios/mission.py
+++ b/hybrid/scenarios/mission.py
@@ -32,6 +32,7 @@ class Mission:
 
         self.tracker = ObjectiveTracker(objectives)
         self.start_time = None
+        self.last_sim_time = None
         self.shown_hints = set()
         self.hint_queue = []  # Queue of hints to be displayed to player
 
@@ -42,6 +43,7 @@ class Mission:
             sim_time: Current simulation time
         """
         self.start_time = sim_time
+        self.last_sim_time = sim_time
 
         # Set start_time on time-based objectives
         for obj in self.tracker.objectives.values():
@@ -56,6 +58,7 @@ class Mission:
             player_ship: Player's ship
         """
         # Check time limit
+        self.last_sim_time = sim.time
         if self.time_limit and self.start_time:
             elapsed = sim.time - self.start_time
             if elapsed > self.time_limit and self.tracker.mission_status == "in_progress":
@@ -136,8 +139,11 @@ class Mission:
                 logger = logging.getLogger(__name__)
                 logger.info(f"Mission hint triggered: {message}")
 
-    def get_status(self) -> Dict:
+    def get_status(self, sim_time: Optional[float] = None) -> Dict:
         """Get mission status.
+
+        Args:
+            sim_time: Current simulation time
 
         Returns:
             dict: Mission status
@@ -153,9 +159,8 @@ class Mission:
         if self.start_time:
             # Add time remaining if there's a limit
             if self.time_limit:
-                import time
-                current_time = time.time()  # This should use sim.time
-                elapsed = current_time - self.start_time if self.start_time else 0
+                current_time = sim_time if sim_time is not None else self.last_sim_time
+                elapsed = current_time - self.start_time if current_time is not None else 0
                 status["time_remaining"] = max(0, self.time_limit - elapsed)
 
         return status

--- a/hybrid_runner.py
+++ b/hybrid_runner.py
@@ -87,7 +87,7 @@ class HybridRunner:
         """Return current mission status and metadata."""
         if not self.mission:
             return {"available": False}
-        status = self.mission.get_status()
+        status = self.mission.get_status(sim_time=self.simulator.time)
         status.update({
             "available": True,
             "briefing": self.mission.briefing,


### PR DESCRIPTION
### Motivation
- Mission elapsed/time-remaining was being computed from wall-clock time which produces incorrect values when the simulator is paused or running at non-real-time speeds.

### Description
- Track the latest simulation time in `Mission` (`last_sim_time`), add an optional `sim_time` parameter to `Mission.get_status()` and compute `time_remaining` from `sim_time` (or `last_sim_time`), and update `HybridRunner.get_mission_status()` to call `mission.get_status(sim_time=self.simulator.time)` so status reflects simulation time.

### Testing
- No automated tests were run for this change; only the code changes were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697862e80d1c8324a0d392701e249282)