### PR TITLE
Changelog: mark damage & heat foundations as Added (v0.6.0, commit 5abe7ae)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Quaternion API documentation in `docs/QUATERNION_API.md`.
 - RCS configuration guide for ship thruster YAML in `docs/RCS_CONFIGURATION_GUIDE.md`.
 - Physics update documentation for Sprint S3 in `docs/PHYSICS_UPDATE.md`.
+- Subsystem damage model foundation (v0.6.0 Phase 1 damage core foundation, commit `5abe7ae`).
+- Heat management system foundation (v0.6.0 Phase 1 damage core foundation, commit `5abe7ae`; heat generation wiring pending).
 
 ### Fixed
 - Captain station claims now auto-elevate permissions for override actions.
@@ -26,8 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Planned
 - Quaternion-based attitude system (Sprint S3)
 - RCS thruster torque calculations (Sprint S3)
-- Subsystem damage model (Sprint S4)
-- Heat management system (Sprint S4)
 - Advanced AI behaviors (Sprint S5)
 - Replay viewer (Sprint S6)
 


### PR DESCRIPTION
### Motivation
- Align the changelog with the implemented damage/heat foundations introduced as part of the Phase 1 damage core work. 
- Preserve accuracy by noting that heat generation wiring is not yet completed. 

### Description
- Updated `CHANGELOG.md` to move “Subsystem damage model” and “Heat management system” into the `Unreleased` `Added` list. 
- The entries reference the Phase 1 damage core foundation with commit `5abe7ae` and explicitly note that heat generation wiring is pending. 
- Removed the duplicate `Planned` entries for the subsystem damage model and heat management system. 

### Testing
- No automated tests were run because this is a documentation-only change to `CHANGELOG.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979d252991c8324a3fe95077652cce7)