### PR TITLE
Report subsystem heat from propulsion, weapons and power; apply heat effects

### DIFF
--- a/hybrid/ship.py
+++ b/hybrid/ship.py
@@ -195,6 +195,11 @@ class Ship:
                     system.tick(dt, self, self.event_bus)
                 except Exception as e:
                     logger.error(f"Error in system {system_type} tick: {e}")
+            if hasattr(system, "report_heat") and callable(system.report_heat):
+                try:
+                    system.report_heat(self, self.event_bus)
+                except Exception as e:
+                    logger.error(f"Error reporting heat for system {system_type}: {e}")
 
         # v0.6.0: Dissipate heat from all subsystems
         self.damage_model.dissipate_heat(dt, self.event_bus, self.id)

--- a/hybrid/systems/combat/combat_system.py
+++ b/hybrid/systems/combat/combat_system.py
@@ -86,7 +86,7 @@ class CombatSystem(BaseSystem):
 
         # Get weapons damage factor
         if hasattr(ship, 'damage_model'):
-            self._damage_factor = ship.damage_model.get_degradation_factor("weapons")
+            self._damage_factor = ship.damage_model.get_combined_factor("weapons")
         else:
             self._damage_factor = 1.0
 
@@ -157,6 +157,8 @@ class CombatSystem(BaseSystem):
             target_ship=target_ship,
             ship_id=self._ship_ref.id,
             damage_factor=self._damage_factor,
+            damage_model=self._ship_ref.damage_model if hasattr(self._ship_ref, "damage_model") else None,
+            event_bus=self._ship_ref.event_bus if hasattr(self._ship_ref, "event_bus") else None,
         )
 
         if result.get("ok"):

--- a/hybrid/systems/power/reactor.py
+++ b/hybrid/systems/power/reactor.py
@@ -24,6 +24,8 @@ class Reactor:
         self.heat_rate = float(heat_rate or 0.0)
         self.heat_per_kw = float(heat_per_kw or 0.0)
         self.overheat_output_factor = float(overheat_output_factor or 0.5)
+        self.last_generated = 0.0
+        self.last_drawn = 0.0
 
     def _normalize_fuel(self, value):
         if value is None:
@@ -32,6 +34,7 @@ class Reactor:
         return value if value > 0 else None
 
     def tick(self, dt):
+        self.last_generated = 0.0
         self._cool(dt)
 
         if self._is_depleted():
@@ -45,6 +48,7 @@ class Reactor:
             generated = self._consume_fuel_for_output(generated)
             if generated > 0:
                 self.available = min(self.capacity, self.available + generated)
+                self.last_generated = generated
 
         self._apply_heat_from_output(dt)
 
@@ -61,6 +65,7 @@ class Reactor:
         if self.available >= amount:
             self.available -= amount
             self.temperature += amount * self.heat_per_kw
+            self.last_drawn += amount
             return True
         return False
 

--- a/hybrid/systems/weapons/truth_weapons.py
+++ b/hybrid/systems/weapons/truth_weapons.py
@@ -392,7 +392,9 @@ class TruthWeapon:
         power_manager,
         target_ship=None,
         ship_id: str = None,
-        damage_factor: float = 1.0
+        damage_factor: float = 1.0,
+        damage_model=None,
+        event_bus=None,
     ) -> Dict:
         """Attempt to fire the weapon.
 
@@ -446,6 +448,11 @@ class TruthWeapon:
             self.ammo -= 1
 
         self.heat += 10.0 * (1.0 / max(0.5, damage_factor))
+        if damage_model is not None:
+            heat_scale = self.specs.subsystem_damage / max(1.0, self.specs.base_damage)
+            heat_amount = self.specs.power_per_shot * (1.0 + heat_scale)
+            if heat_amount > 0:
+                damage_model.add_heat("weapons", heat_amount, event_bus, ship_id)
 
         # Determine hit
         import random


### PR DESCRIPTION
### Motivation
- Add runtime heat accounting so active systems increase subsystem heat based on real activity and trigger overheat penalties. 
- Ensure damage/heat factors are combined into system performance so overheating degrades propulsion, power and weapons as intended. 

### Description
- Added a per-system heat hook in `Ship.tick()` that calls `report_heat()` on systems after their `tick()` to allow systems to report generated heat. 
- Propulsion now records last thrust magnitude and `dt`, computes heat from thrust using the subsystem `heat_generation` and reports it via `damage_model.add_heat()` in `hybrid/systems/propulsion_system.py`. 
- Weapons now add heat per shot for both the simple `Weapon` (`hybrid/systems/weapons/weapon_system.py`) and physics `TruthWeapon` (`hybrid/systems/weapons/truth_weapons.py`) and pass `damage_model`/`event_bus` so `damage_model.add_heat()` is invoked on fire. 
- Power generation and reactors track generated/drawn energy (`last_generated`, `last_drawn`) and the `PowerSystem` and `PowerManagementSystem` aggregate that output into heat using the `power` subsystem `heat_generation` and call `damage_model.add_heat()`. 
- Systems that used damage-only degradation now use the combined damage+heat factor via `damage_model.get_combined_factor()` (propulsion, weapons, combat, power). 
- Added integration regression tests in `tests/systems/test_damage_model_v060.py` (`TestSystemHeatIntegration`) to validate propulsion and weapon heat generation and that overheat penalties affect propulsion output.

### Testing
- Ran `pytest tests/systems/test_damage_model_v060.py` which executed the suite and all tests passed (`27 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979ca464e848324a256366607bb363a)