### PR TITLE
Fix legacy wrapper to explicitly detect command errors

### DIFF
--- a/server/stations/station_dispatch.py
+++ b/server/stations/station_dispatch.py
@@ -210,8 +210,15 @@ def create_legacy_command_wrapper(runner, command_name: str) -> CommandHandler:
             # Convert legacy response format to CommandResult
             if isinstance(response, dict):
                 # Legacy responses have various formats, try to normalize
-                success = response.get("status") != "error"
-                message = response.get("status", response.get("message", "OK"))
+                has_error_key = "error" in response
+                is_error_status = response.get("status") == "error"
+                success = not (has_error_key or is_error_status)
+
+                if success:
+                    message = response.get("message") or response.get("status") or "OK"
+                else:
+                    message = response.get("error") or "Command failed"
+
                 return CommandResult(
                     success=success,
                     message=str(message),

--- a/tests/stations/test_station_dispatch.py
+++ b/tests/stations/test_station_dispatch.py
@@ -1,0 +1,62 @@
+"""Tests for station dispatcher legacy command wrapper behavior."""
+
+from types import SimpleNamespace
+
+from server.stations.station_dispatch import create_legacy_command_wrapper
+
+
+def _make_runner_with_ship(ship_id: str = "ship_1"):
+    """Create minimal runner stub with a single ship registered."""
+    ship = SimpleNamespace(id=ship_id)
+    ships = {ship_id: ship}
+    runner = SimpleNamespace(simulator=SimpleNamespace(ships=ships))
+    return runner
+
+
+def test_legacy_wrapper_treats_error_key_as_failure(monkeypatch):
+    """Responses with an explicit error field should be failures."""
+    runner = _make_runner_with_ship()
+
+    def fake_route_command(ship, command_data):
+        return {"error": "navigation offline"}
+
+    monkeypatch.setattr("hybrid.command_handler.route_command", fake_route_command)
+
+    wrapper = create_legacy_command_wrapper(runner, "set_course")
+    result = wrapper("client_1", "ship_1", {})
+
+    assert result.success is False
+    assert result.message == "navigation offline"
+
+
+def test_legacy_wrapper_treats_error_status_as_failure(monkeypatch):
+    """Responses with status=error should be failures."""
+    runner = _make_runner_with_ship()
+
+    def fake_route_command(ship, command_data):
+        return {"status": "error", "message": "ignored", "detail": "bad route"}
+
+    monkeypatch.setattr("hybrid.command_handler.route_command", fake_route_command)
+
+    wrapper = create_legacy_command_wrapper(runner, "set_course")
+    result = wrapper("client_1", "ship_1", {})
+
+    assert result.success is False
+    assert result.message == "Command failed"
+
+
+def test_legacy_wrapper_treats_successful_dict_as_success(monkeypatch):
+    """Responses without error indicators should be treated as success."""
+    runner = _make_runner_with_ship()
+
+    def fake_route_command(ship, command_data):
+        return {"status": "queued", "message": "Course set"}
+
+    monkeypatch.setattr("hybrid.command_handler.route_command", fake_route_command)
+
+    wrapper = create_legacy_command_wrapper(runner, "set_course")
+    result = wrapper("client_1", "ship_1", {})
+
+    assert result.success is True
+    assert result.message == "Course set"
+


### PR DESCRIPTION
### Motivation
- The legacy command wrapper inferred success ambiguously from `status`, which could misclassify explicit error responses.
- Make error detection deterministic by treating explicit `"error"` keys and `status == "error"` as failures.

### Description
- Updated `create_legacy_command_wrapper()` in `server/stations/station_dispatch.py` to treat a dict response as failure when it contains an `"error"` key or when `response.get("status") == "error"` and to set `success` accordingly.
- Standardized `message` selection to use `response["error"]` (when failure), otherwise `response.get("message")`, then `response.get("status")`, then `"OK"` for successes, and default to `"Command failed"` when no error text is available.
- Added tests in `tests/stations/test_station_dispatch.py` that cover the three shapes: `{"error": "..."}`, `{"status": "error", ...}`, and a successful dict response, while preserving non-dict response handling.

### Testing
- Ran `pytest -q tests/stations/test_station_dispatch.py tests/stations/test_station_commands.py` and the targeted tests passed (all tests in the run succeeded).
- Ran the full stations test suite with `pytest -q tests/stations` and all tests passed, indicating no callers relied on the old ambiguous behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698556322dc083249a677a75f443be48)