### PR TITLE
Fix autopilot target resolution and contact name display

### DIFF
--- a/hybrid/navigation/autopilot/base.py
+++ b/hybrid/navigation/autopilot/base.py
@@ -1,8 +1,11 @@
 # hybrid/navigation/autopilot/base.py
 """Base autopilot class."""
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
 
 class BaseAutopilot(ABC):
     """Abstract base class for all autopilot programs."""
@@ -20,6 +23,7 @@ class BaseAutopilot(ABC):
         self.params = params or {}
         self.status = "initializing"
         self.error_message = None
+        self._target_warned = False
 
     @abstractmethod
     def compute(self, dt: float, sim_time: float) -> Optional[Dict]:
@@ -37,17 +41,36 @@ class BaseAutopilot(ABC):
     def get_target(self):
         """Get target ship or contact.
 
+        Resolves target by:
+        1. Sensor contact (by stable ID like C001 or original ship ID)
+        2. Direct ship lookup in _all_ships_ref (fallback for raw ship IDs)
+
         Returns:
             Target object or None
         """
         if not self.target_id:
             return None
 
-        # Try to get from sensors
+        # Try sensor contacts first (handles both C001 and target_station via id_mapping)
         sensors = self.ship.systems.get("sensors")
         if sensors and hasattr(sensors, "get_contact"):
-            return sensors.get_contact(self.target_id)
+            contact = sensors.get_contact(self.target_id)
+            if contact:
+                self._target_warned = False
+                return contact
 
+        # Fallback: look up directly in all_ships (handles raw ship IDs like target_station)
+        all_ships = getattr(self.ship, "_all_ships_ref", [])
+        for ship in all_ships:
+            if getattr(ship, "id", None) == self.target_id:
+                if not self._target_warned:
+                    logger.info(f"Autopilot: target '{self.target_id}' found via direct ship lookup (not in sensor contacts)")
+                    self._target_warned = True
+                return ship
+
+        if not self._target_warned:
+            logger.warning(f"Autopilot: target '{self.target_id}' not found in sensors or ships")
+            self._target_warned = True
         return None
 
     def get_state(self) -> Dict:

--- a/hybrid/navigation/autopilot/intercept.py
+++ b/hybrid/navigation/autopilot/intercept.py
@@ -62,12 +62,11 @@ class InterceptAutopilot(BaseAutopilot):
         Returns:
             dict: Thrust command or None
         """
-        # Get target
+        # Get target (base class handles log-once via _target_warned)
         target = self.get_target()
         if not target:
             self.status = "error"
             self.error_message = f"Target {self.target_id} not found"
-            logger.warning(f"Intercept: Target {self.target_id} not in sensor contacts")
             return None
 
         # Calculate relative motion

--- a/hybrid/systems/sensors/contact.py
+++ b/hybrid/systems/sensors/contact.py
@@ -169,7 +169,8 @@ class ContactTracker:
                 "age": age,
                 "stale": contact.is_stale(current_time, self.stale_threshold),
                 "detection_method": contact.detection_method,
-                "classification": contact.classification or "Unknown"
+                "classification": contact.classification or "Unknown",
+                "name": contact.name,
             })
 
         # Sort by distance

--- a/hybrid/telemetry.py
+++ b/hybrid/telemetry.py
@@ -182,7 +182,9 @@ def get_sensor_contacts(ship) -> Dict[str, Any]:
                 "bearing": bearing,
                 "confidence": contact_value(contact, "confidence", 0.5),
                 "last_update": contact_value(contact, "last_update", 0),
-                "detection_method": contact_value(contact, "detection_method", "passive")
+                "detection_method": contact_value(contact, "detection_method", "passive"),
+                "name": contact_value(contact, "name", None),
+                "classification": contact_value(contact, "classification", None),
             })
 
     # Get active contacts
@@ -202,7 +204,9 @@ def get_sensor_contacts(ship) -> Dict[str, Any]:
                 "bearing": bearing,
                 "confidence": contact_value(contact, "confidence", 0.9),
                 "last_update": contact_value(contact, "last_update", 0),
-                "detection_method": contact_value(contact, "detection_method", "active")
+                "detection_method": contact_value(contact, "detection_method", "active"),
+                "name": contact_value(contact, "name", None),
+                "classification": contact_value(contact, "classification", None),
             })
 
     # Sort by distance


### PR DESCRIPTION
## Summary
- **Autopilot target fallback**: `BaseAutopilot.get_target()` now falls back to direct ship lookup via `_all_ships_ref` when sensor contacts don't resolve the target. Uses a `_target_warned` flag to log once instead of spamming every tick.
- **Contact name serialization**: `telemetry.get_sensor_contacts()` and `ContactTracker.get_sorted_contacts()` now include `name` and `classification` fields in serialized contact data, so the GUI displays "Tycho Station" instead of "UNKNOWN".
- **Intercept log spam**: Removed per-tick warning from `InterceptAutopilot.compute()` since base class now handles log-once pattern.

## Files changed
- `hybrid/navigation/autopilot/base.py` — `_all_ships_ref` fallback + `_target_warned` flag
- `hybrid/navigation/autopilot/intercept.py` — Remove redundant per-tick warning
- `hybrid/telemetry.py` — Add `name`/`classification` to contact serialization
- `hybrid/systems/sensors/contact.py` — Add `name` to `get_sorted_contacts()` output

## Test plan
- [ ] Load tutorial intercept scenario
- [ ] Verify station shows as "Tycho Station" in sensor contacts panel
- [ ] Verify autopilot intercept engages without "target not found" log spam
- [ ] Check `logs/session_*.log` for clean autopilot logs (single info line, no repeating warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)