### PR TITLE
Expose subsystem targeting to commands, weapons, and telemetry

### DIFF
--- a/hybrid/command_handler.py
+++ b/hybrid/command_handler.py
@@ -51,6 +51,7 @@ system_commands = {
     "get_target_solution": ("targeting", "get_solution"),
     "get_weapon_solution": ("targeting", "get_weapon_solution"),
     "best_weapon": ("targeting", "best_weapon"),
+    "set_target_subsystem": ("targeting", "set_target_subsystem"),
     # Legacy weapon system
     "fire_weapon": ("weapons", "fire"),
     # Combat system commands (Sprint C - truth weapons)

--- a/hybrid/commands/weapon_commands.py
+++ b/hybrid/commands/weapon_commands.py
@@ -8,16 +8,31 @@ from hybrid.utils.errors import success_dict, error_dict, no_target_error
 def cmd_fire(weapons, ship, params):
     """Fire a weapon."""
     weapon_type = params.get("weapon_type", "primary")
+    target_subsystem = params.get("target_subsystem")
 
     # Check if target is locked
-    target_id = getattr(ship, "target_id", None)
+    targeting = ship.systems.get("targeting")
+    target_id = params.get("target") or getattr(ship, "target_id", None)
+    if targeting and getattr(targeting, "locked_target", None):
+        target_id = target_id or targeting.locked_target
+    if target_subsystem is None and targeting and hasattr(targeting, "target_subsystem"):
+        target_subsystem = targeting.target_subsystem
     if not target_id:
         return no_target_error()
 
     if weapons and hasattr(weapons, "fire"):
         return weapons.fire({
             "weapon_type": weapon_type,
-            "target": target_id
+            "target": target_id,
+            "target_subsystem": target_subsystem,
+        })
+    if weapons and hasattr(weapons, "command"):
+        return weapons.command("fire", {
+            "weapon": weapon_type,
+            "weapon_type": weapon_type,
+            "target": target_id,
+            "target_subsystem": target_subsystem,
+            "ship": ship,
         })
 
     return error_dict("NOT_IMPLEMENTED", "Weapons system not available")
@@ -54,7 +69,9 @@ def register_commands(dispatcher):
         handler=cmd_fire,
         args=[
             ArgSpec("weapon_type", "str", required=False, default="primary",
-                    description="Weapon type to fire (primary, secondary, torpedo, etc.)")
+                    description="Weapon type to fire (primary, secondary, torpedo, etc.)"),
+            ArgSpec("target_subsystem", "str", required=False,
+                    description="Subsystem to target (optional)")
         ],
         help_text="Fire weapon at locked target",
         system="weapons"

--- a/hybrid/systems/combat/combat_system.py
+++ b/hybrid/systems/combat/combat_system.py
@@ -119,7 +119,7 @@ class CombatSystem(BaseSystem):
                 sim_time=self._sim_time,
             )
 
-    def fire_weapon(self, weapon_id: str, target_ship=None) -> dict:
+    def fire_weapon(self, weapon_id: str, target_ship=None, target_subsystem: str = None) -> dict:
         """Fire a specific weapon.
 
         Args:
@@ -150,6 +150,11 @@ class CombatSystem(BaseSystem):
                 # This will be passed in via params
                 pass
 
+        if target_subsystem is None:
+            targeting = self._ship_ref.systems.get("targeting")
+            if targeting and hasattr(targeting, "target_subsystem"):
+                target_subsystem = targeting.target_subsystem
+
         # Fire!
         result = weapon.fire(
             sim_time=self._sim_time,
@@ -159,6 +164,7 @@ class CombatSystem(BaseSystem):
             damage_factor=self._damage_factor,
             damage_model=self._ship_ref.damage_model if hasattr(self._ship_ref, "damage_model") else None,
             event_bus=self._ship_ref.event_bus if hasattr(self._ship_ref, "event_bus") else None,
+            target_subsystem=target_subsystem,
         )
 
         if result.get("ok"):
@@ -273,7 +279,8 @@ class CombatSystem(BaseSystem):
                 all_ships = params.get("all_ships", {})
                 target_ship = all_ships.get(target_id)
 
-            return self.fire_weapon(weapon_id, target_ship)
+            target_subsystem = params.get("target_subsystem")
+            return self.fire_weapon(weapon_id, target_ship, target_subsystem)
 
         elif action == "fire_all":
             target_ship = None

--- a/hybrid/systems/weapons/truth_weapons.py
+++ b/hybrid/systems/weapons/truth_weapons.py
@@ -395,6 +395,7 @@ class TruthWeapon:
         damage_factor: float = 1.0,
         damage_model=None,
         event_bus=None,
+        target_subsystem: str = None,
     ) -> Dict:
         """Attempt to fire the weapon.
 
@@ -468,16 +469,18 @@ class TruthWeapon:
             effective_damage = self.specs.base_damage * damage_factor
             subsystem_damage = self.specs.subsystem_damage * damage_factor
 
