### PR TITLE
Add Gate Horizons canon references and enforce contract-only drift guardrails (docs-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,19 @@ This starts the TCP sim server, WebSocket bridge, and GUI HTTP server, then open
 - [Physics update notes](docs/PHYSICS_UPDATE.md)
 
 ## Role in the Gate Horizons universe
-Flaxos Spaceship Sim is the real-time, physics-first tactical mission runtime for ship encounters in the Gate Horizons universe. It simulates RCS attitude control and Epstein main-drive thrust, runs the encounter at real-time cadence, and reports outcomes via a strict contract so the strategic layer can move on. It is not the strategic layer itself. This repo stays focused on mission execution, ship systems, and tactical outcomes only. Gate Horizons handles the months-scale planning, wormhole travel, and wider campaign logic. The contract name and JSON artefacts are fixed now to prevent drift. 
+Flaxos Spaceship Sim is the real-time, physics-first tactical mission runtime for ship encounters in the Gate Horizons universe. It simulates RCS attitude control and Epstein main-drive thrust, runs the encounter at real-time cadence, and reports outcomes via a strict contract so the strategic layer can move on. It is not the strategic layer itself, and it does not own campaign logic or canon. The contract name and JSON artefacts are fixed now to prevent drift.
+
+- This repo is the **real-time tactical mission engine** (RCS + Epstein drive).
+- Gate Horizons is the **strategic meta layer** (months-scale travel via gates/wormholes, lore, canon, encounter generation).
+- Integration is **contract-only**: `EncounterSpec.json` in, `ResultSpec.json` out (conceptual only; do not implement).
+
+### Canon & Style References (Gate Horizons)
+- [Gate Horizons canon pack (repo root)](https://github.com/Flaxos/gate-horizons-canon-pack)
+- [canon/CANON.md](https://github.com/Flaxos/gate-horizons-canon-pack/blob/main/canon/CANON.md)
+- [canon/STYLE_BIBLE.md](https://github.com/Flaxos/gate-horizons-canon-pack/blob/main/canon/STYLE_BIBLE.md)
+- [canon/STORYBOARD.md](https://github.com/Flaxos/gate-horizons-canon-pack/blob/main/canon/STORYBOARD.md)
+- [canon/IMAGE_PROMPT_TEMPLATE.md](https://github.com/Flaxos/gate-horizons-canon-pack/blob/main/canon/IMAGE_PROMPT_TEMPLATE.md)
+- [canon/AI_AGENT_RULES.md](https://github.com/Flaxos/gate-horizons-canon-pack/blob/main/canon/AI_AGENT_RULES.md)
 
 ### Operating modes
 **Standalone sandbox/multi-station game**

--- a/docs/AI_AGENT_RULES.md
+++ b/docs/AI_AGENT_RULES.md
@@ -7,10 +7,16 @@
 ## Preserve the physics model
 - Never change the real-time RCS + Epstein drive model to fit narrative goals.
 - Do not introduce incompatible assumptions (e.g., instant thrust, reactionless drives, or non-canonical tech).
+- Hard-sci aesthetic constraints must remain compatible with the Gate Horizons canon pack.
 
 ## Contract-only boundary
 - The integration boundary is **contract-only** via `EncounterSpec.json` and `ResultSpec.json`.
 - No direct coupling to Gate Horizons internal state, economy, factions, or lore systems.
+- Do not introduce ad-hoc hooks, shared state, or side-channel data exchange.
+
+## Canon and storyboard sources
+- For any lore, storyboard, or style work, treat the Gate Horizons canon pack as the source of truth.
+- Cite `canon/CANON.md`, `canon/STYLE_BIBLE.md`, and `canon/STORYBOARD.md` when documenting narrative or visual constraints.
 
 ## Assumptions must be declared
 - Declare any assumptions in documentation.

--- a/docs/DRIFT_GUARDRAILS.md
+++ b/docs/DRIFT_GUARDRAILS.md
@@ -15,6 +15,16 @@
 - No shields, inertial dampers, or hand-waved armour unless already in canon.
 - No “magical tech” additions to justify gameplay without an explicit, documented basis.
 
+## Drift types (watch list)
+- **Magic tech creep:** adding non-canonical capabilities to make missions easier or more cinematic.
+- **Interface creep:** expanding integration beyond `EncounterSpec.json`/`ResultSpec.json`.
+- **LLM creep:** accepting model-invented lore, tech, or rules not grounded in the canon pack.
+
+## Controls
+- Treat Gate Horizons `canon/CANON.md` and `canon/STYLE_BIBLE.md` as the constraints for lore and aesthetics.
+- Keep integration contract-only: no hidden state, no side channels, no shared runtime hooks.
+- Document any new assumption explicitly and keep it scoped to the tactical layer.
+
 ## Contract-only boundary
 - **Input:** `EncounterSpec.json`
 - **Output:** `ResultSpec.json`

--- a/docs/INTEGRATION_GATE_HORIZONS.md
+++ b/docs/INTEGRATION_GATE_HORIZONS.md
@@ -3,6 +3,19 @@
 ## Purpose
 This document defines the **contract-only integration boundary** between Flaxos Spaceship Sim and the Gate Horizons meta game. Flaxos is the real-time, physics-first tactical runtime. Gate Horizons is the strategic layer that operates at months-scale travel and campaign planning. The interface between them is limited to JSON artefacts so each system can evolve without tight coupling.
 
+## Operating modes
+**Standalone sandbox/scenarios**
+- Local skirmishes, training missions, and multi-station play.
+- No upstream dependency on Gate Horizons; this sim is fully runnable on its own.
+
+**Linked encounter runner (future)**
+- Gate Horizons supplies the encounter definition and consumes the outcome report.
+- Flaxos executes the encounter at real-time cadence and reports results via the contract.
+
+## Timescale separation
+- **Real-time tactical:** Flaxos simulates RCS attitude control and Epstein thrust per tick.
+- **Months-scale strategic:** Gate Horizons handles gate travel, campaign planning, and encounter generation.
+
 ## Encounter Runner Mode (conceptual)
 In Encounter Runner mode, Flaxos accepts a complete, immutable encounter description and executes it as a real-time tactical mission using the existing RCS + Epstein drive model. Flaxos does not resolve campaign state, faction lore, or economy. It simply simulates the encounter, records outcomes, and returns a result report.
 


### PR DESCRIPTION
### Motivation
- Make the repo explicitly part of the Gate Horizons ecosystem while keeping a strict tactical/strategic separation so the sim remains the real-time RCS + Epstein-drive mission engine. 
- Prevent scope and narrative drift by formally declaring a contract-only interface and the timescale separation between tactical simulation and strategic campaign logic. 
- Provide clear rules for AI agents and maintainers to keep changes documentation-only and to forbid physics or behaviour changes for narrative reasons.

### Description
- Updated `README.md` to add a "Role in the Gate Horizons universe" section and a `Canon & Style References (Gate Horizons)` list linking to the Gate Horizons canon pack and its key canon files. 
- Extended `docs/INTEGRATION_GATE_HORIZONS.md` to describe two operating modes (`Standalone sandbox/scenarios` and `Linked encounter runner (future)`), explicit timescale separation, and to emphasise the `EncounterSpec.json` in / `ResultSpec.json` out contract. 
- Tightened `docs/AI_AGENT_RULES.md` to enforce documentation-only scope, require canon-pack sourcing for lore/storyboard work, forbid ad-hoc hooks or side-channel data exchange, and to preserve the RCS + Epstein-drive physics model. 
- Added drift watch-list and controls to `docs/DRIFT_GUARDRAILS.md` to call out "magic tech creep", "interface creep" and "LLM creep" and to point maintainers to the canon files as the source of truth. 

### Testing
- No automated tests were executed because these are documentation-only changes (no code or runtime changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69868b1a049c83248220483e873143db)