### PR TITLE
Handle non-numeric sensor distances in CLI output

### DIFF
--- a/hybrid/cli.py
+++ b/hybrid/cli.py
@@ -95,7 +95,11 @@ def print_ship_state(state, detailed=False):
                     contact_id = contact.get("id", "Unknown")
                     distance = contact.get("distance", "Unknown")
                     method = contact.get("detection_method", "Unknown")
-                    print(f"  {contact_id} @ {distance:.1f} km [{method}]")
+                    if isinstance(distance, (int, float)):
+                        formatted_distance = f"{distance:.1f}"
+                    else:
+                        formatted_distance = str(distance)
+                    print(f"  {contact_id} @ {formatted_distance} km [{method}]")
 
 def run_cli(fleet_dir="hybrid_fleet", dt=0.1):
     """Run the simulator in CLI mode"""


### PR DESCRIPTION
### Motivation
- Prevent formatting errors in `print_ship_state()` when sensor contact `distance` can be non-numeric (for example `"Unknown"` or `None`).

### Description
- Update the sensor contact loop in `print_ship_state()` to check `if isinstance(distance, (int, float)):` and format with `f"{distance:.1f}"` when numeric, otherwise render `distance` via `str(distance)` before printing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69786459673c83249ac643812528c2be)