### PR TITLE
Add interactive CLI options to inspect power profiles and draw profile

### DIFF
--- a/hybrid/cli.py
+++ b/hybrid/cli.py
@@ -163,11 +163,13 @@ def run_cli(fleet_dir="hybrid_fleet", dt=0.1):
             print("3. Set course")
             print("4. Toggle autopilot")
             print("5. Ping sensors")
-            print("6. Set power profile")
-            print("7. Custom command")
-            print("8. Switch ship")
-            print("9. Save states")
-            print("10. Exit")
+            print("6. List power profiles")
+            print("7. Set power profile")
+            print("8. Get power draw profile")
+            print("9. Custom command")
+            print("10. Switch ship")
+            print("11. Save states")
+            print("12. Exit")
             
             try:
                 choice = input("\nEnter command: ")
@@ -208,6 +210,10 @@ def run_cli(fleet_dir="hybrid_fleet", dt=0.1):
                     print("Result:", json.dumps(result, indent=2))
                     
                 elif choice == "6":
+                    result = runner.send_command(selected_ship, "get_power_profiles", {})
+                    print("Result:", json.dumps(result, indent=2))
+
+                elif choice == "7":
                     profile = input("Power profile (offensive/defensive): ").strip()
                     if not profile:
                         print("Profile name required")
@@ -219,7 +225,11 @@ def run_cli(fleet_dir="hybrid_fleet", dt=0.1):
                     )
                     print("Result:", json.dumps(result, indent=2))
 
-                elif choice == "7":
+                elif choice == "8":
+                    result = runner.send_command(selected_ship, "get_draw_profile", {})
+                    print("Result:", json.dumps(result, indent=2))
+
+                elif choice == "9":
                     # Custom command
                     cmd = input("Command: ")
                     args_str = input("Args (JSON): ")
@@ -231,7 +241,7 @@ def run_cli(fleet_dir="hybrid_fleet", dt=0.1):
                     except json.JSONDecodeError:
                         print("Invalid JSON args")
                         
-                elif choice == "8":
+                elif choice == "10":
                     # Switch ship
                     print("\nAvailable ships:")
                     for i, ship_id in enumerate(ship_ids):
@@ -247,12 +257,12 @@ def run_cli(fleet_dir="hybrid_fleet", dt=0.1):
                     except ValueError:
                         print("Invalid input, please enter a number")
                         
-                elif choice == "9":
+                elif choice == "11":
                     # Save states
                     result = runner.save_states()
                     print("Result:", json.dumps(result, indent=2))
                     
-                elif choice == "10":
+                elif choice == "12":
                     # Exit
                     print("Exiting...")
                     break


### PR DESCRIPTION
### Motivation
- Improve CLI usability for power management by exposing quick, interactive actions to list engineering power profiles and inspect per-bus/system draw without crafting raw JSON commands.
- Provide a small, stable vertical slice that reuses existing command routing to keep headless/scripting behaviour intact.

### Description
- Extended the interactive command menu in `hybrid/cli.py` to add `List power profiles` and `Get power draw profile` options and renumbered subsequent menu entries.
- Wired the new menu entries to the existing backend commands via `runner.send_command(..., "get_power_profiles", {})` and `runner.send_command(..., "get_draw_profile", {})` so the interactive UI reuses existing power-management logic.
- Kept changes localized to the CLI (no refactors), preserving the existing command-handling and headless execution paths.

### Testing
- Ran unit tests: `pytest -q tests/systems/power/test_management.py` which passed (3 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a975b429883248ee36738241d5a95)