### PR TITLE
Ensure sensors initialize contacts on first tick

### DIFF
--- a/hybrid/ship.py
+++ b/hybrid/ship.py
@@ -181,7 +181,14 @@ class Ship:
             all_ships (list, optional): List of all ships in simulation
             sim_time (float): Current simulation time
         """
-        self._all_ships_ref = all_ships or []
+        if all_ships is None:
+            resolved_all_ships = [self]
+        elif isinstance(all_ships, dict):
+            resolved_all_ships = list(all_ships.values())
+        else:
+            resolved_all_ships = all_ships
+        self._all_ships_ref = resolved_all_ships
+        self.sim_time = sim_time
 
         # Update AI controller if enabled
         if self.ai_enabled and self.ai_controller:

--- a/hybrid/systems/sensors/passive.py
+++ b/hybrid/systems/sensors/passive.py
@@ -49,6 +49,7 @@ class PassiveSensor:
         if current_tick - self.last_update_tick < self.update_interval:
             return
 
+        initial_scan = self.last_update_tick < 0
         self.last_update_tick = current_tick
 
         # Scan for contacts
@@ -79,10 +80,11 @@ class PassiveSensor:
             # Passive detection has additional probability factor
             detection_probability = min(0.95, accuracy ** 2)  # Squared for lower passive detection
 
-            # Random detection check
-            import random
-            if random.random() > detection_probability:
-                continue
+            # Random detection check (skip on initial scan to populate contacts immediately)
+            if not initial_scan:
+                import random
+                if random.random() > detection_probability:
+                    continue
 
             # Create contact with noise
             noisy_position = add_detection_noise(target_ship.position, accuracy)


### PR DESCRIPTION
### Motivation
- Ships' systems need a consistent, non-empty reference to all ships and the current simulation time on their first tick so sensors and other systems can operate immediately.
- The tutorial scenario expects the `target_station` to appear in sensor contacts on the first tick without waiting for a probabilistic passive scan.

### Description
- Normalize `all_ships` inside `Ship.tick` by resolving dicts/lists and falling back to a single-entry list, and store `sim_time` on the ship so subsystems can read it (`hybrid/ship.py`).
- Make passive sensors populate contacts deterministically on the initial scan by skipping the random detection check for the first update interval (`hybrid/systems/sensors/passive.py`).

### Testing
- Ran a scenario-based integration test using `ScenarioLoader`/`Simulator` and executed one tick; the player ship received a non-empty `_all_ships_ref` and the sensors produced a contact mapping (id mapping contained the `target_station`), indicating successful detection on first tick (test succeeded).
- Re-ran the script to inspect `contact_tracker.id_mapping` and confirmed `{'target_station': 'C001'}` was created (test succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bde1efadc83249506f650ad87f3c7)