### PR TITLE
Fix command routing when ship id is omitted

### DIFF
--- a/hybrid/command_handler.py
+++ b/hybrid/command_handler.py
@@ -107,9 +107,13 @@ def route_command(ship, command_data, all_ships=None):
         if not cmd:
             return {"error": "Missing command parameter"}
 
-        # Validate ship
-        if ship_id != ship.id:
-            return {"error": f"Command sent to wrong ship. Expected {ship.id}, got {ship_id}"}
+        # Validate ship when provided; default to the target ship if omitted
+        if ship_id:
+            if ship_id != ship.id:
+                return {"error": f"Command sent to wrong ship. Expected {ship.id}, got {ship_id}"}
+        else:
+            command_data["ship"] = ship.id
+            ship_id = ship.id
 
         # Execute command
         response = execute_command(ship, cmd, command_data, all_ships)


### PR DESCRIPTION
### Motivation
- Prevent valid CLI/API commands from being rejected when the incoming command omits the `ship` field by defaulting routing to the targeted ship.

### Description
- Update `route_command` to only validate `ship` against `ship.id` when a `ship` value is provided and to set `command_data["ship"] = ship.id` when the field is omitted.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ff37fb7c832496bee8203382e6cc)