### PR TITLE
Fix legacy wrapper compatibility, restore tactical 'fire' alias, and correct reactor overheat throttling

### DIFF
--- a/hybrid/command_handler.py
+++ b/hybrid/command_handler.py
@@ -55,6 +55,7 @@ system_commands = {
     "best_weapon": ("targeting", "best_weapon"),
     "set_target_subsystem": ("targeting", "set_target_subsystem"),
     # Legacy weapon system
+    "fire": ("weapons", "fire"),
     "fire_weapon": ("weapons", "fire"),
     # Combat system commands (Sprint C - truth weapons)
     "fire_railgun": ("combat", "fire"),

--- a/hybrid/systems/power/reactor.py
+++ b/hybrid/systems/power/reactor.py
@@ -55,7 +55,7 @@ class Reactor:
         # If overheated, mark status and throttle output
         if self.temperature > self.thermal_limit:
             self.status = "overheated"
-            self.available = min(self.available, self.capacity * self.overheat_output_factor)
+            self.available *= self.overheat_output_factor
         elif self.status == "overheated" and self.temperature <= self.thermal_limit * 0.9:
             self.status = "nominal"
         elif self.status == "nominal":

--- a/server/stations/station_dispatch.py
+++ b/server/stations/station_dispatch.py
@@ -7,6 +7,7 @@ commands are only executed if the client has the appropriate station claim.
 
 from typing import Dict, Any, Callable, Optional, Tuple, Mapping, Union
 from dataclasses import dataclass
+import inspect
 import logging
 
 from .station_manager import StationManager
@@ -221,9 +222,14 @@ def create_legacy_command_wrapper(
 
             # Build command_data dict for legacy system
             command_data = {"command": command_name, **args}
+            command_data.setdefault("ship", ship.id)
 
             # Route through legacy system
-            response = route_command(ship, command_data, all_ships)
+            route_signature = inspect.signature(route_command)
+            if len(route_signature.parameters) >= 3:
+                response = route_command(ship, command_data, all_ships)
+            else:
+                response = route_command(ship, command_data)
 
             # Convert legacy response format to CommandResult
             if isinstance(response, dict):

--- a/server/stations/station_types.py
+++ b/server/stations/station_types.py
@@ -94,6 +94,7 @@ STATION_DEFINITIONS: Dict[StationType, StationDefinition] = {
             "unlock_target",
             "get_target_solution",
             "set_target_subsystem",
+            "fire",
             "fire_weapon",
         },
         displays={


### PR DESCRIPTION
### Motivation
- Resolve merge-introduced failures where legacy station wrappers assumed a specific `route_command` signature and missed `ship` in legacy payloads, causing runtime TypeErrors and permission lookups to fail. 
- Restore the expected tactical `fire` command alias so permission checks and routing match legacy behavior. 
- Fix reactor overheat behavior to throttle current available output proportionally instead of capping against capacity, matching intended thermal throttling semantics.

### Description
- Ensure legacy wrapper always includes the `ship` field in the legacy `command_data` payload via `command_data.setdefault("ship", ship.id)` in `server/stations/station_dispatch.py`.
- Detect `route_command` call signature with `inspect.signature` and invoke it with either two or three arguments to support both legacy and new variants in `server/stations/station_dispatch.py`.
- Reintroduce the `fire` command mapping to the weapons system in `hybrid/command_handler.py` and add `"fire"` to the TACTICAL station command set in `server/stations/station_types.py` so station permission checks and routing recognize the alias. 
- Change reactor overheat throttling in `hybrid/systems/power/reactor.py` to scale the current `available` output by `overheat_output_factor` instead of comparing to `capacity`.

### Testing
- Ran targeted regression tests: `pytest -q tests/stations/test_station_dispatch.py tests/phase2/test_phase2_integration.py::test_captain_override_system tests/systems/power/test_reactor.py` and they all passed. 
- Ran the full test suite with `pytest -q` which completed successfully with all tests passing (254 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69856c3fd3548324812c7f539a15549d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches command dispatch/permission routing and reactor power behavior, so regressions could block commands or alter simulation balance, though the changes are small and localized.
> 
> **Overview**
> Restores the legacy tactical `fire` alias by routing it to `weapons.fire` and allowing it through the TACTICAL station permission set.
> 
> Fixes legacy station wrapper compatibility by always including `ship` in the legacy command payload and by dynamically calling `route_command` with either 2 or 3 args depending on its detected signature.
> 
> Adjusts reactor overheat throttling to scale current `available` power by `overheat_output_factor` instead of capping against capacity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7f92e8bffb3879e094c22d315f98a9621c8407c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->