### PR TITLE
Improve GUI connection handling and surface errors for scenario, power, and flight controls

### DIFF
--- a/gui/components/flight-computer.js
+++ b/gui/components/flight-computer.js
@@ -602,6 +602,7 @@ class FlightComputer extends HTMLElement {
       statusEl.className = "solution-status invalid";
       statusEl.textContent = "ERROR";
       this.shadowRoot.getElementById("execute-btn").disabled = true;
+      this._showMessage(`Flight computer error: ${error.message}`, "error");
     }
 
     this._updateSolutionDisplay();


### PR DESCRIPTION
### Motivation
- Prevent silent failures when the GUI is disconnected by guarding scenario list/load actions with connection checks and giving users visible feedback.
- Surface failures from websocket `send`/`sendShipCommand` calls to the user instead of only logging to the console, so operators can react to command failures.
- Replace console-only flight computer errors with visible toasts so computation errors are noticed immediately in the UI.

### Description
- `gui/components/scenario-loader.js`: added a connection hint UI element, bound to `wsClient` `status_change` events, and guarded `_loadScenarios()` and `_loadScenario()` to check `wsClient.status !== 'connected'` (attempts `await wsClient.connect()` and shows a warning/error via `system-messages` when unavailable), plus cleanup in `disconnectedCallback()`.
- `gui/components/power-management.js`: added an `allocation-feedback` element and `_setAllocationFeedback()` helper, replaced silent `console.error` handling with promise handlers that show toasts via `system-messages` and update the feedback line when `wsClient.sendShipCommand('set_power_allocation', ...)` succeeds or fails.
- `gui/components/flight-computer.js`: when `_compute()` throws, the error now triggers a visible message via the existing `_showMessage()` helper in addition to updating the solution status element.
- Added small helper `_showMessage()` usage in modified components so failures are surfaced consistently to the `system-messages` component.

### Testing
- Launched a local static server for the GUI with `python -m http.server 8000` to serve files for manual/visual checks (server started successfully).
- Attempted an automated screenshot via Playwright to capture the scenario panel, but the Playwright/browser launch crashed in this environment (SIGSEGV) and the screenshot run failed.
- No unit or integration test suite was executed against the modified code in this rollout; manual UI validation is recommended after deploying the changes to a running server + websocket bridge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979dd068564832483805dc1823e37b2)