### PR TITLE
Fix contact flickering in passive sensor

### DIFF
--- a/hybrid/systems/sensors/passive.py
+++ b/hybrid/systems/sensors/passive.py
@@ -108,7 +108,15 @@ class PassiveSensor:
 
             detected[target_ship.id] = contact
 
-        # Update contacts
+        # Merge new detections with existing contacts (don't drop on failed re-detect)
+        # Failed re-detection degrades confidence rather than removing the contact
+        for existing_id, existing_contact in self.contacts.items():
+            if existing_id not in detected:
+                # Contact not re-detected this scan — degrade confidence
+                existing_contact.confidence *= 0.8
+                if existing_contact.confidence > 0.1:
+                    detected[existing_id] = existing_contact
+
         self.contacts = detected
 
         logger.debug(f"Passive sensor on {observer_ship.id}: {len(detected)} contacts")


### PR DESCRIPTION
## Summary
- Passive sensor was **replacing its entire contact list** every scan cycle (`self.contacts = detected`). With `detection_probability = accuracy^2`, a station at 54km on a 200km-range sensor had only ~29% chance of detection per scan — causing 71% of scans to drop the contact entirely.
- Now failed re-detections **degrade confidence by 20%** per scan instead of removing the contact. Contact is only dropped when confidence falls below 10%, giving roughly 10 scan cycles of persistence.
- This fixes the station flickering in/out of the sensor contacts panel, which also made it impossible to select the target for autopilot engagement.

## Test plan
- [ ] Load tutorial scenario — station contact should remain stable in contacts panel
- [ ] Contact confidence should slowly decrease if not re-detected, not instantly vanish
- [ ] Selecting the contact as autopilot target should work reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)