### PR TITLE
Auto-assign player to captain station on scenario load

### DIFF
--- a/gui/components/scenario-loader.js
+++ b/gui/components/scenario-loader.js
@@ -288,7 +288,22 @@ class ScenarioLoader extends HTMLElement {
 
       if (response && response.ok !== false) {
         this._currentScenario = this._selectedScenario;
-        statusBox.textContent = `Loaded: ${this._selectedScenario} (${response.ships_loaded} ships)`;
+
+        // Build status message
+        let statusMsg = `Loaded: ${this._selectedScenario} (${response.ships_loaded} ships)`;
+        if (response.auto_assigned) {
+          statusMsg += ` - Assigned to ${response.assigned_ship}`;
+        }
+        statusBox.textContent = statusMsg;
+
+        console.log("Scenario loaded:", {
+          scenario: this._selectedScenario,
+          shipsLoaded: response.ships_loaded,
+          playerShipId: response.player_ship_id,
+          autoAssigned: response.auto_assigned,
+          assignedShip: response.assigned_ship,
+          station: response.station
+        });
 
         // Dispatch event for other components
         this.dispatchEvent(new CustomEvent("scenario-loaded", {
@@ -296,6 +311,9 @@ class ScenarioLoader extends HTMLElement {
             scenario: this._selectedScenario,
             shipsLoaded: response.ships_loaded,
             playerShipId: response.player_ship_id,
+            autoAssigned: response.auto_assigned,
+            assignedShip: response.assigned_ship,
+            station: response.station,
             mission: response.mission
           },
           bubbles: true
@@ -303,7 +321,9 @@ class ScenarioLoader extends HTMLElement {
 
         this._renderScenarios();
       } else {
-        statusBox.textContent = `Failed: ${response?.error || 'Unknown error'}`;
+        const errorMsg = response?.error || 'Unknown error';
+        statusBox.textContent = `Failed: ${errorMsg}`;
+        console.error("Scenario load failed:", errorMsg);
       }
     } catch (error) {
       statusBox.textContent = `Error: ${error.message}`;

--- a/gui/js/main.js
+++ b/gui/js/main.js
@@ -153,10 +153,15 @@ function setupGlobalEvents() {
 
   // Listen for scenario load to set player ship ID
   document.addEventListener("scenario-loaded", (e) => {
-    const { playerShipId, scenario, shipsLoaded, mission } = e.detail;
+    const { playerShipId, scenario, shipsLoaded, autoAssigned, station, mission } = e.detail;
     if (playerShipId) {
       stateManager.setPlayerShipId(playerShipId);
       console.log(`Scenario "${scenario}" loaded with ${shipsLoaded} ships, player: ${playerShipId}`);
+      if (autoAssigned) {
+        console.log(`Auto-assigned to ship ${playerShipId} as ${station || "captain"}`);
+      }
+    } else {
+      console.warn(`Scenario "${scenario}" loaded but no player ship ID received`);
     }
     showSystemMessage("success", `Scenario "${scenario}" loaded`, "Mission Ready");
   });


### PR DESCRIPTION
## Summary
This PR implements automatic assignment of the player client to the captain station when a scenario is loaded, streamlining the single-player experience by eliminating the need for manual station assignment.

## Key Changes

- **Server-side auto-assignment** (`server/main.py`):
  - Relaxed permission check for scenario loading to allow all clients to load scenarios
  - Added automatic assignment of the loading client to the player ship with captain station control
  - Included `auto_assigned`, `assigned_ship`, and `station` fields in the load response

- **Enhanced status messaging** (`gui/components/scenario-loader.js`):
  - Updated status box to display auto-assignment information when applicable
  - Added detailed console logging for scenario load events and failures
  - Extended the `scenario-loaded` event detail to include auto-assignment metadata

- **Updated event handling** (`gui/js/main.js`):
  - Modified the `scenario-loaded` event listener to handle new auto-assignment fields
  - Added logging to confirm auto-assignment details
  - Added warning log when scenario loads without a player ship ID

## Implementation Details

The auto-assignment flow:
1. Client requests scenario load via `load_scenario` command
2. Server loads the scenario and retrieves the player ship ID
3. Server automatically assigns the client to that ship and claims the captain station
4. Response includes auto-assignment confirmation and station details
5. Client-side UI and event handlers reflect the assignment status

This change improves the user experience for single-player scenarios by automatically putting the player in control without requiring additional setup steps.

https://claude.ai/code/session_01YXxDhxz3vrh7jdSyj3LqBz