### PR TITLE
Add automatic secondary load shedding with hysteresis

### DIFF
--- a/tests/systems/power/test_management.py
+++ b/tests/systems/power/test_management.py
@@ -106,11 +106,11 @@ def test_secondary_recovery_uses_hysteresis_and_restores_high_criticality_first(
     pm.tick(0.0, ship=ship)
     assert all(system.enabled is False for system in ship.systems.values())
 
-    pm.reactors["secondary"].available = 40.0  # below warning recovery (0.45), no restore
+    pm.reactors["secondary"].available = 25.0  # below critical recovery (0.3), no restore
     pm.tick(0.0, ship=ship)
     assert all(system.enabled is False for system in ship.systems.values())
 
-    pm.reactors["secondary"].available = 50.0  # above warning recovery, restore
+    pm.reactors["secondary"].available = 35.0  # above critical recovery, restore
     pm.tick(0.0, ship=ship)
     assert all(system.enabled is True for system in ship.systems.values())
 


### PR DESCRIPTION
### Motivation
- Prevent deep discharge of the secondary/battery bus by automatically shedding non-critical secondary loads when stored charge falls below configurable thresholds.
- Make shedding configurable and observable so UI/AI can respond to battery bands and avoid rapid on/off flapping.

### Description
- Added configurable shedding policy and defaults (`DEFAULT_SECONDARY_SHEDDING_POLICY`) and per-system fallback criticality (`DEFAULT_SECONDARY_CRITICALITY`) in `hybrid/systems/power/management.py`.
- Parse `secondary_shedding` config and `system_map` metadata to build per-system secondary criticality, and added `_build_secondary_system_metadata()` to populate that mapping.
- Implemented battery charge band evaluation and automatic shedding in `_handle_secondary_load_shedding()` called from `tick()`, with prioritized shedding of lowest-criticality secondary systems and tracking of currently shed systems.
- Implemented recovery with hysteresis to avoid flapping and restoration ordering (higher-criticality systems restored first); added events `secondary_battery_band`, `secondary_load_shed`, and `secondary_load_restored` and exposed shedding status in `get_state()`.
- Added unit tests `tests/systems/power/test_management.py` covering threshold crossing, shedding order, and hysteresis-based recovery/restoration.

### Testing
- Ran `pytest -q tests/systems/power/test_management.py` and all tests passed (3 passed).
- Ran `pytest -q tests/systems/power` where the new tests passed but an unrelated existing test `tests/systems/power/test_reactor.py::test_reactor_ramp_and_overheat` failed in the suite run; this failure is pre-existing and not caused by the shedding changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698556486cc083248f384485fe5cb3ed)