### PR TITLE
Unify power command routing across CLI and GUI

### DIFF
--- a/hybrid/power_command_service.py
+++ b/hybrid/power_command_service.py
@@ -1,0 +1,32 @@
+"""Shared command helpers for power-management operations.
+
+This keeps CLI and GUI paths aligned on the same command names/payload shapes.
+"""
+
+
+def toggle_system_command(system_name, enabled):
+    return "toggle_system_power", {
+        "system": system_name,
+        "enabled": bool(enabled),
+    }
+
+
+def set_power_profile_command(profile_name):
+    return "set_power_profile", {"profile": profile_name}
+
+
+def set_power_allocation_command(allocation):
+    return "set_power_allocation", {"allocation": allocation}
+
+
+def get_power_profiles_command():
+    return "get_power_profiles", {}
+
+
+def get_power_telemetry_command():
+    return "get_power_telemetry", {}
+
+
+def get_draw_profile_command():
+    return "get_draw_profile", {}
+

--- a/server/stations/station_types.py
+++ b/server/stations/station_types.py
@@ -126,6 +126,8 @@ STATION_DEFINITIONS: Dict[StationType, StationDefinition] = {
             "set_power_profile",
             "get_power_profiles",
             "set_power_allocation",
+            "get_power_telemetry",
+            "get_draw_profile",
         },
         displays={
             "power_grid", "reactor_status", "system_status",

--- a/tests/systems/power/test_command_parity.py
+++ b/tests/systems/power/test_command_parity.py
@@ -1,0 +1,86 @@
+import copy
+
+from hybrid.ship import Ship
+from hybrid.power_command_service import (
+    get_draw_profile_command,
+    get_power_profiles_command,
+    get_power_telemetry_command,
+    set_power_allocation_command,
+    set_power_profile_command,
+    toggle_system_command,
+)
+
+
+def _build_ship():
+    cfg = {
+        "systems": {
+            "power_management": {
+                "primary": {"capacity": 120.0, "output_rate": 60.0, "thermal_limit": 200.0},
+                "secondary": {"capacity": 80.0, "output_rate": 40.0, "thermal_limit": 200.0},
+                "tertiary": {"capacity": 40.0, "output_rate": 20.0, "thermal_limit": 200.0},
+                "power_allocation": {"primary": 0.5, "secondary": 0.3, "tertiary": 0.2},
+                "system_map": {
+                    "propulsion": "primary",
+                    "sensors": "secondary",
+                    "bio": "tertiary",
+                },
+            },
+            "propulsion": {"power_draw": 20.0},
+            "sensors": {"power_draw": 10.0},
+            "bio": {"power_draw": 5.0},
+        },
+    }
+    return Ship("parity_ship", cfg)
+
+
+def test_set_power_profile_parity_ship_vs_pm_command():
+    ship = _build_ship()
+    pm = ship.systems["power_management"]
+
+    cmd, payload = set_power_profile_command("offensive")
+    ship_result = ship.command(cmd, copy.deepcopy(payload))
+
+    pm_ship = _build_ship()
+    pm_result = pm_ship.systems["power_management"].command("set_power_profile", {**payload, "ship": pm_ship})
+
+    assert ship_result["status"] == pm_result["status"]
+    assert ship.systems["power_management"].active_profile == pm_ship.systems["power_management"].active_profile
+    assert ship.systems["power_management"].power_allocation == pm_ship.systems["power_management"].power_allocation
+
+
+def test_set_power_allocation_parity_ship_vs_pm_command():
+    ship = _build_ship()
+    pm_ship = _build_ship()
+
+    keys = list(ship.systems["power_management"].reactors.keys())
+    allocation = {name: idx + 1 for idx, name in enumerate(keys)}
+
+    cmd, payload = set_power_allocation_command(allocation)
+    ship_result = ship.command(cmd, copy.deepcopy(payload))
+    pm_result = pm_ship.systems["power_management"].command("set_power_allocation", {**payload, "ship": pm_ship})
+
+    assert ship_result["power_allocation"] == pm_result["power_allocation"]
+    assert ship.systems["power_management"].power_allocation == pm_ship.systems["power_management"].power_allocation
+
+
+def test_toggle_and_telemetry_commands_available_via_shared_paths():
+    ship = _build_ship()
+
+    toggle_cmd, toggle_payload = toggle_system_command("sensors", False)
+    toggle_result = ship.command(toggle_cmd, toggle_payload)
+    assert toggle_result["status"] == "system_power_state_updated"
+    assert ship.systems["sensors"].enabled is False
+
+    profiles_cmd, profiles_payload = get_power_profiles_command()
+    profiles_result = ship.command(profiles_cmd, profiles_payload)
+    assert "profiles" in profiles_result
+
+    telemetry_cmd, telemetry_payload = get_power_telemetry_command()
+    telemetry_result = ship.command(telemetry_cmd, telemetry_payload)
+    assert "draw_by_bus_kw" in telemetry_result
+    assert "supply_by_bus_kw" in telemetry_result
+
+    draw_cmd, draw_payload = get_draw_profile_command()
+    draw_result = ship.command(draw_cmd, draw_payload)
+    assert "draw_by_bus" in draw_result
+    assert "total_draw_kw" in draw_result


### PR DESCRIPTION
### Motivation
- Reduce duplicated behavior by making CLI and GUI call the same command entry points for power toggles, allocation, profiles and telemetry.
- Ensure that all power changes are routed through the `PowerManagementSystem.command()` entrypoint instead of ad-hoc field edits.
- Keep bus and system names data-driven from the ship `system_map`/schema so no hardcoded bus or system names are introduced.

### Description
- Added a small shared command contract module `hybrid/power_command_service.py` that exposes helpers like `set_power_profile_command`, `set_power_allocation_command`, `toggle_system_command`, `get_power_telemetry_command`, and `get_draw_profile_command` used by both CLI and GUI.
- Refactored the ship-level handlers to route power operations through `PowerManagementSystem.command()` via a new `_power_management_command` helper and added ship commands `toggle_system_power`, `get_power_telemetry`, and `get_draw_profile` to centralize behavior (see `hybrid/ship.py`).
- Extended `PowerManagementSystem` with `set_system_power_state`, `get_power_telemetry`, and draw-profile aggregation built from the configured `system_map` (no hardcoded bus names), and wired these into `command()` (see `hybrid/systems/power/management.py`).
- Updated callers: CLI menu and headless flags (`hybrid/cli.py`) and GUI power controls (`hybrid/gui/run_gui.py`) now use the shared helpers to send identical payloads, and station server handlers now call the ship command entrypoints instead of mutating power internals (see `server/stations/station_commands.py` and `server/stations/station_types.py`).
- Added API docs describing the command contract and new telemetry endpoints in `docs/API_REFERENCE.md` and a regression test `tests/systems/power/test_command_parity.py` validating parity between CLI/GUI ship command paths and direct `PowerManagementSystem` calls.

### Testing
- Ran static compile checks: `python -m py_compile hybrid/cli.py hybrid/gui/run_gui.py hybrid/ship.py hybrid/systems/power/management.py server/stations/station_commands.py hybrid/power_command_service.py` and they succeeded.
- Ran unit tests: `python -m pytest tests/systems/power/test_command_parity.py tests/systems/power/test_management.py` and both tests passed (4 passed).
- Verified the CLI/GUI call paths exercise the same `PowerManagementSystem.command()` entrypoint via the new shared helpers and tests assert equivalent system state changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69855649c12083249a33f421fbc0c51d)