### PR TITLE
Add v0.6.0 release plan for engineering and weapons

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This starts the TCP sim server, WebSocket bridge, and GUI HTTP server, then open
 - [Feature status](docs/FEATURE_STATUS.md)
 - [Known issues](docs/KNOWN_ISSUES.md)
 - [Sprint plan](docs/NEXT_SPRINT.md)
+- [Next release plan](docs/NEXT_RELEASE_PLAN.md)
 - [Quaternion API](docs/QUATERNION_API.md)
 - [RCS configuration guide](docs/RCS_CONFIGURATION_GUIDE.md)
 - [Physics update notes](docs/PHYSICS_UPDATE.md)

--- a/docs/NEXT_RELEASE_PLAN.md
+++ b/docs/NEXT_RELEASE_PLAN.md
@@ -1,0 +1,90 @@
+# Next Release Plan - v0.6.0: Engineering + Weapons Gameplay Loops
+
+**Release Theme**: Damage, Heat, and Sub-Targeting
+**Goal**: Complete both the **Engineering** and **Weapons** gameplay loops by tying combat outcomes to subsystem damage, heat management, and targeted strikes.
+
+---
+
+## ✅ Release Objectives
+
+### 1) Damage Model (Engineering + Weapons)
+Introduce subsystem-level damage so combat outcomes directly affect ship functionality.
+
+**Key deliverables**
+- Subsystem health states: **online → damaged → offline → destroyed**.
+- Damage propagation for **direct hits** and **AoE** weapons.
+- System effects: damaged systems have degraded performance; offline systems stop working.
+
+**Gameplay impact**
+- Engineering must triage and manage system reliability.
+- Tactical decisions influence which enemy capabilities are disabled.
+
+---
+
+### 2) Heat Management (Engineering)
+Add heat generation and dissipation as a real operational constraint.
+
+**Key deliverables**
+- Heat accumulation from **reactor load**, **weapon firing**, and **sustained thrust**.
+- Heat dissipation model per ship/system.
+- Overheat thresholds with penalties: cooldown delays, auto-shutdown, or efficiency loss.
+
+**Gameplay impact**
+- Engineering balances power/weapon usage to avoid cascading failures.
+- Tactical tradeoffs between burst damage vs sustained operations.
+
+---
+
+### 3) Sub-Targeting (Weapons)
+Enable targeting of specific subsystems, tying directly into the damage model.
+
+**Key deliverables**
+- Command surface for selecting subsystem targets.
+- Weapon effect weighting (precision vs AoE) for subsystem damage application.
+- Telemetry updates to show subsystem status and critical damage.
+
+**Gameplay impact**
+- Weapons loop becomes a tactical game of disabling enemy capabilities.
+- Engineering loop gains urgency through targeted damage responses.
+
+---
+
+## 🧭 Phased Delivery (4–6 Weeks)
+
+### **Phase 1 — Damage Core**
+- Define subsystem health schema.
+- Wire damage application pipeline for hits and AoE.
+- Update telemetry to expose subsystem states.
+
+### **Phase 2 — Heat Model**
+- Add heat variables per ship/system.
+- Implement heat generation/dissipation rules.
+- Wire overheat penalties into system performance.
+
+### **Phase 3 — Sub-Targeting**
+- Add sub-target command flow to tactical interface/commands.
+- Route weapon damage to selected subsystems.
+- Update telemetry and event messages for targeted hits.
+
+### **Phase 4 — Balance & Validation**
+- Tune damage/heat thresholds for gameplay pacing.
+- Add regression tests for damage/heat and subsystem targeting flows.
+- Update docs and scenario hints to reflect new mechanics.
+
+---
+
+## ✅ Acceptance Criteria
+
+- Subsystem damage changes ship behavior in meaningful ways.
+- Heat is a limiting resource that requires active management.
+- Weapons can disable subsystems via sub-targeting.
+- Existing weapons/sensor behaviors remain stable and deterministic.
+
+---
+
+## 📌 Out of Scope (Deferred)
+
+- Drones and multi-weapon mounts (S5).
+- Advanced AI doctrine (S5).
+- Replay viewer and CI/CD (S6).
+


### PR DESCRIPTION
### Motivation
- Provide a concise roadmap for v0.6.0 to complete Engineering and Weapons gameplay loops (damage, heat, and sub-targeting) and align upcoming development work.

### Description
- Add `docs/NEXT_RELEASE_PLAN.md` containing phased objectives for subsystem damage, heat management, and sub-targeting, and link the new plan from `README.md`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697941ae037883248836a3feed8ecff6)