### PR TITLE
Document Gate Horizons encounter-runner contract, add drift guardrails and AI agent rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ This starts the TCP sim server, WebSocket bridge, and GUI HTTP server, then open
 - [Architecture overview](docs/ARCHITECTURE.md)
 - [Station architecture](STATION_ARCHITECTURE.md)
 - [API reference](docs/API_REFERENCE.md)
+- [Gate Horizons integration](docs/INTEGRATION_GATE_HORIZONS.md)
+- [Drift guardrails](docs/DRIFT_GUARDRAILS.md)
+- [AI agent rules](docs/AI_AGENT_RULES.md)
 - [Getting started tutorial](docs/TUTORIAL.md)
 - [Feature status](docs/FEATURE_STATUS.md)
 - [Known issues](docs/KNOWN_ISSUES.md)
@@ -47,6 +50,29 @@ This starts the TCP sim server, WebSocket bridge, and GUI HTTP server, then open
 - [Quaternion API](docs/QUATERNION_API.md)
 - [RCS configuration guide](docs/RCS_CONFIGURATION_GUIDE.md)
 - [Physics update notes](docs/PHYSICS_UPDATE.md)
+
+## Role in the Gate Horizons universe
+Flaxos Spaceship Sim is the real-time, physics-first tactical mission runtime for ship encounters in the Gate Horizons universe. It simulates RCS attitude control and Epstein main-drive thrust, runs the encounter at real-time cadence, and reports outcomes via a strict contract so the strategic layer can move on. It is not the strategic layer itself. This repo stays focused on mission execution, ship systems, and tactical outcomes only. Gate Horizons handles the months-scale planning, wormhole travel, and wider campaign logic. The contract name and JSON artefacts are fixed now to prevent drift. 
+
+### Operating modes
+**Standalone sandbox/multi-station game**
+- Run scenarios, skirmishes, and training missions locally.
+- Multi-crew stations and AI can be used for co-op or solo play.
+
+**Encounter Runner (Gate Horizons contract runtime)**
+- Loads an encounter definition (`EncounterSpec.json`) to spawn actors, initial states, objectives, and rules.
+- Runs the mission in real time with the existing physics model.
+- Emits a mission result (`ResultSpec.json`) that the meta game can consume.
+
+### Contract-only integration boundary
+This repo integrates with Gate Horizons via contract-only artefacts:
+- **Input:** `EncounterSpec.json` (spawn list, initial state, objectives, rules, scenario metadata)
+- **Output:** `ResultSpec.json` (outcomes, resource usage, losses, mission flags, timelines)
+
+No direct coupling to Gate Horizons internal state or data models is permitted. If a detail is not in the encounter contract, it does not belong inside this runtime.
+
+### Timescale alignment
+Gate Horizons operates at a strategic timescale (months across gates and wormholes). Flaxos runs the tactical real-time simulation of a local encounter. The split is intentional: strategic decisions stay outside; tactical execution and physics stay here.
 
 ## Android/Pydroid UAT (TCP JSON)
 The sim server speaks **newline-delimited JSON over TCP** (one JSON object per line). The Android UI can run in Pydroid and connect over your LAN.

--- a/docs/AI_AGENT_RULES.md
+++ b/docs/AI_AGENT_RULES.md
@@ -1,0 +1,27 @@
+# AI Agent Rules (Documentation + Guardrails)
+
+## Scope and authorisation
+- **Documentation-only unless explicitly authorised.**
+- If a request is ambiguous, default to documentation updates and ask for clarity in a future turn.
+
+## Preserve the physics model
+- Never change the real-time RCS + Epstein drive model to fit narrative goals.
+- Do not introduce incompatible assumptions (e.g., instant thrust, reactionless drives, or non-canonical tech).
+
+## Contract-only boundary
+- The integration boundary is **contract-only** via `EncounterSpec.json` and `ResultSpec.json`.
+- No direct coupling to Gate Horizons internal state, economy, factions, or lore systems.
+
+## Assumptions must be declared
+- Declare any assumptions in documentation.
+- If a new behaviour is proposed, document it as a **future consideration**, not a promise.
+
+## Allowed AI usage
+- Documentation drafting and editing.
+- Scenario writing and encounter briefs (as content only).
+- Test encounter drafting for QA or planning purposes.
+
+## Disallowed AI usage
+- Implementing physics changes to satisfy story outcomes.
+- Injecting hidden behaviour or non-contract data exchange.
+- Expanding scope into strategic or economic simulation.

