### PR TITLE
Wire legacy station dispatch wrappers with dynamic all_ships provider

### DIFF
--- a/server/stations/station_dispatch.py
+++ b/server/stations/station_dispatch.py
@@ -5,7 +5,7 @@ Wraps existing command handlers with station permission checks to ensure
 commands are only executed if the client has the appropriate station claim.
 """
 
-from typing import Dict, Any, Callable, Optional, Tuple
+from typing import Dict, Any, Callable, Optional, Tuple, Mapping, Union
 from dataclasses import dataclass
 import logging
 
@@ -176,7 +176,23 @@ class StationAwareDispatcher:
         }
 
 
-def create_legacy_command_wrapper(runner, command_name: str) -> CommandHandler:
+ShipMapProvider = Union[Callable[[], Mapping[str, Any]], Mapping[str, Any]]
+
+
+def _resolve_ship_map(provider: Optional[ShipMapProvider], runner) -> Mapping[str, Any]:
+    """Resolve the current ship map from a provider or runner fallback."""
+    if callable(provider):
+        return provider()
+    if provider is not None:
+        return provider
+    return runner.simulator.ships
+
+
+def create_legacy_command_wrapper(
+    runner,
+    command_name: str,
+    ship_map_provider: Optional[ShipMapProvider] = None,
+) -> CommandHandler:
     """
     Create a wrapper for legacy command handlers that work with the old system.
 
@@ -193,8 +209,10 @@ def create_legacy_command_wrapper(runner, command_name: str) -> CommandHandler:
             # Import here to avoid circular dependency
             from hybrid.command_handler import route_command
 
+            all_ships = _resolve_ship_map(ship_map_provider, runner)
+
             # Get the ship