+            subsystem_target = target_subsystem or self._select_subsystem_target()
+
             # Apply to target
             if hasattr(target_ship, 'take_damage'):
                 damage_result = target_ship.take_damage(
                     effective_damage,
-                    source=f"{ship_id}:{self.specs.name}"
+                    source=f"{ship_id}:{self.specs.name}",
+                    target_subsystem=subsystem_target,
                 )
 
             # Apply subsystem damage
             if hasattr(target_ship, 'damage_model'):
-                subsystem_target = self._select_subsystem_target()
                 target_ship.damage_model.apply_damage(
                     subsystem_target, subsystem_damage
                 )

--- a/hybrid/telemetry.py
+++ b/hybrid/telemetry.py
@@ -47,6 +47,11 @@ def get_ship_telemetry(ship, sim_time: float = None) -> Dict[str, Any]:
 
     # Get targeting data
     target_id = getattr(ship, "target_id", None)
+    target_subsystem = getattr(ship, "target_subsystem", None)
+    targeting = ship.systems.get("targeting")
+    if targeting:
+        target_id = target_id or getattr(targeting, "locked_target", target_id)
+        target_subsystem = getattr(targeting, "target_subsystem", target_subsystem)
 
     # Get navigation mode
     nav = ship.systems.get("navigation")
@@ -90,6 +95,7 @@ def get_ship_telemetry(ship, sim_time: float = None) -> Dict[str, Any]:
         },
         "delta_v_remaining": delta_v_remaining,
         "target_id": target_id,
+        "target_subsystem": target_subsystem,
         "nav_mode": nav_mode,
         "autopilot_program": autopilot_program,
         "helm_queue": helm_queue,

--- a/server/stations/station_telemetry.py
+++ b/server/stations/station_telemetry.py
@@ -38,8 +38,8 @@ class StationTelemetryFilter:
             # Tactical displays
             "weapons_status": ["weapons"],
             "ammunition": ["weapons"],
-            "target_info": ["target_id"],
-            "targeting_status": ["target_id"],
+            "target_info": ["target_id", "target_subsystem"],
+            "targeting_status": ["target_id", "target_subsystem"],
 
             # Operations displays
             "contacts": ["sensors"],

--- a/server/stations/station_types.py
+++ b/server/stations/station_types.py
@@ -92,6 +92,7 @@ STATION_DEFINITIONS: Dict[StationType, StationDefinition] = {
             "lock_target",
             "unlock_target",
             "get_target_solution",
+            "set_target_subsystem",
             "fire_weapon",
         },
         displays={


### PR DESCRIPTION
### Motivation
- Allow Tactical to select a specific subsystem to target so firing solutions and damage application can be subsystem-directed. 
- Surface the selected subsystem across the targeting state and firing solutions so UI/clients can display and act on the selection. 
- Ensure weapons and combat paths forward the selection so `Ship.take_damage` receives a `target_subsystem` to apply targeted subsystem damage.

### Description
- Add `target_subsystem` state and management in the targeting system and new API method `set_target_subsystem` and accept `target_subsystem` in `lock` commands via `TargetingSystem` (`hybrid/systems/targeting/targeting_system.py`).
- Extend sensor commands with optional `target_subsystem` on `target` and add `target_subsystem` / `set_target_subsystem` command handlers (`hybrid/commands/sensor_commands.py`).
- Propagate `target_subsystem` from command layer into weapons paths by updating weapon command handling (`hybrid/commands/weapon_commands.py`), legacy `WeaponSystem` (`hybrid/systems/weapons/weapon_system.py`), truth weapons (`hybrid/systems/weapons/truth_weapons.py`), and `CombatSystem` (`hybrid/systems/combat/combat_system.py`) so they pass `target_subsystem` into `Ship.take_damage` and `DamageModel.apply_damage` when present.
- Expose `target_subsystem` in telemetry and station filters so Tactical displays can receive it (`hybrid/telemetry.py`, `server/stations/station_telemetry.py`, `server/stations/station_types.py`).
- Wire dispatcher/command routing to accept `set_target_subsystem` and register the commands (`hybrid/command_handler.py`, command registrations in sensor/weapon modules).
- Add an integration test `test_targeted_subsystem_damage_via_command` to `tests/systems/combat/test_combat_system.py` that locks, selects a subsystem, fires, and asserts subsystem health was reduced.

### Testing
- Ran `pytest tests/systems/combat/test_combat_system.py` and all tests passed: 22 passed, 0 failed. 
- The new test verifies that issuing `lock_target` + `set_target_subsystem` and then `fire_weapon` results in damage applied to the specified subsystem. 
- Unit and integration behavior exercised includes command routing, targeting state propagation, weapon fire paths, and telemetry exposure for Tactical.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979cc2b58a08324bdf559f3c1d14d0e)