### PR TITLE
Expose ship list to systems during tick

### DIFF
--- a/hybrid/ship.py
+++ b/hybrid/ship.py
@@ -181,6 +181,8 @@ class Ship:
             all_ships (list, optional): List of all ships in simulation
             sim_time (float): Current simulation time
         """
+        self._all_ships_ref = all_ships or []
+
         # Update AI controller if enabled
         if self.ai_enabled and self.ai_controller:
             try:

--- a/hybrid/simulator.py
+++ b/hybrid/simulator.py
@@ -188,6 +188,7 @@ class Simulator:
 
         for ship in all_ships:
             try:
+                ship._all_ships_ref = all_ships
                 ship.tick(self.dt, all_ships, self.time)
             except Exception as e:
                 logger.error(f"Error in ship {ship.id} tick: {e}")


### PR DESCRIPTION
### Motivation
- Systems (notably sensors) need access to the current list of ships as soon as the first tick runs so passive/active detection and contact tracking work immediately (e.g., tutorial `target_station` should appear in contacts). 

### Description
- In `hybrid/simulator.py` assign `ship._all_ships_ref = all_ships` before calling `ship.tick(...)` so every ship has the current ship list available during its tick. 
- In `hybrid/ship.py` persist the passed `all_ships` at the top of `Ship.tick` with `self._all_ships_ref = all_ships or []` so systems can read the reference reliably. 

### Testing
- Ran a short integration script that loads `scenarios/01_tutorial_intercept.yaml`, adds ships to a `Simulator`, starts it, calls `tick()`, and inspected `player.systems['sensors'].all_ships` and then executed `sensor.ping(...)` followed by another `tick()` which populated `sensor.contact_tracker.id_mapping`; the sensor saw both ships and mapped `target_station` to `C001`, indicating success. 
- The test script completed without errors and produced the expected contacts mapping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979d912ce10832484495eab295c69ce)