### PR TITLE
Make intercept playable via mission system (add mission_kill objectives)

### DIFF
--- a/scenarios/06_intercept_mission.yaml
+++ b/scenarios/06_intercept_mission.yaml
@@ -1,0 +1,204 @@
+# Combat Mission: Intercept and disable an enemy corvette
+
+name: "Intercept: Mission Kill"
+description: "Intercept and disable a hostile corvette by achieving a mission kill."
+
+dt: 0.1
+
+ships:
+  - id: "player_ship"
+    name: "UNS Hunter"
+    class: "frigate"
+    faction: "unsa"
+    mass: 2500.0
+    max_hull_integrity: 250.0
+    hull_integrity: 250.0
+    ai_enabled: false
+    position:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+    velocity:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+    orientation:
+      pitch: 0.0
+      yaw: 45.0
+      roll: 0.0
+    systems:
+      propulsion:
+        enabled: true
+        power_draw: 80
+        mass: 350
+        main_drive:
+          thrust: {x: 0.0, y: 0.0, z: 0.0}
+          max_thrust: 400.0
+      rcs:
+        enabled: true
+        max_torque: 50.0
+        attitude_rate: 15.0
+      sensors:
+        enabled: true
+        power_draw: 25
+        passive:
+          range: 40000.0
+        active:
+          scan_range: 80000.0
+          cooldown_time: 4.0
+        signature_base: 1.3
+      navigation:
+        enabled: true
+        power_draw: 10
+      targeting:
+        enabled: true
+        lock_time: 1.5
+        lock_range: 80000.0
+      combat:
+        enabled: true
+        railguns: 2
+        pdcs: 4
+      weapons:
+        enabled: true
+        power_draw: 40
+        weapons:
+          - name: "torpedo"
+            power_cost: 30
+            max_heat: 80
+            ammo: 8
+            damage: 50.0
+      power_management:
+        primary: {output: 150.0}
+        secondary: {output: 80.0}
+        tertiary: {output: 40.0}
+        system_map:
+          propulsion: "primary"
+          weapons: "primary"
+          combat: "primary"
+          sensors: "secondary"
+          targeting: "secondary"
+          rcs: "secondary"
+          navigation: "tertiary"
+    damage_model:
+      propulsion: {max_health: 100.0, health: 100.0}
+      rcs: {max_health: 80.0, health: 80.0}
+      weapons: {max_health: 90.0, health: 90.0}
+      sensors: {max_health: 70.0, health: 70.0}
+
+  - id: "enemy_corvette"
+    name: "Pirate Raider"
+    class: "corvette"
+    faction: "hostile"
+    mass: 1500.0
+    max_hull_integrity: 150.0
+    hull_integrity: 150.0
+    ai_enabled: true
+    position:
+      x: 25000.0
+      y: 15000.0
+      z: 5000.0
+    velocity:
+      x: -50.0
+      y: 30.0
+      z: 10.0
+    orientation:
+      pitch: 5.0
+      yaw: 210.0
+      roll: 0.0
+    systems:
+      propulsion:
+        enabled: true
+        power_draw: 50
+        mass: 200
+        main_drive:
+          thrust: {x: 0.0, y: 0.0, z: 0.0}
+          max_thrust: 250.0
+      rcs:
+        enabled: true
+        max_torque: 30.0
+        attitude_rate: 20.0
+      sensors:
+        enabled: true
+        power_draw: 15
+        passive:
+          range: 25000.0
+        active:
+          scan_range: 50000.0
+          cooldown_time: 5.0
+        signature_base: 0.9
+      navigation:
+        enabled: true
+        power_draw: 8
+      targeting:
+        enabled: true
+        lock_time: 2.0
+        lock_range: 60000.0
+      combat:
+        enabled: true
+        railguns: 1
+        pdcs: 2
+      weapons:
+        enabled: true
+        power_draw: 25
+        weapons:
+          - name: "torpedo"
+            power_cost: 25
+            max_heat: 60
+            ammo: 4
+            damage: 40.0
+      power_management:
+        primary: {output: 100.0}
+        secondary: {output: 50.0}
+        tertiary: {output: 25.0}
+        system_map:
+          propulsion: "primary"
+          weapons: "primary"
+          combat: "primary"
+          sensors: "secondary"
+          targeting: "secondary"
+          rcs: "secondary"
+          navigation: "tertiary"
+    damage_model:
+      propulsion: {max_health: 80.0, health: 80.0}
+      rcs: {max_health: 60.0, health: 60.0}
+      weapons: {max_health: 70.0, health: 70.0}
+      sensors: {max_health: 50.0, health: 50.0}
+
+mission:
+  name: "Intercept and Disable"
+  description: "Disable the hostile corvette by achieving a mission kill."
+
+  briefing: |
+    MISSION: Intercept hostile corvette "Pirate Raider".
+
+    Objective:
+    - Disable the target's propulsion or weapons systems.
+    - Maintain your ship's combat readiness.
+
+    Tactical notes:
+    - Use railguns at range for subsystem damage.
+    - PDCs are effective for close defense.
+    - A mission kill is achieved when the target loses mobility or firepower.
+
+  objectives:
+    - id: "mission_kill_target"
+      type: "mission_kill"
+      description: "Achieve mission kill on the enemy corvette"
+      required: true
+      params:
+        target: "enemy_corvette"
+
+    - id: "avoid_mission_kill"
+      type: "avoid_mission_kill"
+      description: "Avoid being mission killed"
+      required: true
+      params:
+        target: "player_ship"
+
+  success_message: |
+    Target disabled. Mission accomplished.
+
+    The enemy corvette has suffered a mission kill. Return to base.
+
+  failure_message: |
+    Mission failed. Your ship was mission killed.


### PR DESCRIPTION
### Motivation

- Convert the legacy intercept scenario into the mission system so the scenario can be played and evaluated by the `Mission`/`ObjectiveTracker` machinery.  
- Support mission-style win/fail logic for mission kills (disable mobility or weapons) and for avoiding being mission killed.

### Description

- Extended `ObjectiveType` with `MISSION_KILL` and `AVOID_MISSION_KILL` and wired them into `Objective.check()` to allow mission-file objectives to reference them (`hybrid/scenarios/objectives.py`).
- Implemented `_check_mission_kill` and `_check_avoid_mission_kill` to evaluate mission-kill state using each ship's `damage_model` (`is_mission_kill`, `get_degradation_factor`) and hull/destruction state, and passed the `ObjectiveTracker` into checks where needed.
- Added a mission-based intercept scenario file at `scenarios/06_intercept_mission.yaml` using the `mission` block and the new objective types.
- Updated tests `tests/systems/combat/test_combat_system.py` to load the mission YAML via `ScenarioLoader` and assert mission success/failure by applying damage to the ships' `DamageModel`.

### Testing

- Ran the intercept-focused tests with `pytest tests/systems/combat/test_combat_system.py -k intercept`, which selected and ran the updated intercept tests and reported `2 passed`.
- The modified test suite exercises scenario loading via `ScenarioLoader` and mission evaluation via `Mission`/`ObjectiveTracker` and the `DamageModel` helpers, and all assertions in the intercept tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979cfacb0688324acfc5be7437b337b)