### PR TITLE
Fix contact names, autopilot target resolution, and tutorial checks

### DIFF
--- a/gui/components/autopilot-control.js
+++ b/gui/components/autopilot-control.js
@@ -283,7 +283,8 @@ class AutopilotControl extends HTMLElement {
       const id = contact.contact_id || contact.id;
       const option = document.createElement("option");
       option.value = id;
-      option.textContent = `${id} (${contact.classification || "UNKNOWN"})`;
+      const label = contact.name || contact.classification || "UNKNOWN";
+      option.textContent = `${id} — ${label}`;
       if (id === currentValue) {
         option.selected = true;
       }

--- a/gui/components/docking-panel.js
+++ b/gui/components/docking-panel.js
@@ -380,7 +380,7 @@ class DockingPanel extends HTMLElement {
         const id = contact.contact_id || contact.id;
         const option = document.createElement("option");
         option.value = id;
-        option.textContent = `${id} (${contact.classification || "UNKNOWN"})`;
+        option.textContent = `${id} — ${contact.name || contact.classification || "UNKNOWN"}`;
         select.appendChild(option);
       });
     }

--- a/gui/components/flight-computer-panel.js
+++ b/gui/components/flight-computer-panel.js
@@ -570,7 +570,7 @@ class FlightComputerPanel extends HTMLElement {
       const id = contact.contact_id || contact.id;
       const option = document.createElement("option");
       option.value = id;
-      option.textContent = `${id} (${contact.classification || "UNKNOWN"})`;
+      option.textContent = `${id} — ${contact.name || contact.classification || "UNKNOWN"}`;
       select.appendChild(option);
     });
 