--- a/docs/DRIFT_GUARDRAILS.md
+++ b/docs/DRIFT_GUARDRAILS.md
@@ -1,0 +1,31 @@
+# Drift Guardrails (Hard Rules)
+
+## What this repo is
+- A real-time, physics-first tactical simulator with RCS attitude control and Epstein main-drive thrust.
+- The **mission execution layer** for encounters, with outcomes delivered via `ResultSpec.json`.
+- A sandbox for scenarios, training missions, and multi-station gameplay.
+
+## What this repo is NOT
+- The strategic campaign layer for Gate Horizons.
+- A lore, economy, faction, or diplomacy engine.
+- A narrative arbiter that bends physics to fit story beats.
+
+## Hard sci-fi constraints
+- Preserve hard-sci-fi assumptions unless canon explicitly changes them.
+- No shields, inertial dampers, or hand-waved armour unless already in canon.
+- No “magical tech” additions to justify gameplay without an explicit, documented basis.
+
+## Contract-only boundary
+- **Input:** `EncounterSpec.json`
+- **Output:** `ResultSpec.json`
+- No hidden coupling to Gate Horizons internal state or data models.
+
+## AI agent constraints
+- Any AI agent work must preserve the real-time RCS + Epstein model.
+- Do not change the physics model to satisfy narrative or balance requests.
+- Any assumptions or additions must be declared explicitly in documentation.
+
+## Non-goals to avoid drift
+- Do not implement campaign time progression, trade, or faction reputation.
+- Do not introduce strategic planning logic.
+- Do not embed Gate Horizons world state inside this repo.

--- a/docs/INTEGRATION_GATE_HORIZONS.md
+++ b/docs/INTEGRATION_GATE_HORIZONS.md
@@ -1,0 +1,36 @@
+# Gate Horizons Integration (Encounter Runner Mode)
+
+## Purpose
+This document defines the **contract-only integration boundary** between Flaxos Spaceship Sim and the Gate Horizons meta game. Flaxos is the real-time, physics-first tactical runtime. Gate Horizons is the strategic layer that operates at months-scale travel and campaign planning. The interface between them is limited to JSON artefacts so each system can evolve without tight coupling.
+
+## Encounter Runner Mode (conceptual)
+In Encounter Runner mode, Flaxos accepts a complete, immutable encounter description and executes it as a real-time tactical mission using the existing RCS + Epstein drive model. Flaxos does not resolve campaign state, faction lore, or economy. It simply simulates the encounter, records outcomes, and returns a result report.
+
+## Contract: `EncounterSpec.json` (input)
+At minimum, the encounter specification must include:
+- **Encounter metadata**: scenario name, version, seed, and time budget or termination conditions.
+- **Actors**: ships and entities to spawn, with identifiers, factions (if relevant), and initial state (position, velocity, orientation, system loadouts, and any enabled/disabled systems).
+- **Objectives**: mission goals, win/loss conditions, and scoring criteria.
+- **Rules**: engagement constraints, sensor rules, legal actions, and any encounter-specific toggles.
+- **Environment**: local space parameters that affect the encounter (e.g. reference frame, local hazards, visibility constraints), if required.
+
+Flaxos treats this input as authoritative. If the information is not present in the contract, it is out of scope for this runtime.
+
+## Contract: `ResultSpec.json` (output)
+At minimum, the result report must include:
+- **Outcome summary**: win/loss/neutral, objective completion, and score (if defined).
+- **Losses and damage**: destroyed or disabled actors, and critical system states at mission end.
+- **Resource usage**: fuel, munitions, power constraints, and other consumables.
+- **Timeline/flags**: key events, mission flags, and termination reason.
+- **Survivor state**: final ship states required for campaign continuity (position, velocity, hull status, and critical system status).
+
+This report is a mission-level summary, not a full sim replay. Gate Horizons can decide how much detail it needs as long as the minimum contract remains stable.
+
+## Non-goals (to prevent drift)
+- No direct access to Gate Horizons world state, economy, or faction logic.
+- No narrative arbitration beyond the contract’s objectives and rules.
+- No changes to physics or system behaviour to satisfy lore or story beats.
+- No hidden or implicit integration: all integration must go through `EncounterSpec.json` and `ResultSpec.json`.
+
+## Notes on timescale
+Gate Horizons operates across months of travel and planning. Flaxos executes the tactical engagement at real-time cadence. Keep the boundary sharp so strategic decisions stay in the meta layer, and tactical execution remains deterministic and physics-first here.


### PR DESCRIPTION
### Motivation
- Lock the repo’s role as a real‑time, physics‑first tactical mission runtime for Gate Horizons to prevent scope drift. 
- Make the integration boundary explicit and contract‑only so strategic (months‑scale) logic remains outside this runtime.
- Establish hard guardrails and AI agent rules to preserve the RCS + Epstein physics model and stop narrative or campaign features creeping into the sim.

### Description
- Added `docs/INTEGRATION_GATE_HORIZONS.md` describing Encounter Runner mode, the `EncounterSpec.json` input expectations, and the `ResultSpec.json` output minimums, plus explicit non‑goals. 
- Added `docs/DRIFT_GUARDRAILS.md` enumerating what the repo is/ is not, hard sci‑fi constraints, the contract boundary, and non‑goals to prevent feature creep. 
- Added `docs/AI_AGENT_RULES.md` defining allowed AI usage (documentation, scenario drafting), strict prohibitions (no physics changes, no hidden data exchange), and a documentation‑first authorisation stance. 
- Updated `README.md` to link the new docs and include a concise “Role in the Gate Horizons universe” section that describes the two operating modes (Standalone vs Encounter Runner), the contract‑only integration statement, and the timescale alignment.

### Testing
- No automated tests were run because these are documentation‑only changes; CI should validate formatting/spelling if present in the pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698681a3bbbc8324a462d34615104ac7)