### PR TITLE
Handle optional NumPy in Phase 2 integration tests

### DIFF
--- a/PHASE2_COMPLETION_SUMMARY.md
+++ b/PHASE2_COMPLETION_SUMMARY.md
@@ -196,7 +196,7 @@ This document summarizes the completion of Phase 2 enhancements for the Flaxos S
 ### 8. Integration Testing ✓
 
 **Files Created:**
-- `test_phase2_integration.py`
+- `tests/phase2/test_phase2_integration.py`
 
 **Test Suite:**
 - 7 comprehensive integration tests
@@ -224,7 +224,7 @@ Note: 3 tests require numpy dependency (pre-existing requirement)
 ### New Files Created
 1. `server/stations/crew_system.py` (406 lines)
 2. `scenarios/fleet_combat_scenario.json` (691 lines)
-3. `test_phase2_integration.py` (416 lines)
+3. `tests/phase2/test_phase2_integration.py` (416 lines)
 4. `PHASE2_COMPLETION_SUMMARY.md` (this file)
 
 ### Modified Files

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ See [`docs/ANDROID_AUTO_UPDATE.md`](docs/ANDROID_AUTO_UPDATE.md) for complete do
 ```bash
 pip install pyyaml flask
 
-# Optional: numpy (required for fleet formations)
+# Optional: numpy (required for fleet formations + Phase 2 integration tests)
 pip install numpy
 ```
 
-**Note**: NumPy is optional. Core functionality works without it, but fleet formation features require NumPy.
+**Note**: NumPy is optional. Core functionality works without it, but fleet formation features and the Phase 2 integration tests are skipped without NumPy.
 
 ### 2) Start the server (desktop recommended)
 Run the sim server from your desktop/laptop so it can host the simulation loop:

--- a/tests/phase2/test_phase2_integration.py
+++ b/tests/phase2/test_phase2_integration.py
@@ -11,36 +11,47 @@ This script validates all Phase 2 enhancements:
 6. Multi-ship combat scenario loading
 """
 
-import sys
 import os
+import sys
 import logging
 
 import pytest
 
 # Add project root to path
-ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, ROOT_DIR)
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 # Check for numpy availability (optional dependency)
-try:
-    import numpy
-    HAS_NUMPY = True
-except ImportError:
-    HAS_NUMPY = False
+def has_numpy() -> bool:
+    try:
+        import numpy  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+HAS_NUMPY = has_numpy()
+if not HAS_NUMPY:
     logger.warning("NumPy not available - some tests will be skipped")
     logger.warning("To run all tests: pip install numpy")
 
+
+def require_numpy() -> None:
+    if not HAS_NUMPY:
+        pytest.skip("Test requires numpy (pip install numpy)")
+
+
+@pytest.mark.skipif(not HAS_NUMPY, reason="NumPy not available (pip install numpy).")
 def test_fleet_manager_integration():
     """Test that FleetManager is integrated with Simulator"""
     logger.info("=" * 60)
     logger.info("TEST 1: Fleet Manager Integration")
     logger.info("=" * 60)
 
-    if not HAS_NUMPY:
-        pytest.skip("Test requires numpy (pip install numpy)")
+    require_numpy()
 
     from hybrid.simulator import Simulator
     from hybrid.fleet.fleet_manager import FleetManager
@@ -72,14 +83,14 @@ def test_fleet_manager_integration():
     logger.info("✓ Fleet creation test passed")
 
 
+@pytest.mark.skipif(not HAS_NUMPY, reason="NumPy not available (pip install numpy).")
 def test_ai_controller_integration():
     """Test that AI Controller is integrated with Ship"""
     logger.info("\n" + "=" * 60)
     logger.info("TEST 2: AI Controller Integration")
     logger.info("=" * 60)
 
-    if not HAS_NUMPY:
-        pytest.skip("Test requires numpy (pip install numpy)")
+    require_numpy()
 
     from hybrid.ship import Ship
     from hybrid.fleet.ai_controller import AIBehavior
@@ -328,14 +339,14 @@ def test_scenario_loading():
         logger.info(f"  - {obj['type'].upper()}: {obj['description']}")
 
 
+@pytest.mark.skipif(not HAS_NUMPY, reason="NumPy not available (pip install numpy).")
 def test_simulator_tick_integration():
     """Test that simulator tick properly updates fleet manager and AI"""
     logger.info("\n" + "=" * 60)
     logger.info("TEST 7: Simulator Tick Integration")
     logger.info("=" * 60)
 
-    if not HAS_NUMPY:
-        pytest.skip("Test requires numpy (pip install numpy)")
+    require_numpy()
 
     from hybrid.simulator import Simulator
     from hybrid.fleet.ai_controller import AIBehavior


### PR DESCRIPTION
### Motivation
- Make the Phase 2 integration test suite runnable in environments without NumPy by skipping NumPy-dependent cases.
- Ensure contributors know NumPy is optional but required for certain features/tests by updating docs.
- Normalize the test file location under `tests/phase2` and fix project root resolution for imports used by the test.

### Description
- Moved the test file to `tests/phase2/test_phase2_integration.py` and updated references in `PHASE2_COMPLETION_SUMMARY.md` to the new path.
- Added a small helper `has_numpy()` and `require_numpy()` in `tests/phase2/test_phase2_integration.py` and applied `@pytest.mark.skipif(not HAS_NUMPY, ...)` to NumPy-dependent tests (`test_fleet_manager_integration`, `test_ai_controller_integration`, and `test_simulator_tick_integration`).
- Adjusted `ROOT_DIR` resolution in the test to `os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))` so imports resolve correctly when run from the tests directory.
- Documented the optional NumPy requirement in `README.md` (noting that fleet formations and Phase 2 integration tests are skipped without NumPy).

### Testing
- No automated test run was executed as part of this change (no `pytest`/CI invocation was performed).
- Changes were exercised via file relocation and code edits; `git commit` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697864b5e2548324bb5003b24d2d5868)