### PR TITLE
Add `set_plan` and `set_power_allocation` station permissions and register power allocation command

### DIFF
--- a/hybrid/command_handler.py
+++ b/hybrid/command_handler.py
@@ -43,6 +43,7 @@ system_commands = {
     "helm_queue_status": ("helm", "queue_status"),
     "ping_sensors": ("sensors", "ping"),
     "override_bio_monitor": ("bio_monitor", "override"),
+    "set_power_allocation": ("power_management", "set_power_allocation"),
     "request_docking": ("docking", "request_docking"),
     "cancel_docking": ("docking", "cancel_docking"),
     # Targeting commands (Sprint C)

--- a/server/stations/station_types.py
+++ b/server/stations/station_types.py
@@ -66,6 +66,7 @@ STATION_DEFINITIONS: Dict[StationType, StationDefinition] = {
             "rcs_angular_velocity",
             "rcs_clear",
             "set_course",
+            "set_plan",
             "autopilot",
             "helm_override",
             "queue_helm_command",
@@ -124,6 +125,7 @@ STATION_DEFINITIONS: Dict[StationType, StationDefinition] = {
             "override_bio_monitor",
             "set_power_profile",
             "get_power_profiles",
+            "set_power_allocation",
         },
         displays={
             "power_grid", "reactor_status", "system_status",


### PR DESCRIPTION
### Motivation
- Enable Helm to issue `set_plan` and Engineering to issue `set_power_allocation`, and ensure `set_power_allocation` is routed to the ship `power_management` system so the station-aware dispatcher can register and enforce permissions (Captain still inherits via `all_commands`).

### Description
- Updated `server/stations/station_types.py` to add `"set_plan"` to `StationType.HELM` command set and `"set_power_allocation"` to `StationType.ENGINEERING` command set.
- Updated `hybrid/command_handler.py` `system_commands` mapping to include `"set_power_allocation": ("power_management", "set_power_allocation")` so legacy command registration picks it up and routes to the power system.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979dada827c8324a64007c53be5c47b)