### PR TITLE
Refactor command handler ship lookup to single canonical helper

### DIFF
--- a/commands/handlers.py
+++ b/commands/handlers.py
@@ -1,24 +1,23 @@
 # handlers.py
 
-def find_ship(ship_id, sectors):
-    for sector_coords, sector in sectors.items():
-        print(f"[DEBUG] Checking sector {sector_coords}")
-        ships = sector.get("ships", {})
-        if ship_id in ships:
-            print(f"[DEBUG] Found ship '{ship_id}' in sector {sector_coords}")
-            return ships[ship_id]
-    print(f"[DEBUG] Ship '{ship_id}' not found in any sector")
-    return None
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def truncate(d, decimals=2):
     return {k: round(v, decimals) for k, v in d.items()}
 
+
 def find_ship(ship_id, sectors):
     for sector_coords, sector in sectors.items():
+        logger.debug("Checking sector %s", sector_coords)
         ships = sector.get("ships", {})
         if ship_id in ships:
+            logger.debug("Found ship '%s' in sector %s", ship_id, sector_coords)
             return ships[ship_id]
+    logger.debug("Ship '%s' not found in any sector", ship_id)
     return None
 
 def handle_command(request: dict, sectors: dict) -> dict:

--- a/tests/test_command_handlers.py
+++ b/tests/test_command_handlers.py
@@ -1,0 +1,35 @@
+"""Focused tests for commands.handlers."""
+
+from commands.handlers import handle_command
+
+
+def test_handle_command_finds_ship_across_sectors():
+    """Ship lookup should traverse all sectors until it finds the target ship."""
+    sectors = {
+        (0, 0, 0): {
+            "ships": {
+                "ship_alpha": {
+                    "position": {"x": 1.0, "y": 2.0, "z": 3.0},
+                    "velocity": {"x": 0.1, "y": 0.2, "z": 0.3},
+                }
+            }
+        },
+        (1, 0, 0): {
+            "ships": {
+                "ship_bravo": {
+                    "position": {"x": 4.0, "y": 5.0, "z": 6.0},
+                    "velocity": {"x": 0.4, "y": 0.5, "z": 0.6},
+                }
+            }
+        },
+    }
+
+    result = handle_command(
+        {
+            "command_type": "get_position",
+            "payload": {"ship": "ship_bravo"},
+        },
+        sectors,
+    )
+
+    assert result == {"position": {"x": 4.0, "y": 5.0, "z": 6.0}}


### PR DESCRIPTION
### Motivation
- Remove duplicated `find_ship` implementations to centralize ship lookup logic and avoid maintenance drift. 
- Replace debug `print` calls with configurable logging so verbosity can be controlled through the project's logging configuration.

### Description
- Consolidated ship lookup into one canonical helper `find_ship` in `commands/handlers.py` and removed the duplicate definition. 
- Replaced inline `print` debug statements with a module logger obtained via `logging.getLogger(__name__)` and added `logger.debug` calls inside `find_ship`. 
- Kept `handle_command()` behavior unchanged and ensured it uses the canonical `find_ship` for locating ships. 
- Added a focused test `tests/test_command_handlers.py` that asserts `handle_command()` can find a ship located in a different sector.

### Testing
- Ran the new focused test with `pytest -q tests/test_command_handlers.py` and it passed (`1 passed`). 
- Imported `find_ship` and `handle_command` to verify callability via a small runtime check and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985564717288324b07897534e41f08a)