### PR TITLE
Add engineering draw profile command for per-bus power diagnostics

### DIFF
--- a/hybrid/command_handler.py
+++ b/hybrid/command_handler.py
@@ -44,6 +44,7 @@ system_commands = {
     "ping_sensors": ("sensors", "ping"),
     "override_bio_monitor": ("bio_monitor", "override"),
     "set_power_allocation": ("power_management", "set_power_allocation"),
+    "get_draw_profile": ("power_management", "get_draw_profile"),
     "request_docking": ("docking", "request_docking"),
     "cancel_docking": ("docking", "cancel_docking"),
     # Targeting commands (Sprint C)

--- a/server/stations/station_commands.py
+++ b/server/stations/station_commands.py
@@ -372,6 +372,44 @@ def register_station_commands(
             data=power_management.get_profiles()
         )
 
+    def cmd_get_draw_profile(client_id: str, ship_id: str, args: Dict[str, Any]) -> CommandResult:
+        """
+        Return engineering draw profile (supply/requested/delta by power bus).
+        """
+        session = station_manager.get_session(client_id)
+        if not session or not session.ship_id:
+            return CommandResult(
+                success=False,
+                message="Not assigned to a ship"
+            )
+
+        target_ship_id = args.get("ship") or ship_id or session.ship_id
+        if not target_ship_id:
+            return CommandResult(
+                success=False,
+                message="Ship ID required"
+            )
+
+        ship = _resolve_ship(target_ship_id)
+        if not ship:
+            return CommandResult(
+                success=False,
+                message=f"Ship not found: {target_ship_id}"
+            )
+
+        power_management = ship.systems.get("power_management")
+        if not power_management:
+            return CommandResult(
+                success=False,
+                message="Power management system not available"
+            )
+
+        return CommandResult(
+            success=True,
+            message="Power draw profile retrieved",
+            data=power_management.get_draw_profile(ship=ship)
+        )
+
     def cmd_heartbeat(client_id: str, ship_id: str, args: Dict[str, Any]) -> CommandResult:
         """
         Heartbeat to keep session alive.
@@ -768,6 +806,12 @@ def register_station_commands(
     dispatcher.register_command(
         "get_power_profiles",
         cmd_get_power_profiles,
+        station=StationType.ENGINEERING
+    )
+
+    dispatcher.register_command(
+        "get_draw_profile",
+        cmd_get_draw_profile,
         station=StationType.ENGINEERING
     )
 

--- a/server/stations/station_types.py
+++ b/server/stations/station_types.py
@@ -126,6 +126,7 @@ STATION_DEFINITIONS: Dict[StationType, StationDefinition] = {
             "set_power_profile",
             "get_power_profiles",
             "set_power_allocation",
+            "get_draw_profile",
         },
         displays={
             "power_grid", "reactor_status", "system_status",

--- a/tests/systems/power/test_management.py
+++ b/tests/systems/power/test_management.py
@@ -17,3 +17,90 @@ def test_request_power_priority():
     result = pm.request_power(6.0, "test_unit")
     assert result
     assert pm.reactors["secondary"].available == pytest.approx(4.0)
+
+
+class _DummySystem:
+    def __init__(self, power_draw, enabled=True):
+        self.power_draw = power_draw
+        self.enabled = enabled
+
+
+class _DummyShip:
+    def __init__(self, systems):
+        self.systems = systems
+
+
+def test_get_draw_profile_nominal_case():
+    config = {
+        "primary": {"capacity": 120.0, "output_rate": 10.0, "thermal_limit": 100.0},
+        "secondary": {"capacity": 50.0, "output_rate": 5.0, "thermal_limit": 100.0},
+        "tertiary": {"capacity": 20.0, "output_rate": 2.0, "thermal_limit": 100.0},
+        "system_map": {
+            "propulsion": "primary",
+            "sensors": "primary",
+            "rcs": "secondary",
+            "nav": "tertiary",
+        },
+    }
+    pm = PowerManagementSystem(config)
+    pm.reactors["primary"].available = 100.0
+    pm.reactors["secondary"].available = 40.0
+    pm.reactors["tertiary"].available = 10.0
+
+    ship = _DummyShip(
+        {
+            "power_management": pm,
+            "propulsion": _DummySystem(60.0, enabled=True),
+            "sensors": _DummySystem(20.0, enabled=True),
+            "rcs": _DummySystem(12.0, enabled=True),
+            "nav": _DummySystem(6.0, enabled=True),
+        }
+    )
+
+    result = pm.get_draw_profile(ship=ship)
+    assert set(result.keys()) == {"active_profile", "buses", "totals"}
+    assert set(result["totals"].keys()) == {"available_kw", "requested_kw", "delta_kw"}
+
+    primary = result["buses"]["primary"]
+    assert primary["available_kw"] == pytest.approx(100.0)
+    assert primary["requested_kw"] == pytest.approx(80.0)
+    assert primary["delta_kw"] == pytest.approx(20.0)
+    assert primary["status"] == "surplus"
+    assert [s["name"] for s in primary["top_consumers"]] == ["propulsion", "sensors"]
+
+    assert result["totals"]["available_kw"] == pytest.approx(150.0)
+    assert result["totals"]["requested_kw"] == pytest.approx(98.0)
+    assert result["totals"]["delta_kw"] == pytest.approx(52.0)
+
+
+def test_get_draw_profile_deficit_and_command_path():
+    config = {
+        "primary": {"capacity": 120.0, "output_rate": 10.0, "thermal_limit": 100.0},
+        "secondary": {"capacity": 20.0, "output_rate": 5.0, "thermal_limit": 100.0},
+        "system_map": {
+            "propulsion": "primary",
+            "rcs": "secondary",
+            "comms": "secondary",
+        },
+    }
+    pm = PowerManagementSystem(config)
+    pm.reactors["primary"].available = 30.0
+    pm.reactors["secondary"].available = 8.0
+
+    ship = _DummyShip(
+        {
+            "power_management": pm,
+            "propulsion": _DummySystem(42.0, enabled=True),
+            "rcs": _DummySystem(5.0, enabled=True),
+            "comms": _DummySystem(6.0, enabled=True),
+            "spare": _DummySystem(100.0, enabled=False),
+        }
+    )
+
+    result = pm.command("get_draw_profile", {"ship": ship})
+
+    assert result["buses"]["primary"]["status"] == "deficit"
+    assert result["buses"]["primary"]["delta_kw"] == pytest.approx(-12.0)
+    assert result["buses"]["secondary"]["status"] == "deficit"
+    assert result["buses"]["secondary"]["requested_kw"] == pytest.approx(11.0)
+    assert all(s["name"] != "spare" for s in result["buses"]["unassigned"]["systems"])


### PR DESCRIPTION
### Motivation
- Provide a stable, GUI/CLI-friendly power diagnostic that shows per-bus supply vs requested draw and the top consumers to help engineering triage power problems.
- Make the information available via the existing command/dispatcher paths so stations and CLI tools can query live ship state.

### Description
- Added `PowerManagementSystem.get_draw_profile(ship=None)` which computes per-bus `available_kw`, `requested_kw`, `delta_kw`, `status`, a sorted `systems` list and `top_consumers`, plus aggregated `totals` and `active_profile`.
- Implemented helper iterators `_iter_enabled_consumers` and `_resolve_bus_for_system` to collect enabled systems (including weapon consumers) and map them to buses using `system_map`.
- Exposed the action in `PowerManagementSystem.command()` as `get_draw_profile` and added a `system_commands` mapping for `get_draw_profile` in `hybrid/command_handler.py` so commands route to the power system.
- Added server-side engineering station support by implementing `cmd_get_draw_profile` and registering `get_draw_profile` in `server/stations/station_commands.py`, and added the command to the engineering station definition in `server/stations/station_types.py`.
- Added unit tests in `tests/systems/power/test_management.py` covering a nominal/surplus case and a deficit/command-path case and asserting the stable output schema.

### Testing
- Ran `pytest -q tests/systems/power/test_management.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69855647e7ac83248bbd9c166bd2927c)