### PR TITLE
Fix autopilot self-override loop causing log spam

### DIFF
--- a/hybrid/systems/helm_system.py
+++ b/hybrid/systems/helm_system.py
@@ -345,8 +345,11 @@ class HelmSystem(BaseSystem):
             
             self.attitude_target = {"pitch": pitch, "yaw": yaw, "roll": roll}
 
-            # Record manual input - triggers manual override if autopilot active
-            if ship:
+            # Only record manual input if this is from the pilot, not the autopilot.
+            # Autopilot-originated heading commands must NOT trigger manual override,
+            # otherwise the autopilot disengages itself every tick.
+            from_autopilot = params.get("_from_autopilot", False)
+            if ship and not from_autopilot:
                 self._record_manual_input(ship, getattr(ship, "sim_time", 0.0))
 
                 # Route to RCS if available
@@ -359,6 +362,11 @@ class HelmSystem(BaseSystem):
                         "control_authority": self.control_authority,
                         "rcs_response": result,
                     }
+            elif ship:
+                # Autopilot command - route to RCS without triggering override
+                rcs = ship.systems.get("rcs")
+                if rcs:
+                    rcs.set_attitude_target(self.attitude_target)
 
             return {
                 "status": "Attitude target set",

--- a/hybrid/systems/navigation/navigation.py
+++ b/hybrid/systems/navigation/navigation.py
@@ -164,26 +164,25 @@ class NavigationSystem(BaseSystem):
             propulsion.set_throttle({"thrust": thrust_value, "_ship": ship, "ship": ship})
 
         # Apply heading via RCS through helm (attitude target, not instant teleport)
+        # Mark as autopilot-originated so helm doesn't trigger manual override
         if heading:
+            attitude = {
+                "pitch": heading.get("pitch", ship.orientation.get("pitch", 0)),
+                "yaw": heading.get("yaw", ship.orientation.get("yaw", 0)),
+                "roll": heading.get("roll", ship.orientation.get("roll", 0)),
+            }
             helm = ship.systems.get("helm")
             if helm and hasattr(helm, "_cmd_set_orientation_target"):
-                # Use helm's orientation target command
                 helm._cmd_set_orientation_target({
-                    "pitch": heading.get("pitch", ship.orientation.get("pitch", 0)),
-                    "yaw": heading.get("yaw", ship.orientation.get("yaw", 0)),
-                    "roll": heading.get("roll", ship.orientation.get("roll", 0)),
+                    **attitude,
                     "_ship": ship,
-                    "ship": ship
+                    "ship": ship,
+                    "_from_autopilot": True,
                 })
             else:
-                # Fallback: direct RCS control
                 rcs = ship.systems.get("rcs")
                 if rcs and hasattr(rcs, "set_attitude_target"):
-                    rcs.set_attitude_target({
-                        "pitch": heading.get("pitch", ship.orientation.get("pitch", 0)),
-                        "yaw": heading.get("yaw", ship.orientation.get("yaw", 0)),
-                        "roll": heading.get("roll", ship.orientation.get("roll", 0))
-                    })
+                    rcs.set_attitude_target(attitude)
 
     def command(self, action: str, params: dict):
         """Handle navigation commands.


### PR DESCRIPTION
## Summary
- **Root cause**: `NavigationSystem._apply_autopilot_command()` routed heading changes through `helm._cmd_set_orientation_target()`, which called `_record_manual_input()` → `nav.controller.set_manual_input()`. This made the autopilot's own commands trigger manual override every tick, creating a tight engage/disengage loop.
- **Fix**: Autopilot-originated heading commands now carry `_from_autopilot: True`. The helm skips `_record_manual_input` when this flag is set, still routing to RCS normally. Manual pilot inputs continue to override as before.
- **Symptoms fixed**: Log spam ("Manual override engaged" / "Manual override timeout, resuming autopilot" hundreds of times per second), autopilot programs unable to stay engaged, GUI showing "MANUAL" even after engaging intercept/hold programs.

## Files changed
- `hybrid/systems/navigation/navigation.py` — Pass `_from_autopilot: True` flag in autopilot heading commands
- `hybrid/systems/helm_system.py` — Respect `_from_autopilot` flag; skip manual override trigger for autopilot commands while still routing to RCS

## Test plan
- [ ] Engage intercept autopilot on Mission 1 — verify no log spam, autopilot stays engaged
- [ ] Autopilot status panel should show "INTERCEPT" (not "MANUAL") while program is active
- [ ] Manual throttle/heading commands should still trigger manual override and pause autopilot for 5s
- [ ] All 154 system tests pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)