--- a/gui/components/sensor-contacts.js
+++ b/gui/components/sensor-contacts.js
@@ -555,7 +555,7 @@ class SensorContacts extends HTMLElement {
 
   _renderContactRow(contact) {
     const id = contact.contact_id || contact.id || "???";
-    const classification = contact.classification || contact.class || "UNKNOWN";
+    const classification = contact.name || contact.classification || contact.class || "UNKNOWN";
     const bearing = contact.bearing ?? "---";
     const range = contact.range ?? contact.distance ?? 0;
     const rangeRate = contact.range_rate ?? contact.closure ?? 0;

--- a/gui/components/tutorial-overlay.js
+++ b/gui/components/tutorial-overlay.js
@@ -12,15 +12,54 @@ const CHECK_POLL_MS = 1500;
 const AUTO_ADVANCE_MS = 1000;
 
 // -- Check helpers --------------------------------------------------------
-const _ms = () => stateManager.getState("mission");
-const missionActive = () => { const m = _ms(); if (!m) return false; const s = m.mission_status || m.status; return s === "active" || s === "in_progress" || s === "loaded"; };
-const missionComplete = () => { const m = _ms(); if (!m) return false; const s = m.mission_status || m.status; return s === "success" || s === "complete" || s === "completed"; };
+// Mission state: poll via wsClient since stateManager doesn't track mission
+let _missionCache = null;
+let _missionPollTime = 0;
+const _pollMission = async () => {
+  const now = Date.now();
+  if (now - _missionPollTime < 2000 && _missionCache) return _missionCache;
+  try {
+    _missionCache = await wsClient.send("get_mission", {});
+    _missionPollTime = now;
+  } catch { /* ignore */ }
+  return _missionCache;
+};
+// Sync checks (use cached mission data)
+const missionActive = () => {
+  if (!_missionCache) { _pollMission(); return false; }
+  const s = _missionCache.mission_status || _missionCache.status;
+  return s === "active" || s === "in_progress" || s === "loaded" || !!_missionCache.name;
+};
+const missionComplete = () => {
+  if (!_missionCache) return false;
+  const s = _missionCache.mission_status || _missionCache.status;
+  return s === "success" || s === "complete" || s === "completed";
+};
 const helmActive = () => document.querySelector("#view-helm")?.classList.contains("active") ?? false;
 const hasTarget = () => !!stateManager.getTargeting()?.target_id;
-const autopilotActive = () => { const n = stateManager.getNavigation(); return n?.autopilot?.enabled === true || n?.autopilot?.mode === "intercept"; };
-const targetDist = () => { const n = stateManager.getNavigation(); return n?.autopilot?.distance ?? n?.autopilot?.range ?? Infinity; };
-const shipSpeed = () => { const v = stateManager.getNavigation()?.velocity || [0,0,0]; return Math.sqrt(v[0]*v[0]+v[1]*v[1]+v[2]*v[2]); };
-const courseActive = () => { const n = stateManager.getNavigation(); return n?.autopilot?.mode === "course" || n?.autopilot?.enabled === true; };
+const autopilotActive = () => {
+  const ship = stateManager.getShipState();
+  const nav = ship?.systems?.navigation || {};
+  const ap = nav.autopilot_state || nav.autopilot || {};
+  return ap.enabled === true || ap.active === true || (ap.mode && ap.mode !== "off" && ap.mode !== "manual");
+};
+const targetDist = () => {
+  const ship = stateManager.getShipState();
+  const nav = ship?.systems?.navigation || {};
+  const ap = nav.autopilot_state || nav.autopilot || {};
+  return ap.distance ?? ap.range ?? Infinity;
+};
+const shipSpeed = () => {
+  const nav = stateManager.getNavigation();
+  const v = nav?.velocity || [0, 0, 0];
+  return Math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+};
+const courseActive = () => {
+  const ship = stateManager.getShipState();
+  const nav = ship?.systems?.navigation || {};
+  const ap = nav.autopilot_state || nav.autopilot || {};
+  return ap.mode === "course" || ap.mode === "goto_position" || ap.enabled === true;
+};
 
 const TRACKS = {
   autopilot: {

--- a/hybrid/systems/sensors/active.py
+++ b/hybrid/systems/sensors/active.py
@@ -134,7 +134,8 @@ class ActiveSensor:
                 bearing=bearing,
                 distance=distance,
                 signature=signature,
-                classification=target_ship.class_type if accuracy > 0.8 else "Unknown"
+                classification=target_ship.class_type if accuracy > 0.8 else "Unknown",
+                name=getattr(target_ship, "name", None) if accuracy > 0.5 else None,
             )
 
             detected[target_ship.id] = contact

--- a/hybrid/systems/sensors/contact.py
+++ b/hybrid/systems/sensors/contact.py
@@ -20,6 +20,7 @@ class ContactData:
     distance: Optional[float] = None  # Distance from observer
     signature: Optional[float] = None  # Thermal/EM signature strength
     classification: Optional[str] = None  # Ship class if known
+    name: Optional[str] = None  # Ship name if identified
 
     def is_stale(self, current_time: float, stale_threshold: float = 60.0) -> bool:
         """Check if contact is stale.
@@ -80,15 +81,25 @@ class ContactTracker:
         self.contacts[stable_id] = contact_data
 
     def get_contact(self, contact_id: str) -> Optional[ContactData]:
-        """Get a contact by ID.
+        """Get a contact by stable ID or original ship ID.
 
         Args:
-            contact_id: Stable contact ID
+            contact_id: Stable contact ID (e.g. C001) or original ship ID
 
         Returns:
             ContactData or None
         """
-        return self.contacts.get(contact_id)
+        # Try stable contact ID first
+        contact = self.contacts.get(contact_id)
+        if contact:
+            return contact
+
+        # Fall back to looking up by original ship ID
+        stable_id = self.id_mapping.get(contact_id)
+        if stable_id:
+            return self.contacts.get(stable_id)
+
+        return None
 
     def get_all_contacts(self, current_time: float, include_stale: bool = False) -> Dict[str, ContactData]:
         """Get all contacts.

--- a/hybrid/systems/sensors/passive.py
+++ b/hybrid/systems/sensors/passive.py
@@ -102,7 +102,8 @@ class PassiveSensor:
                 bearing=bearing,
                 distance=distance,
                 signature=signature,
-                classification=self._classify_contact(target_ship, accuracy)
+                classification=self._classify_contact(target_ship, accuracy),
+                name=getattr(target_ship, "name", None) if accuracy > 0.5 else None,
             )
 
             detected[target_ship.id] = contact

--- a/hybrid/systems/sensors/sensor_system.py
+++ b/hybrid/systems/sensors/sensor_system.py
@@ -138,6 +138,7 @@ class SensorSystem(BaseSystem):
             "distance": contact.distance,
             "signature": contact.signature,
             "classification": contact.classification,
+            "name": getattr(contact, "name", None),
         }
 
     def command(self, action: str, params: dict):
@@ -263,7 +264,8 @@ class SensorSystem(BaseSystem):
                 "bearing": contact.bearing,
                 "distance": contact.distance,
                 "signature": contact.signature,
-                "classification": contact.classification
+                "classification": contact.classification,
+                "name": getattr(contact, "name", None),
             }
             for contact_id, contact in all_contacts.items()
         ]


### PR DESCRIPTION
## Summary
- **Contact name display**: Added `name` field to `ContactData`, populated by passive/active sensors when confidence > 50%. GUI dropdowns and contact lists now show ship names instead of "UNKNOWN"
- **Autopilot target resolution**: `ContactTracker.get_contact()` now resolves targets by both stable contact ID (e.g. C001) and original ship ID (e.g. target_station) via `id_mapping` fallback — fixes "Target not in sensor contacts" errors
- **Tutorial auto-advance fixes**: Mission state polling now uses `wsClient.send("get_mission")` directly instead of `stateManager` (which doesn't track mission state). Added 2s cache to avoid spamming. Fixed `autopilotActive()` to check correct state path (`systems.navigation.autopilot_state`)

## Files changed
- `hybrid/systems/sensors/contact.py` — Added `name` field, dual-lookup in `get_contact()`
- `hybrid/systems/sensors/passive.py` / `active.py` — Populate contact name from ship
- `hybrid/systems/sensors/sensor_system.py` — Include name in serialized contact output
- `gui/components/tutorial-overlay.js` — Fix mission polling and autopilot state checks
- `gui/components/sensor-contacts.js` — Show contact name in display
- `gui/components/autopilot-control.js` / `docking-panel.js` / `flight-computer-panel.js` — Show name in dropdowns

## Test plan
- [ ] Load Mission 1, verify station contact shows name instead of "UNKNOWN"
- [ ] Set autopilot intercept on station — should resolve target without errors
- [ ] Walk through tutorial — steps auto-advance when conditions are met
- [ ] Verify active ping also populates contact names

🤖 Generated with [Claude Code](https://claude.com/claude-code)