-            ship = runner.simulator.ships.get(ship_id)
+            ship = all_ships.get(ship_id)
             if not ship:
                 return CommandResult(
                     success=False,
@@ -205,7 +223,7 @@ def create_legacy_command_wrapper(runner, command_name: str) -> CommandHandler:
             command_data = {"command": command_name, **args}
 
             # Route through legacy system
-            response = route_command(ship, command_data)
+            response = route_command(ship, command_data, all_ships)
 
             # Convert legacy response format to CommandResult
             if isinstance(response, dict):
@@ -247,10 +265,16 @@ def register_legacy_commands(dispatcher: StationAwareDispatcher, runner):
     from hybrid.command_handler import system_commands
     from .station_types import get_station_for_command
 
+    ship_map_provider = lambda: runner.simulator.ships
+
     # Register all system commands from the legacy system
     registered_commands = set()
     for command_name, (system, action) in system_commands.items():
-        handler = create_legacy_command_wrapper(runner, command_name)
+        handler = create_legacy_command_wrapper(
+            runner,
+            command_name,
+            ship_map_provider=ship_map_provider,
+        )
         dispatcher.register_command(
             command=command_name,
             handler=handler,
@@ -270,7 +294,11 @@ def register_legacy_commands(dispatcher: StationAwareDispatcher, runner):
         if command not in registered_commands and get_station_for_command(command)
     )
     for command_name in extra_commands:
-        handler = create_legacy_command_wrapper(runner, command_name)
+        handler = create_legacy_command_wrapper(
+            runner,
+            command_name,
+            ship_map_provider=ship_map_provider,
+        )
         dispatcher.register_command(
             command=command_name,
             handler=handler,

--- a/tests/stations/test_station_dispatch_legacy.py
+++ b/tests/stations/test_station_dispatch_legacy.py
@@ -1,0 +1,74 @@
+"""Tests for legacy station dispatch wrappers."""
+
+from types import SimpleNamespace
+
+from server.stations.station_dispatch import (
+    create_legacy_command_wrapper,
+    register_legacy_commands,
+    StationAwareDispatcher,
+)
+from server.stations.station_manager import StationManager
+
+
+def test_create_legacy_command_wrapper_forwards_all_ships_callable(monkeypatch):
+    """Legacy wrapper should pass all_ships from provider to route_command."""
+    ship = SimpleNamespace(id="ship_alpha")
+    all_ships = {"ship_alpha": ship, "ship_bravo": SimpleNamespace(id="ship_bravo")}
+    runner = SimpleNamespace(simulator=SimpleNamespace(ships={}))
+
+    captured = {}
+
+    def fake_route_command(target_ship, command_data, provided_all_ships):
+        captured["target_ship"] = target_ship
+        captured["command_data"] = command_data
+        captured["all_ships"] = provided_all_ships
+        return {"status": "ok", "cross_ship_visible": "ship_bravo" in provided_all_ships}
+
+    monkeypatch.setattr("hybrid.command_handler.route_command", fake_route_command)
+
+    wrapper = create_legacy_command_wrapper(
+        runner,
+        "set_thrust",
+        ship_map_provider=lambda: all_ships,
+    )
+
+    result = wrapper("client_1", "ship_alpha", {"ship": "ship_alpha", "value": 0.75})
+
+    assert result.success is True
+    assert result.data["cross_ship_visible"] is True
+    assert captured["target_ship"] is ship
+    assert captured["all_ships"] is all_ships
+    assert captured["command_data"]["command"] == "set_thrust"
+
+
+def test_register_legacy_commands_wires_dynamic_ship_provider(monkeypatch):
+    """Registered wrappers should resolve all_ships at execution time."""
+    ship_alpha = SimpleNamespace(id="ship_alpha")
+    ships = {"ship_alpha": ship_alpha}
+    runner = SimpleNamespace(simulator=SimpleNamespace(ships=ships))
+    dispatcher = StationAwareDispatcher(StationManager())
+
+    captured = {}
+
+    def fake_route_command(target_ship, command_data, provided_all_ships):
+        captured["target_ship"] = target_ship
+        captured["command_data"] = command_data
+        captured["all_ships"] = provided_all_ships
+        return {"status": "ok"}
+
+    monkeypatch.setattr("hybrid.command_handler.route_command", fake_route_command)
+
+    register_legacy_commands(dispatcher, runner)
+
+    # Add ship after registration; callable provider should expose updated map
+    ship_bravo = SimpleNamespace(id="ship_bravo")
+    ships["ship_bravo"] = ship_bravo
+
+    handler = dispatcher.handlers["set_thrust"]
+    result = handler("client_1", "ship_bravo", {"ship": "ship_bravo", "value": 0.5})
+
+    assert result.success is True
+    assert captured["target_ship"] is ship_bravo
+    assert captured["all_ships"] is ships
+    assert "ship_alpha" in captured["all_ships"]
+    assert "ship_bravo" in captured["all_ships"]


### PR DESCRIPTION
### Motivation
- Legacy command routing needs access to the current ship map so commands that depend on cross-ship context can be executed correctly using `route_command(..., all_ships=...)`.
- The dispatcher must provide the ship map without introducing circular imports and while allowing the map to be dynamic (ships can be added after registration).

### Description
- Added a `ShipMapProvider` type and `_resolve_ship_map()` helper and extended `create_legacy_command_wrapper()` to accept an optional `ship_map_provider` (callable or mapping) and resolve it at execution time.
- Updated the legacy wrapper to look up the ship in the resolved `all_ships` map and to call `route_command(ship, command_data, all_ships)` so `all_ships` is forwarded to legacy routing.
- Wired a dynamic provider (`lambda: runner.simulator.ships`) into every legacy wrapper created by `register_legacy_commands()` so wrappers see an up-to-date ship map at runtime.
- Added tests in `tests/stations/test_station_dispatch_legacy.py` that validate the wrapper forwards `all_ships` and that registration uses a dynamic provider; imports for `hybrid.command_handler` remain localized to avoid circular imports.

### Testing
- Ran `pytest -q tests/stations/test_station_dispatch_legacy.py` and the new tests passed (2 passed).
- Ran `pytest -q tests/stations` and the full station test suite passed (`36 passed`).
- Verified import sanity by importing the modified module successfully with a small runtime check (`python -c "import server.stations.station_dispatch as sd; print('ok')"`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69855644f18083248fcabd3e631fd7c5)