### PR TITLE
Add rendezvous autopilot, fix sensors/map, overhaul scenario

### DIFF
--- a/gui/components/autopilot-control.js
+++ b/gui/components/autopilot-control.js
@@ -8,6 +8,7 @@ import { wsClient } from "../js/ws-client.js";
 
 const AUTOPILOT_MODES = [
   { id: "manual", label: "MANUAL", description: "Direct control" },
+  { id: "rendezvous", label: "RENDEZVOUS", description: "Approach and arrive at target with zero relative velocity (flip-and-burn)" },
   { id: "intercept", label: "INTERCEPT", description: "Approach target" },
   { id: "match", label: "MATCH", description: "Match velocity" },
   { id: "hold", label: "HOLD", description: "Hold position" },
@@ -104,6 +105,11 @@ class AutopilotControl extends HTMLElement {
 
         .mode-btn.active {
           box-shadow: 0 0 12px rgba(0, 170, 255, 0.3);
+        }
+
+        /* Rendezvous is the primary tutorial mode — span full width for prominence */
+        .mode-btn[data-mode="rendezvous"] {
+          grid-column: 1 / -1;
         }
 
         .target-section {
@@ -304,7 +310,7 @@ class AutopilotControl extends HTMLElement {
   _updateEngageButton() {
     const engageBtn = this.shadowRoot.getElementById("engage-btn");
     const hintEl = this.shadowRoot.getElementById("engage-hint");
-    const needsTarget = ["intercept", "match"].includes(this._selectedMode);
+    const needsTarget = ["rendezvous", "intercept", "match"].includes(this._selectedMode);
     const isDisabled = needsTarget && !this._selectedTarget;
     engageBtn.disabled = isDisabled;
 

--- a/gui/components/autopilot-status.js
+++ b/gui/components/autopilot-status.js
@@ -12,8 +12,23 @@
 import { stateManager } from "../js/state-manager.js";
 import { wsClient } from "../js/ws-client.js";
 
-// Autopilot phases for GoToPosition
-const PHASES = ["ACCELERATE", "COAST", "BRAKE", "HOLD"];
+// Phase lists for different autopilot programs.
+// GoToPosition uses uppercase, Rendezvous uses lowercase, Intercept has its own set.
+// We normalise to uppercase for display and map them into a common ordered list.
+const GOTO_PHASES = ["ACCELERATE", "COAST", "BRAKE", "HOLD"];
+const RENDEZVOUS_PHASES = ["BURN", "FLIP", "BRAKE", "STATIONKEEP"];
+const INTERCEPT_PHASES = ["INTERCEPT", "APPROACH", "MATCH"];
+
+// Map program names to their phase lists
+const PROGRAM_PHASES = {
+  goto_position: GOTO_PHASES,
+  set_course: GOTO_PHASES,
+  rendezvous: RENDEZVOUS_PHASES,
+  intercept: INTERCEPT_PHASES,
+};
+
+// Default fallback
+const DEFAULT_PHASES = GOTO_PHASES;
 
 class AutopilotStatus extends HTMLElement {
   constructor() {
@@ -24,7 +39,12 @@ class AutopilotStatus extends HTMLElement {
     this._phase = null;
     this._status = null;
     this._mode = "manual";
-    this._courseInfo = null;
+    this._apState = null;
+    this._range = null;
+    this._closingSpeed = null;
+    this._brakingDistance = null;
+    this._eta = null;
+    this._statusText = null;
   }
 
   connectedCallback() {
@@ -149,10 +169,19 @@ class AutopilotStatus extends HTMLElement {
           background: var(--status-nominal, #00ff88);
         }
 
+        /* GoToPosition phases */
         .phase-segment.accelerate.active { background: var(--status-warning, #ffaa00); }
         .phase-segment.coast.active { background: var(--status-info, #00aaff); }
         .phase-segment.brake.active { background: var(--status-critical, #ff4444); }
         .phase-segment.hold.active { background: var(--status-nominal, #00ff88); }
+        /* Rendezvous phases */
+        .phase-segment.burn.active { background: var(--status-warning, #ffaa00); }
+        .phase-segment.flip.active { background: #cc66ff; }
+        .phase-segment.stationkeep.active { background: var(--status-nominal, #00ff88); }
+        /* Intercept phases */
+        .phase-segment.intercept.active { background: var(--status-warning, #ffaa00); }
+        .phase-segment.approach.active { background: var(--status-info, #00aaff); }
+        .phase-segment.match.active { background: var(--status-nominal, #00ff88); }
 
         .phase-labels {
           display: flex;
@@ -168,6 +197,23 @@ class AutopilotStatus extends HTMLElement {
         .phase-label.active {
           color: var(--text-primary, #e0e0e0);
           font-weight: 600;
+        }
+
+        /* Status Text */
+        .status-text {
+          font-size: 0.75rem;
+          color: var(--text-secondary, #888899);
+          text-align: center;
+          padding: 6px 8px;
+          margin-bottom: 8px;
+          background: var(--bg-input, #1a1a24);
+          border-radius: 4px;
+          font-style: italic;
+          min-height: 1.4em;
+        }
+
+        .status-text:empty {
+          display: none;
         }
 
         /* Info Grid */
@@ -250,19 +296,11 @@ class AutopilotStatus extends HTMLElement {
             </div>
 
             <div class="phase-progress" id="phase-progress">
-              <div class="phase-bar">
-                <div class="phase-segment accelerate" data-phase="ACCELERATE"></div>
-                <div class="phase-segment coast" data-phase="COAST"></div>
-                <div class="phase-segment brake" data-phase="BRAKE"></div>
-                <div class="phase-segment hold" data-phase="HOLD"></div>
-              </div>
-              <div class="phase-labels">
-                <span class="phase-label" data-phase="ACCELERATE">Accel</span>
-                <span class="phase-label" data-phase="COAST">Coast</span>
-                <span class="phase-label" data-phase="BRAKE">Brake</span>
-                <span class="phase-label" data-phase="HOLD">Hold</span>
-              </div>
+              <div class="phase-bar" id="phase-bar"></div>
+              <div class="phase-labels" id="phase-labels"></div>
             </div>
+
+            <div class="status-text" id="status-text"></div>
 
             <div class="info-grid">
               <div class="info-item">
@@ -278,8 +316,8 @@ class AutopilotStatus extends HTMLElement {
                 <div class="info-value" id="info-braking">--</div>
               </div>
               <div class="info-item">
-                <div class="info-label">Target</div>
-                <div class="info-value" id="info-target">--</div>
+                <div class="info-label">ETA</div>
+                <div class="info-value" id="info-eta">--</div>
               </div>
             </div>
 
@@ -307,19 +345,34 @@ class AutopilotStatus extends HTMLElement {
     const ship = stateManager.getShipState();
     const navigation = ship?.systems?.navigation || {};
     const helm = ship?.systems?.helm || {};
-    // Station-filtered view nests under ship.autopilot
+    // Station-filtered HELM view nests autopilot data under ship.autopilot
     const ap = ship?.autopilot || {};
 
-    // Check all possible paths: top-level, station-filtered, nested systems
+    // Check all possible paths for mode and program name
     this._mode = ship?.nav_mode || ap.mode || navigation.mode || helm.mode || "manual";
     this._program = ship?.autopilot_program || ap.program || navigation.current_program || helm.autopilot_program || null;
-    this._status = ship?.autopilot_state?.status || ap.autopilot_state?.status || navigation.autopilot_state?.status || null;
 
-    // Get course info from any available path
-    this._courseInfo = ship?.course || ap.course || navigation.course || ship?.autopilot_state || ap.autopilot_state || navigation.autopilot_state || null;
-    if (this._courseInfo) {
-      this._phase = this._courseInfo.phase || null;
-    }
+    // Autopilot state dict -- the rich data from the autopilot's get_state().
+    // Telemetry puts it at top-level as "autopilot_state", station filter
+    // nests it under "autopilot.autopilot_state", and navigation system
+    // exposes it via systems.navigation.autopilot_state.
+    const apState = ship?.autopilot_state
+      || ap.autopilot_state
+      || navigation.autopilot_state
+      || null;
+
+    this._status = apState?.status || null;
+    this._apState = apState;
+
+    // Phase from autopilot state (normalise to uppercase for display)
+    this._phase = apState?.phase?.toUpperCase() || null;
+
+    // Extract numeric fields -- autopilots use "range" or "distance" depending on type
+    this._range = apState?.range ?? apState?.distance ?? null;
+    this._closingSpeed = apState?.closing_speed ?? null;
+    this._brakingDistance = apState?.braking_distance ?? null;
+    this._eta = apState?.time_to_arrival ?? null;
+    this._statusText = apState?.status_text ?? null;
 
     this._updateDisplay();
   }
@@ -378,86 +431,106 @@ class AutopilotStatus extends HTMLElement {
   }
 
   _updatePhaseProgress() {
-    const segments = this.shadowRoot.querySelectorAll(".phase-segment");
-    const labels = this.shadowRoot.querySelectorAll(".phase-label");
-    const currentPhase = this._phase?.toUpperCase() || null;
-    const currentIndex = PHASES.indexOf(currentPhase);
+    const bar = this.shadowRoot.getElementById("phase-bar");
+    const labelsContainer = this.shadowRoot.getElementById("phase-labels");
+    if (!bar || !labelsContainer) return;
 
-    segments.forEach((segment, index) => {
-      segment.classList.remove("active", "completed");
-      if (index < currentIndex) {
-        segment.classList.add("completed");
-      } else if (index === currentIndex) {
-        segment.classList.add("active");
-      }
-    });
+    // Pick the phase list for the current program
+    const programKey = this._program?.toLowerCase() || "";
+    const phases = PROGRAM_PHASES[programKey] || DEFAULT_PHASES;
+    const currentPhase = this._phase || null;
+    const currentIndex = phases.indexOf(currentPhase);
 
-    labels.forEach((label, index) => {
-      label.classList.remove("active");
-      if (index === currentIndex) {
-        label.classList.add("active");
-      }
+    // Rebuild segments and labels to match the active program's phases
+    bar.innerHTML = phases.map(
+      (p) => `<div class="phase-segment ${p.toLowerCase()}" data-phase="${p}"></div>`
+    ).join("");
+    labelsContainer.innerHTML = phases.map(
+      (p) => `<span class="phase-label" data-phase="${p}">${this._shortPhaseLabel(p)}</span>`
+    ).join("");
+
+    // Apply active/completed classes
+    bar.querySelectorAll(".phase-segment").forEach((seg, i) => {
+      if (i < currentIndex) seg.classList.add("completed");
+      else if (i === currentIndex) seg.classList.add("active");
     });
+    labelsContainer.querySelectorAll(".phase-label").forEach((lbl, i) => {
+      if (i === currentIndex) lbl.classList.add("active");
+    });
+  }
+
+  /** Short display label for a phase name */
+  _shortPhaseLabel(phase) {
+    const labels = {
+      ACCELERATE: "Accel",
+      COAST: "Coast",
+      BRAKE: "Brake",
+      HOLD: "Hold",
+      BURN: "Burn",
+      FLIP: "Flip",
+      STATIONKEEP: "Stnkeep",
+      INTERCEPT: "Intrcpt",
+      APPROACH: "Approach",
+      MATCH: "Match",
+    };
+    return labels[phase] || phase;
   }
 
   _updateInfoGrid() {
     const distanceEl = this.shadowRoot.getElementById("info-distance");
     const closingEl = this.shadowRoot.getElementById("info-closing");
     const brakingEl = this.shadowRoot.getElementById("info-braking");
-    const targetEl = this.shadowRoot.getElementById("info-target");
+    const etaEl = this.shadowRoot.getElementById("info-eta");
+    const statusTextEl = this.shadowRoot.getElementById("status-text");
 
-    if (this._courseInfo) {
-      // Distance
-      if (distanceEl) {
-        const dist = this._courseInfo.distance;
-        if (dist !== null && dist !== undefined) {
-          if (dist > 1000) {
-            distanceEl.textContent = `${(dist / 1000).toFixed(2)} km`;
-          } else {
-            distanceEl.textContent = `${dist.toFixed(1)} m`;
-          }
-        } else {
-          distanceEl.textContent = "--";
-        }
-      }
-
-      // Closing speed
-      if (closingEl) {
-        const closing = this._courseInfo.closing_speed;
-        if (closing !== null && closing !== undefined) {
-          closingEl.textContent = `${closing.toFixed(1)} m/s`;
-        } else {
-          closingEl.textContent = "--";
-        }
-      }
-
-      // Braking distance
-      if (brakingEl) {
-        const braking = this._courseInfo.braking_distance;
-        if (braking !== null && braking !== undefined) {
-          if (braking > 1000) {
-            brakingEl.textContent = `${(braking / 1000).toFixed(2)} km`;
-          } else {
-            brakingEl.textContent = `${braking.toFixed(1)} m`;
-          }
-        } else {
-          brakingEl.textContent = "--";
-        }
-      }
-
-      // Target/destination
-      if (targetEl) {
-        const dest = this._courseInfo.destination;
-        if (dest) {
-          const x = dest.x?.toFixed(0) || 0;
-          const y = dest.y?.toFixed(0) || 0;
-          const z = dest.z?.toFixed(0) || 0;
-          targetEl.textContent = `(${x}, ${y}, ${z})`;
-        } else {
-          targetEl.textContent = "--";
-        }
-      }
+    // Distance (use normalised _range which covers both "range" and "distance" fields)
+    if (distanceEl) {
+      distanceEl.textContent = this._formatDistance(this._range);
     }
+
+    // Closing speed
+    if (closingEl) {
+      closingEl.textContent = this._closingSpeed != null
+        ? `${this._closingSpeed.toFixed(1)} m/s`
+        : "--";
+    }
+
+    // Braking distance
+    if (brakingEl) {
+      brakingEl.textContent = this._formatDistance(this._brakingDistance);
+    }
+
+    // ETA
+    if (etaEl) {
+      etaEl.textContent = this._formatEta(this._eta);
+    }
+
+    // Human-readable status text from the autopilot
+    if (statusTextEl) {
+      statusTextEl.textContent = this._statusText || "";
+    }
+  }
+
+  /** Format a distance in metres for display: "427.3 km" or "850 m" */
+  _formatDistance(metres) {
+    if (metres == null) return "--";
+    if (metres >= 1000) {
+      return `${(metres / 1000).toFixed(1)} km`;
+    }
+    return `${metres.toFixed(0)} m`;
+  }
+
+  /** Format seconds into "Xm Ys" or "Xs" */
+  _formatEta(seconds) {
+    if (seconds == null) return "--";
+    if (seconds <= 0) return "0s";
+    if (seconds < 60) return `${seconds.toFixed(0)}s`;
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    if (m < 60) return `${m}m ${String(s).padStart(2, "0")}s`;
+    const h = Math.floor(m / 60);
+    const rm = m % 60;
+    return `${h}h ${String(rm).padStart(2, "0")}m`;
   }
 
   async _engageHold() {

--- a/gui/components/sensor-contacts.js
+++ b/gui/components/sensor-contacts.js
@@ -7,22 +7,35 @@ import { stateManager } from "../js/state-manager.js";
 import { wsClient } from "../js/ws-client.js";
 import { helmRequests, calculate3DBearing } from "../js/helm-requests.js";
 
+// How long a lost contact remains visible (faded) before removal
+const STALE_TIMEOUT_MS = 8000;
+
 class SensorContacts extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: "open" });
     this._unsubscribe = null;
     this._selectedContact = null;
+    // Map of contactId -> { contact, lostAt } for contacts that disappeared from server data
+    this._staleContacts = new Map();
+    this._staleTimer = null;
   }
 
   connectedCallback() {
     this.render();
     this._subscribe();
+    // Periodically purge expired stale contacts
+    this._staleTimer = setInterval(() => this._purgeStaleContacts(), 2000);
   }
 
   disconnectedCallback() {
     if (this._unsubscribe) {
       this._unsubscribe();
+      this._unsubscribe = null;
+    }
+    if (this._staleTimer) {
+      clearInterval(this._staleTimer);
+      this._staleTimer = null;
     }
   }
 
@@ -146,6 +159,8 @@ class SensorContacts extends HTMLElement {
           flex: 1;
           overflow-y: auto;
           padding: 8px 0;
+          /* Stable minimum height prevents panel resize when contacts come/go */
+          min-height: 140px;
         }
 
         .contact-row {
@@ -154,7 +169,7 @@ class SensorContacts extends HTMLElement {
           gap: 6px;
           padding: 8px 16px;
           cursor: pointer;
-          transition: background 0.1s ease;
+          transition: opacity 0.4s ease, background 0.1s ease;
           font-family: var(--font-mono, "JetBrains Mono", monospace);
           font-size: 0.75rem;
         }
@@ -220,6 +235,23 @@ class SensorContacts extends HTMLElement {
           background: var(--status-info, #00aaff);
           border-color: var(--status-info, #00aaff);
           color: var(--bg-primary, #0a0a0f);
+        }
+
+        .contact-row.stale {
+          opacity: 0.35;
+          pointer-events: none;
+        }
+
+        .contact-row.stale .contact-id {
+          color: var(--text-dim, #555566);
+        }
+
+        .stale-label {
+          color: var(--status-warning, #ffaa00);
+          font-size: 0.6rem;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.5px;
         }
 
         .contact-row:hover {
@@ -531,8 +563,51 @@ class SensorContacts extends HTMLElement {
 
   _updateContactsList(contacts) {
     const list = this.shadowRoot.getElementById("contacts-list");
+    const liveContacts = contacts || [];
 
-    if (!contacts || contacts.length === 0) {
+    // Build set of currently live contact IDs
+    const liveIds = new Set(
+      liveContacts.map(c => c.contact_id || c.id)
+    );
+
+    // Any previously known contact (live or stale) that reappears: remove from stale
+    for (const id of liveIds) {
+      this._staleContacts.delete(id);
+    }
+
+    // Track which contacts just disappeared: mark as stale
+    // Compare against what was rendered last time (live rows from previous frame)
+    if (this._lastLiveIds) {
+      for (const prevId of this._lastLiveIds) {
+        if (!liveIds.has(prevId) && !this._staleContacts.has(prevId)) {
+          // Contact disappeared — find its last known data from previous render
+          const lastData = this._lastContactData?.get(prevId);
+          if (lastData) {
+            this._staleContacts.set(prevId, {
+              contact: lastData,
+              lostAt: Date.now()
+            });
+          }
+        }
+      }
+    }
+
+    // Save current live state for next comparison
+    this._lastLiveIds = liveIds;
+    this._lastContactData = new Map(
+      liveContacts.map(c => [c.contact_id || c.id, c])
+    );
+
+    // Purge expired stale contacts
+    this._purgeStaleContacts();
+
+    // Merge live + stale contacts for display
+    const allContacts = [...liveContacts];
+    for (const [id, entry] of this._staleContacts) {
+      allContacts.push(entry.contact);
+    }
+
+    if (allContacts.length === 0) {
       list.innerHTML = `
         <div class="empty-state">
           <div class="empty-icon">○</div>
@@ -542,18 +617,41 @@ class SensorContacts extends HTMLElement {
       return;
     }
 
-    // Sort by range (nearest first)
-    const sorted = [...contacts].sort((a, b) => {
+    // Sort by range (nearest first), stale contacts sort to bottom
+    const sorted = [...allContacts].sort((a, b) => {
+      const aId = a.contact_id || a.id;
+      const bId = b.contact_id || b.id;
+      const aStale = this._staleContacts.has(aId) ? 1 : 0;
+      const bStale = this._staleContacts.has(bId) ? 1 : 0;
+      if (aStale !== bStale) return aStale - bStale;
       const rangeA = a.range || a.distance || Infinity;
       const rangeB = b.range || b.distance || Infinity;
       return rangeA - rangeB;
     });
 
-    list.innerHTML = sorted.map(contact => this._renderContactRow(contact)).join("");
+    list.innerHTML = sorted
+      .map(contact => {
+        const cId = contact.contact_id || contact.id;
+        const isStale = this._staleContacts.has(cId);
+        return this._renderContactRow(contact, isStale);
+      })
+      .join("");
     this._updateContactSelection();
   }
 
-  _renderContactRow(contact) {
+  /**
+   * Remove stale contacts that have exceeded the timeout
+   */
+  _purgeStaleContacts() {
+    const now = Date.now();
+    for (const [id, entry] of this._staleContacts) {
+      if (now - entry.lostAt > STALE_TIMEOUT_MS) {
+        this._staleContacts.delete(id);
+      }
+    }
+  }
+
+  _renderContactRow(contact, isStale = false) {
     const id = contact.contact_id || contact.id || "???";
     const classification = contact.name || contact.classification || contact.class || "UNKNOWN";
     const bearing = contact.bearing ?? "---";
@@ -581,15 +679,17 @@ class SensorContacts extends HTMLElement {
     const relY = posY - shipY;
     const relZ = posZ - shipZ;
 
+    const staleClass = isStale ? "stale" : "";
+
     return `
-      <div class="contact-row ${isSelected ? 'selected' : ''}" data-contact-id="${id}">
+      <div class="contact-row ${isSelected ? 'selected' : ''} ${staleClass}" data-contact-id="${id}">
         <span class="contact-id">${isSelected ? '►' : ' '}${id.substring(0, 5)}</span>
-        <span class="contact-class">${classification.substring(0, 8)}</span>
-        <span class="contact-bearing">${this._formatBearing(bearing)}°</span>
-        <span class="contact-range">${this._formatRange(range)}</span>
-        <span class="contact-closure ${closureClass}">${closureSign}${Math.abs(rangeRate).toFixed(0)}</span>
+        <span class="contact-class">${isStale ? '<span class="stale-label">LOST</span>' : classification.substring(0, 8)}</span>
+        <span class="contact-bearing">${isStale ? '---' : this._formatBearing(bearing) + '°'}</span>
+        <span class="contact-range">${isStale ? '---' : this._formatRange(range)}</span>
+        <span class="contact-closure ${closureClass}">${isStale ? '---' : closureSign + Math.abs(rangeRate).toFixed(0)}</span>
       </div>
-      <div class="contact-expanded ${isSelected ? 'visible' : ''}" data-contact-id="${id}">
+      <div class="contact-expanded ${isSelected && !isStale ? 'visible' : ''}" data-contact-id="${id}">
         <div class="position-grid">
           <div class="pos-item">
             <div class="pos-label">Rel X</div>

--- a/gui/components/tactical-map.js
+++ b/gui/components/tactical-map.js
@@ -5,7 +5,7 @@
 
 import { stateManager } from "../js/state-manager.js";
 
-const MAP_SCALE_OPTIONS = [1000, 5000, 10000, 50000, 100000]; // meters per screen radius
+const MAP_SCALE_OPTIONS = [1000, 5000, 10000, 50000, 100000, 250000, 500000, 1000000]; // meters per screen radius
 
 const WEAPON_RANGES = {
   PDC: 5000,        // 5km in meters
@@ -18,6 +18,7 @@ class TacticalMap extends HTMLElement {
     this.attachShadow({ mode: "open" });
     this._unsubscribe = null;
     this._scaleIndex = 2; // Default 10km
+    this._autoFit = true; // Auto-scale to fit all contacts
     this._showVelocityVectors = true;
     this._showHeading = true;
     this._showGrid = true;
@@ -202,6 +203,7 @@ class TacticalMap extends HTMLElement {
           <button class="control-btn" id="zoom-out">−</button>
           <span class="scale-display" id="scale-display">10 km</span>
           <button class="control-btn" id="zoom-in">+</button>
+          <button class="control-btn active" id="auto-fit" title="Auto-fit to show all contacts">A</button>
         </div>
         <div class="control-group">
           <button class="control-btn" id="toggle-vectors" title="Velocity Vectors">V</button>
@@ -288,10 +290,11 @@ class TacticalMap extends HTMLElement {
   }
 
   _setupInteraction() {
-    // Zoom controls
+    // Zoom controls — manual zoom disables auto-fit
     this.shadowRoot.getElementById("zoom-in").addEventListener("click", () => {
       if (this._scaleIndex > 0) {
         this._scaleIndex--;
+        this._setAutoFit(false);
         this._updateScaleDisplay();
         this._draw();
       }
@@ -300,9 +303,17 @@ class TacticalMap extends HTMLElement {
     this.shadowRoot.getElementById("zoom-out").addEventListener("click", () => {
       if (this._scaleIndex < MAP_SCALE_OPTIONS.length - 1) {
         this._scaleIndex++;
+        this._setAutoFit(false);
         this._updateScaleDisplay();
         this._draw();
       }
+    });
+
+    // Auto-fit toggle
+    const autoFitBtn = this.shadowRoot.getElementById("auto-fit");
+    autoFitBtn.addEventListener("click", () => {
+      this._setAutoFit(!this._autoFit);
+      this._draw();
     });
 
     // Toggle buttons
@@ -344,6 +355,80 @@ class TacticalMap extends HTMLElement {
       this._handleCanvasClick(e);
     });
 
+    this._updateScaleDisplay();
+  }
+
+  _setAutoFit(enabled) {
+    this._autoFit = enabled;
+    const btn = this.shadowRoot.getElementById("auto-fit");
+    if (btn) btn.classList.toggle("active", enabled);
+  }
+
+  /**
+   * Resolve a contact's world position. Prefers the position field from telemetry,
+   * but reconstructs from distance + bearing relative to the player if missing.
+   */
+  _resolveContactPosition(contact, playerPos) {
+    // If telemetry includes the actual position, use it directly
+    if (contact.position && (contact.position.x !== undefined || contact.position.y !== undefined)) {
+      return contact.position;
+    }
+
+    // Reconstruct from distance + bearing.
+    // Server bearing is {yaw, pitch} where yaw = atan2(dy, dx) in the XY plane.
+    // A scalar bearing is treated as yaw in degrees.
+    if (contact.distance != null && contact.bearing != null) {
+      const yawDeg = typeof contact.bearing === "object"
+        ? (contact.bearing.yaw || 0)
+        : contact.bearing;
+      const pitchDeg = typeof contact.bearing === "object"
+        ? (contact.bearing.pitch || 0)
+        : 0;
+      const yawRad = (yawDeg * Math.PI) / 180;
+      const pitchRad = (pitchDeg * Math.PI) / 180;
+      const horizDist = contact.distance * Math.cos(pitchRad);
+      return {
+        x: playerPos.x + horizDist * Math.cos(yawRad),
+        y: playerPos.y + horizDist * Math.sin(yawRad),
+        z: playerPos.z + contact.distance * Math.sin(pitchRad),
+      };
+    }
+
+    // No usable position data — place at player origin (will overlap)
+    return { x: playerPos.x, y: playerPos.y, z: playerPos.z };
+  }
+
+  /**
+   * Auto-fit the scale so all contacts are visible with some padding.
+   */
+  _autoFitScale(contacts, playerPos) {
+    if (!contacts || contacts.length === 0) return;
+
+    let maxDist = 0;
+    for (const contact of contacts) {
+      const pos = this._resolveContactPosition(contact, playerPos);
+      const dx = pos.x - playerPos.x;
+      const dz = pos.z - playerPos.z;
+      const dist = Math.sqrt(dx * dx + dz * dz);
+      if (dist > maxDist) maxDist = dist;
+    }
+
+    if (maxDist < 100) return; // All contacts very close, keep current scale
+
+    // Add 20% padding so contacts aren't at the very edge
+    const neededScale = maxDist * 1.2;
+
+    // Find the smallest scale option that fits
+    for (let i = 0; i < MAP_SCALE_OPTIONS.length; i++) {
+      if (MAP_SCALE_OPTIONS[i] >= neededScale) {
+        this._scaleIndex = i;
+        this._updateScaleDisplay();
+        return;
+      }
+    }
+
+    // If nothing fits, use the largest available
+    this._scaleIndex = MAP_SCALE_OPTIONS.length - 1;
     this._updateScaleDisplay();
   }
 
@@ -394,6 +479,20 @@ class TacticalMap extends HTMLElement {
 
     // Draw contacts
     const contacts = stateManager.getContacts() || [];
+
+    // Auto-fit scale to show all contacts before rendering.
+    // We do this before drawing so the scale is correct for this frame.
+    if (this._autoFit && contacts.length > 0) {
+      const prevIndex = this._scaleIndex;
+      this._autoFitScale(contacts, playerPos);
+      // If the scale changed, we need to redraw with the new pixelsPerMeter.
+      // Guard against repeated redraws by only redrawing once per auto-fit change.
+      if (this._scaleIndex !== prevIndex) {
+        this._draw();
+        return;
+      }
+    }
+
     contacts.forEach(contact => {
       this._drawContact(ctx, contact, playerPos, centerX, centerY, pixelsPerMeter, playerVel, scale);
     });
@@ -579,8 +678,8 @@ class TacticalMap extends HTMLElement {
   }
 
   _drawContact(ctx, contact, playerPos, centerX, centerY, pixelsPerMeter, playerVel, scale) {
-    // Calculate relative position
-    const contactPos = contact.position || { x: 0, y: 0, z: 0 };
+    // Calculate relative position — reconstruct from distance/bearing if position is missing
+    const contactPos = this._resolveContactPosition(contact, playerPos);
     const relX = (contactPos.x - playerPos.x) * pixelsPerMeter;
     const relZ = (contactPos.z - playerPos.z) * pixelsPerMeter;
 
@@ -732,7 +831,7 @@ class TacticalMap extends HTMLElement {
     // Calculate distance and bearing from player
     const ship = stateManager.getShipState();
     const playerPos = ship?.position || { x: 0, y: 0, z: 0 };
-    const contactPos = contact.position || { x: 0, y: 0, z: 0 };
+    const contactPos = this._resolveContactPosition(contact, playerPos);
 
     const dx = contactPos.x - playerPos.x;
     const dz = contactPos.z - playerPos.z;

--- a/gui/js/ws-client.js
+++ b/gui/js/ws-client.js
@@ -6,7 +6,7 @@
 class WSClient extends EventTarget {
   constructor(url = null) {
     super();
-    this.url = url || `ws://${window.location.hostname}:8080`;
+    this.url = url || `ws://${window.location.hostname}:8081`;
     this.socket = null;
     this.status = "disconnected"; // disconnected, connecting, connected
     this.reconnectAttempts = 0;

--- a/gui/ws_bridge.py
+++ b/gui/ws_bridge.py
@@ -283,6 +283,15 @@ class WSBridge:
         wrapped = WSEnvelope.response(response_data)
         await websocket.send(wrapped.to_wire())
 
+    async def _tcp_reconnect_loop(self):
+        """Periodically retry TCP connection if not connected."""
+        while self._running:
+            if not self.tcp.connected:
+                connected = await self.tcp.connect()
+                if connected:
+                    await self._maybe_broadcast_tcp_status()
+            await asyncio.sleep(2)
+
     async def start(self):
         """Start the WebSocket server."""
         self._running = True
@@ -301,8 +310,13 @@ class WSBridge:
             ping_timeout=10
         ):
             logger.info("WebSocket bridge running. Press Ctrl+C to stop.")
-            while self._running:
-                await asyncio.sleep(1)
+            # Start background TCP reconnection loop
+            reconnect_task = asyncio.create_task(self._tcp_reconnect_loop())
+            try:
+                while self._running:
+                    await asyncio.sleep(1)
+            finally:
+                reconnect_task.cancel()
 
     def stop(self):
         """Signal the bridge to stop."""

--- a/hybrid/navigation/autopilot/__init__.py
+++ b/hybrid/navigation/autopilot/__init__.py
@@ -9,6 +9,7 @@ from .formation import FormationAutopilot, EchelonFormationAutopilot
 from .goto_position import GoToPositionAutopilot
 from .orbit import OrbitAutopilot
 from .evasive import EvasiveAutopilot
+from .rendezvous import RendezvousAutopilot
 from .factory import AutopilotFactory
 
 __all__ = [
@@ -21,5 +22,6 @@ __all__ = [
     'GoToPositionAutopilot',
     'OrbitAutopilot',
     'EvasiveAutopilot',
+    'RendezvousAutopilot',
     'AutopilotFactory'
 ]

--- a/hybrid/navigation/autopilot/factory.py
+++ b/hybrid/navigation/autopilot/factory.py
@@ -11,6 +11,7 @@ from hybrid.navigation.autopilot.formation import FormationAutopilot, EchelonFor
 from hybrid.navigation.autopilot.goto_position import GoToPositionAutopilot
 from hybrid.navigation.autopilot.orbit import OrbitAutopilot
 from hybrid.navigation.autopilot.evasive import EvasiveAutopilot
+from hybrid.navigation.autopilot.rendezvous import RendezvousAutopilot
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,8 @@ class AutopilotFactory:
         "orbit": OrbitAutopilot,
         "evasive": EvasiveAutopilot,
         "jink": EvasiveAutopilot,  # Alias
+        "rendezvous": RendezvousAutopilot,
+        "dock_approach": RendezvousAutopilot,  # Alias
         "off": None  # Disengage autopilot
     }
 
@@ -111,6 +114,7 @@ class AutopilotFactory:
             "echelon": "Formation keeping with collision avoidance",
             "orbit": "Maintain circular orbit around a point",
             "evasive": "Random jink pattern to avoid incoming fire",
+            "rendezvous": "Flip-and-burn to arrive at target with zero velocity",
             "off": "Disengage autopilot"
         }
 

--- a/hybrid/navigation/autopilot/goto_position.py
+++ b/hybrid/navigation/autopilot/goto_position.py
@@ -2,6 +2,7 @@
 """Go-to-position autopilot for set_course navigation."""
 
 import logging
+import math
 from typing import Dict, Optional
 
 from hybrid.navigation.autopilot.base import BaseAutopilot
@@ -165,14 +166,49 @@ class GoToPositionAutopilot(BaseAutopilot):
         max_accel = self._get_max_accel()
         braking_distance = (closing_speed ** 2) / (2 * max_accel) if closing_speed > 0 else 0.0
 
+        # ETA estimate
+        time_to_arrival = None
+        if closing_speed > 0.1:
+            time_to_arrival = distance / closing_speed
+        elif max_accel > 0 and distance > 0 and self.phase == self.PHASE_ACCELERATE:
+            # Rough brachistochrone estimate: t = 2 * sqrt(d / a)
+            time_to_arrival = 2.0 * math.sqrt(distance / max_accel)
+
+        # Also expose as "range" for consistent field naming across autopilots
         state.update({
             "phase": self.phase,
             "destination": self.target_position,
             "distance": distance,
+            "range": distance,
             "closing_speed": closing_speed,
             "braking_distance": braking_distance,
+            "time_to_arrival": time_to_arrival,
             "stop": self.stop_at_target,
             "tolerance": self.tolerance,
             "complete": self.completed,
+            "status_text": self._build_status_text(distance, closing_speed, time_to_arrival),
         })
         return state
+
+    def _build_status_text(self, distance: float, closing_speed: float,
+                           eta: float = None) -> str:
+        """Human-readable status for the GUI."""
+        range_str = f"{distance / 1000:.1f}km" if distance >= 1000 else f"{distance:.0f}m"
+        eta_str = ""
+        if eta is not None:
+            if eta < 60:
+                eta_str = f", ETA {eta:.0f}s"
+            else:
+                minutes = int(eta) // 60
+                secs = int(eta) % 60
+                eta_str = f", ETA {minutes}m {secs:02d}s"
+
+        if self.phase == self.PHASE_ACCELERATE:
+            return f"Accelerating -- {range_str}{eta_str}"
+        elif self.phase == self.PHASE_COAST:
+            return f"Coasting -- {range_str}, {closing_speed:.1f} m/s{eta_str}"
+        elif self.phase == self.PHASE_BRAKE:
+            return f"Braking -- {range_str} remaining{eta_str}"
+        elif self.phase == self.PHASE_HOLD:
+            return f"Holding position at destination"
+        return f"En route -- {range_str}"

--- a/hybrid/navigation/autopilot/intercept.py
+++ b/hybrid/navigation/autopilot/intercept.py
@@ -209,16 +209,55 @@ class InterceptAutopilot(BaseAutopilot):
         """Get intercept autopilot state.
 
         Returns:
-            dict: State with phase info
+            dict: State with phase, range, closing_speed, time_to_arrival,
+            and human-readable status_text for GUI display.
         """
         state = super().get_state()
         state["phase"] = self.phase
         state["desired_approach_speed"] = self.desired_approach_speed
 
         target = self.get_target()
-        if target:
-            rel_motion = calculate_relative_motion(self.ship, target)
-            state["range"] = rel_motion["range"]
-            state["closing_speed"] = -rel_motion["range_rate"] if rel_motion["closing"] else 0
+        if not target:
+            state["status_text"] = "Target lost"
+            return state
+
+        rel_motion = calculate_relative_motion(self.ship, target)
+        current_range = rel_motion["range"]
+        closing_speed = -rel_motion["range_rate"] if rel_motion["closing"] else 0
+
+        # ETA estimate: distance / closing_speed when closing, else None
+        time_to_arrival = None
+        if closing_speed > 0.1:
+            time_to_arrival = current_range / closing_speed
+
+        state["range"] = current_range
+        state["closing_speed"] = closing_speed
+        state["time_to_arrival"] = time_to_arrival
+        state["status_text"] = self._build_status_text(
+            current_range, closing_speed, time_to_arrival
+        )
 
         return state
+
+    def _build_status_text(self, distance: float, closing_speed: float,
+                           eta: float = None) -> str:
+        """Human-readable status for the GUI."""
+        range_str = f"{distance / 1000:.1f}km" if distance >= 1000 else f"{distance:.0f}m"
+        if self.phase == "intercept":
+            eta_str = f", ETA {self._format_eta(eta)}" if eta else ""
+            return f"Intercept burn -- {range_str}{eta_str}"
+        elif self.phase == "approach":
+            return f"Approaching -- {range_str}, {closing_speed:.1f} m/s"
+        else:  # match
+            return f"Matching velocity at {range_str}"
+
+    @staticmethod
+    def _format_eta(seconds: float) -> str:
+        """Format seconds into compact time string."""
+        if seconds is None or seconds < 0:
+            return "0s"
+        if seconds < 60:
+            return f"{seconds:.0f}s"
+        minutes = int(seconds) // 60
+        secs = int(seconds) % 60
+        return f"{minutes}m {secs:02d}s"

--- a/hybrid/navigation/autopilot/rendezvous.py
+++ b/hybrid/navigation/autopilot/rendezvous.py
@@ -1,0 +1,262 @@
+# hybrid/navigation/autopilot/rendezvous.py
+"""Rendezvous autopilot - flip-and-burn trajectory to arrive at a target
+with near-zero relative velocity.  Burn -> flip -> brake -> stationkeep."""
+
+import logging
+import math
+from typing import Dict, Optional
+
+from hybrid.navigation.autopilot.base import BaseAutopilot
+from hybrid.navigation.autopilot.match_velocity import MatchVelocityAutopilot
+from hybrid.navigation.relative_motion import (
+    calculate_relative_motion, vector_to_heading,
+)
+from hybrid.utils.math_utils import subtract_vectors, magnitude
+
+logger = logging.getLogger(__name__)
+
+
+class RendezvousAutopilot(BaseAutopilot):
+    """Flip-and-burn autopilot for arriving at a stationary or slow target.
+
+    Phases:
+        burn        - Accelerate toward target.
+        flip        - Rotate 180 degrees to face retrograde.
+        brake       - Decelerate toward target.
+        stationkeep - Hold position via MatchVelocityAutopilot.
+    """
+
+    STATIONKEEP_RANGE = 100.0       # metres
+    STATIONKEEP_SPEED = 1.0         # m/s relative
+    FLIP_TOLERANCE_DEG = 10.0       # degrees
+    # Start braking slightly early to avoid overshooting
+    BRAKE_MARGIN = 1.05
+
+    def __init__(self, ship, target_id: Optional[str] = None,
+                 params: Optional[Dict] = None):
+        """Initialise rendezvous autopilot.
+
+        Args:
+            ship: Ship under autopilot control.
+            target_id: Sensor contact ID of the target.
+            params: Optional overrides -- max_thrust (0-1),
+                    stationkeep_range (m), stationkeep_speed (m/s).
+        """
+        super().__init__(ship, target_id, params or {})
+        self.max_thrust: float = self.params.get("max_thrust", 1.0)
+        self.stationkeep_range: float = self.params.get(
+            "stationkeep_range", self.STATIONKEEP_RANGE)
+        self.stationkeep_speed: float = self.params.get(
+            "stationkeep_speed", self.STATIONKEEP_SPEED)
+        self.phase: str = "burn"
+        self._match_ap: Optional[MatchVelocityAutopilot] = None
+        self.status = "active"
+        if not target_id:
+            self.status = "error"
+            self.error_message = "No target specified for rendezvous"
+
+    def _get_max_accel(self) -> float:
+        """Max linear acceleration (m/s^2) from propulsion, with safe floor."""
+        propulsion = self.ship.systems.get("propulsion")
+        if propulsion and hasattr(propulsion, "max_thrust") and self.ship.mass > 0:
+            return max(propulsion.max_thrust / self.ship.mass, 0.01)
+        return 0.01
+
+    @staticmethod
+    def _braking_distance(speed: float, accel: float) -> float:
+        """Kinematic braking distance: d = v^2 / (2a)."""
+        if accel <= 0:
+            return float("inf")
+        return (speed * speed) / (2.0 * accel)
+
+    # ----- core compute ------------------------------------------------
+
+    def compute(self, dt: float, sim_time: float) -> Optional[Dict]:
+        """Compute thrust/heading command for this tick.
+
+        Args:
+            dt: Simulation time step (seconds).
+            sim_time: Current simulation clock (seconds).
+        Returns:
+            ``{thrust, heading}`` or ``None`` on error.
+        """
+        target = self.get_target()
+        if not target:
+            self.status = "error"
+            self.error_message = f"Target {self.target_id} not found"
+            return None
+
+        rel = calculate_relative_motion(self.ship, target)
+        current_range: float = rel["range"]
+        closing_speed: float = -rel["range_rate"] if rel["closing"] else 0.0
+
+        # Station-keep handoff (highest priority)
+        rel_speed = magnitude(rel["relative_velocity_vector"])
+        if current_range <= self.stationkeep_range and rel_speed < self.stationkeep_speed:
+            self.phase = "stationkeep"
+            self.status = "stationkeeping"
+            return self._compute_stationkeep(dt, sim_time)
+
+        a_max = self._get_max_accel()
+        d_brake = self._braking_distance(closing_speed, a_max) * self.BRAKE_MARGIN
+
+        # Phase transitions
+        if self.phase == "burn":
+            if closing_speed > 0 and current_range <= d_brake:
+                logger.info(
+                    "Rendezvous: BURN -> FLIP at range %.0f m, "
+                    "closing %.1f m/s, d_brake %.0f m",
+                    current_range, closing_speed, d_brake)
+                self.phase = "flip"
+        elif self.phase == "flip":
+            if self._heading_is_retrograde(rel):
+                logger.info("Rendezvous: FLIP -> BRAKE (aligned retrograde)")
+                self.phase = "brake"
+        elif self.phase == "brake":
+            if closing_speed <= 0 and current_range > self.stationkeep_range:
+                logger.info("Rendezvous: BRAKE -> BURN (lost closing speed)")
+                self.phase = "burn"
+
+        # Execute current phase
+        if self.phase == "burn":
+            self.status = "burning"
+            return self._compute_burn(target)
+        elif self.phase == "flip":
+            self.status = "flipping"
+            return self._compute_flip(rel)
+        elif self.phase == "brake":
+            self.status = "braking"
+            return self._compute_brake(rel)
+        return self._compute_stationkeep(dt, sim_time)
+
+    # ----- phase implementations ---------------------------------------
+
+    def _compute_burn(self, target) -> Dict:
+        """Accelerate toward the target."""
+        target_pos = target.position if hasattr(target, "position") else target
+        vec = subtract_vectors(target_pos, self.ship.position)
+        return {"thrust": self._clamp_thrust(self.max_thrust),
+                "heading": vector_to_heading(vec)}
+
+    def _compute_flip(self, rel: Dict) -> Dict:
+        """Command retrograde heading, zero thrust while RCS rotates."""
+        return {"thrust": 0.0, "heading": self._retrograde_heading(rel)}
+
+    def _compute_brake(self, rel: Dict) -> Dict:
+        """Thrust retrograde to bleed closing speed."""
+        return {"thrust": self._clamp_thrust(self.max_thrust),
+                "heading": self._retrograde_heading(rel)}
+
+    def _compute_stationkeep(self, dt: float, sim_time: float) -> Optional[Dict]:
+        """Delegate to MatchVelocityAutopilot for station-keeping."""
+        if self._match_ap is None:
+            self._match_ap = MatchVelocityAutopilot(
+                self.ship, self.target_id,
+                {"tolerance": 0.5, "max_thrust": self.max_thrust})
+        return self._match_ap.compute(dt, sim_time)
+
+    # ----- heading helpers ---------------------------------------------
+
+    def _retrograde_heading(self, rel: Dict) -> Dict:
+        """Heading that opposes the ship's velocity relative to target.
+
+        rel_vel = target_vel - ship_vel, so the ship's own motion toward
+        target is -rel_vel.  Pointing along +rel_vel is retrograde.
+        """
+        rv = rel["relative_velocity_vector"]
+        retro = {"x": rv["x"], "y": rv["y"], "z": rv["z"]}
+        if magnitude(retro) < 0.01:
+            return self.ship.orientation
+        return vector_to_heading(retro)
+
+    def _heading_is_retrograde(self, rel: Dict) -> bool:
+        """True if ship heading is within FLIP_TOLERANCE_DEG of retrograde."""
+        desired = self._retrograde_heading(rel)
+        cur = self.ship.orientation
+        yaw_err = abs(self._normalize_angle(
+            desired.get("yaw", 0) - cur.get("yaw", 0)))
+        pitch_err = abs(self._normalize_angle(
+            desired.get("pitch", 0) - cur.get("pitch", 0)))
+        return yaw_err < self.FLIP_TOLERANCE_DEG and pitch_err < self.FLIP_TOLERANCE_DEG
+
+    # ----- state / telemetry -------------------------------------------
+
+    def get_state(self) -> Dict:
+        """Rich state dict for GUI: phase, range, closing_speed,
+        braking_distance, time_to_arrival, status_text."""
+        state = super().get_state()
+        state["phase"] = self.phase
+
+        target = self.get_target()
+        if not target:
+            state["status_text"] = "Target lost"
+            return state
+
+        rel = calculate_relative_motion(self.ship, target)
+        current_range = rel["range"]
+        closing_speed = -rel["range_rate"] if rel["closing"] else 0.0
+        a_max = self._get_max_accel()
+        d_brake = self._braking_distance(closing_speed, a_max)
+        eta = self._estimate_eta(current_range, closing_speed, a_max)
+
+        state.update({
+            "range": current_range,
+            "closing_speed": closing_speed,
+            "braking_distance": d_brake,
+            "time_to_arrival": eta,
+            "status_text": self._build_status_text(current_range, eta),
+        })
+        return state
+
+    def _estimate_eta(self, distance: float, closing_speed: float,
+                      a_max: float) -> Optional[float]:
+        """Rough ETA in seconds, or None if indeterminate."""
+        if self.phase == "stationkeep":
+            return 0.0
+        if self.phase in ("burn", "flip"):
+            # Symmetric brachistochrone: t = 2*sqrt(d/a)
+            if a_max > 0 and distance > 0:
+                return 2.0 * math.sqrt(distance / a_max)
+            return None
+        # brake phase: t = v / a
+        if a_max > 0 and closing_speed > 0:
+            return closing_speed / a_max
+        if closing_speed > 0.01:
+            return distance / closing_speed
+        return None
+
+    def _build_status_text(self, distance: float,
+                           eta: Optional[float]) -> str:
+        """Human-readable one-liner for the GUI."""
+        d = _format_distance(distance)
+        t = _format_time(eta) if eta is not None else "unknown"
+        if self.phase == "burn":
+            return f"Burning toward target -- {d}, ETA {t}"
+        if self.phase == "flip":
+            return "Flipping for deceleration burn"
+        if self.phase == "brake":
+            return f"Braking -- {d} remaining, ETA {t}"
+        return f"Station-keeping at {d}"
+
+
+# ----- module-level formatting helpers ---------------------------------
+
+def _format_distance(metres: float) -> str:
+    """Format a distance for display."""
+    if metres >= 1_000_000:
+        return f"{metres / 1000:.0f}km"
+    if metres >= 1_000:
+        return f"{metres / 1000:.1f}km"
+    return f"{metres:.0f}m"
+
+def _format_time(seconds: float) -> str:
+    """Format seconds into a compact human string."""
+    if seconds < 0:
+        return "0s"
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    m, s = divmod(int(seconds), 60)
+    if m < 60:
+        return f"{m}m {s:02d}s"
+    h, m = divmod(m, 60)
+    return f"{h}h {m:02d}m"

--- a/hybrid/systems/sensors/contact.py
+++ b/hybrid/systems/sensors/contact.py
@@ -252,6 +252,11 @@ def calculate_detection_signature(ship) -> float:
 def calculate_detection_accuracy(distance: float, signature: float, sensor_range: float) -> float:
     """Calculate detection accuracy based on distance and signature.
 
+    Uses an S-curve (smoothstep) for range falloff so detection is reliable
+    within ~80% of sensor range, then degrades sharply near max range.
+    This models real sensor behaviour: inverse-square signal strength means
+    SNR is comfortable well inside rated range, with a noise floor near the edge.
+
     Args:
         distance: Distance to target
         signature: Target signature strength
@@ -263,8 +268,15 @@ def calculate_detection_accuracy(distance: float, signature: float, sensor_range
     if distance > sensor_range:
         return 0.0
 
-    # Base accuracy from range
-    range_factor = 1.0 - (distance / sensor_range)
+    # Shifted smoothstep: detection stays near-perfect within 60% of rated
+    # range, then drops off steeply from 60-100%. This models real sensors
+    # where SNR is comfortable well inside rated range (inverse-square signal
+    # is still strong) but degrades rapidly near the noise floor at max range.
+    # At 85% range (427km/500km): range_factor ~0.30, accuracy ~0.24
+    ratio = distance / sensor_range
+    t = max(0.0, min(1.0, (ratio - 0.6) / 0.4))  # Remap 60-100% to 0-1
+    smoothstep = 3.0 * t * t - 2.0 * t * t * t
+    range_factor = 1.0 - smoothstep
 
     # Signature factor (stronger signature = better detection)
     signature_factor = min(1.0, signature / 100.0)

--- a/hybrid/systems/sensors/passive.py
+++ b/hybrid/systems/sensors/passive.py
@@ -77,8 +77,11 @@ class PassiveSensor:
             # Calculate detection probability
             accuracy = calculate_detection_accuracy(distance, signature, self.range)
 
-            # Passive detection has additional probability factor
-            detection_probability = min(0.95, accuracy ** 2)  # Squared for lower passive detection
+            # Detection probability equals accuracy directly. The S-curve range
+            # falloff in calculate_detection_accuracy already models the realistic
+            # drop-off near max range — squaring it again was punishing targets
+            # within operational range too harshly (e.g. 2% at 85% range).
+            detection_probability = min(0.95, accuracy)
 
             # Random detection check (skip on initial scan to populate contacts immediately)
             if not initial_scan:
@@ -109,13 +112,23 @@ class PassiveSensor:
             detected[target_ship.id] = contact
 
         # Merge new detections with existing contacts (don't drop on failed re-detect)
-        # Failed re-detection degrades confidence rather than removing the contact
+        # Failed re-detection degrades confidence gradually rather than removing.
+        # Re-detected contacts keep the higher of old and new confidence so a
+        # briefly-degraded contact snaps back when re-detected.
         for existing_id, existing_contact in self.contacts.items():
             if existing_id not in detected:
-                # Contact not re-detected this scan — degrade confidence
-                existing_contact.confidence *= 0.8
+                # Contact not re-detected this scan — degrade confidence slowly.
+                # 5% per scan means a contact survives ~45 missed scans before
+                # dropping below the 0.1 threshold from confidence 0.95, giving
+                # the sensor time to re-detect intermittent contacts.
+                existing_contact.confidence *= 0.95
                 if existing_contact.confidence > 0.1:
                     detected[existing_id] = existing_contact
+            else:
+                # Re-detected: keep the higher confidence so contacts that were
+                # degrading recover immediately on successful re-detection.
+                new_contact = detected[existing_id]
+                new_contact.confidence = max(new_contact.confidence, existing_contact.confidence)
 
         self.contacts = detected
 

--- a/hybrid/telemetry.py
+++ b/hybrid/telemetry.py
@@ -182,8 +182,27 @@ def get_sensor_contacts(ship) -> Dict[str, Any]:
             distance = calculate_distance(ship.position, position)
             bearing = calculate_bearing(ship.position, position)
 
+            # Serialize position as dict for JSON transport
+            pos_dict = None
+            if position is not None:
+                if hasattr(position, "x"):
+                    pos_dict = {"x": position.x, "y": position.y, "z": getattr(position, "z", 0)}
+                elif isinstance(position, dict):
+                    pos_dict = {"x": position.get("x", 0), "y": position.get("y", 0), "z": position.get("z", 0)}
+
+            # Get velocity if available
+            velocity = contact_value(contact, "velocity", None)
+            vel_dict = None
+            if velocity is not None:
+                if hasattr(velocity, "x"):
+                    vel_dict = {"x": velocity.x, "y": velocity.y, "z": getattr(velocity, "z", 0)}
+                elif isinstance(velocity, dict):
+                    vel_dict = {"x": velocity.get("x", 0), "y": velocity.get("y", 0), "z": velocity.get("z", 0)}
+
             contacts_list.append({
                 "id": contact_id,
+                "position": pos_dict,
+                "velocity": vel_dict,
                 "distance": distance,
                 "bearing": bearing,
                 "confidence": contact_value(contact, "confidence", 0.5),
@@ -204,8 +223,27 @@ def get_sensor_contacts(ship) -> Dict[str, Any]:
             distance = calculate_distance(ship.position, position)
             bearing = calculate_bearing(ship.position, position)
 
+            # Serialize position as dict for JSON transport
+            pos_dict = None
+            if position is not None:
+                if hasattr(position, "x"):
+                    pos_dict = {"x": position.x, "y": position.y, "z": getattr(position, "z", 0)}
+                elif isinstance(position, dict):
+                    pos_dict = {"x": position.get("x", 0), "y": position.get("y", 0), "z": position.get("z", 0)}
+
+            # Get velocity if available
+            velocity = contact_value(contact, "velocity", None)
+            vel_dict = None
+            if velocity is not None:
+                if hasattr(velocity, "x"):
+                    vel_dict = {"x": velocity.x, "y": velocity.y, "z": getattr(velocity, "z", 0)}
+                elif isinstance(velocity, dict):
+                    vel_dict = {"x": velocity.get("x", 0), "y": velocity.get("y", 0), "z": velocity.get("z", 0)}
+
             contacts_list.append({
                 "id": contact_id,
+                "position": pos_dict,
+                "velocity": vel_dict,
                 "distance": distance,
                 "bearing": bearing,
                 "confidence": contact_value(contact, "confidence", 0.9),

--- a/scenarios/01_tutorial_intercept.yaml
+++ b/scenarios/01_tutorial_intercept.yaml
@@ -1,8 +1,8 @@
-# Tutorial Mission: Basic Intercept
-# Learn the basics of navigation and autopilot
+# Tutorial Mission: Basic Intercept & Dock
+# Learn the basics of navigation, autopilot, and docking
 
-name: "Tutorial: Intercept and Approach"
-description: "Learn to use sensors and autopilot to intercept a target"
+name: "Tutorial: Intercept and Dock"
+description: "Learn to use sensors and autopilot to rendezvous with and dock at a station"
 
 dt: 0.1
 
@@ -21,7 +21,7 @@ ships:
         max_fuel: 10000
       sensors:
         passive:
-          range: 200000
+          range: 500000  # 500km — enough to detect station at ~427km
         active:
           scan_range: 500000
       navigation: {}
@@ -30,7 +30,7 @@ ships:
   - id: "target_station"
     name: "Tycho Station"
     class: "station"
-    position: {x: 50000, y: 20000, z: 0}  # ~54km away
+    position: {x: 400000, y: 150000, z: 0}  # ~427km away
     velocity: {x: 0, y: 0, z: 0}  # Stationary
     mass: 100000
     systems:
@@ -40,21 +40,23 @@ ships:
 
 mission:
   name: "First Contact"
-  description: "Intercept Tycho Station and close to docking range"
+  description: "Rendezvous with Tycho Station and dock"
 
   briefing: |
     Welcome, pilot. This is a training mission to familiarize you with
     the basic systems of your ship.
 
-    Your objective is to intercept Tycho Station, currently 54km away.
-    The station is stationary, so this should be straightforward.
+    Your objective is to rendezvous with Tycho Station, currently ~430km
+    away, and dock with it. The station is stationary, so use the
+    "rendezvous" autopilot mode for a smooth approach.
 
     Steps:
-    1. Use 'contacts' to detect the station
-    2. Use 'target C001' to lock it as your target
-    3. Use 'autopilot intercept C001' to engage automatic pursuit
-    4. Monitor your progress with 'status'
-    5. The autopilot will bring you within 1km automatically
+    1. Use sensors to detect the station
+    2. Target the station contact
+    3. Engage autopilot in rendezvous mode to approach
+    4. When within 5km, request docking
+    5. The docking system will complete the dock automatically
+       once range and velocity criteria are met
 
     Good luck!
 
@@ -66,23 +68,30 @@ mission:
       params:
         target: "target_station"
 
-    - id: "close_to_1km"
+    - id: "close_to_5km"
       type: "reach_range"
-      description: "Close to within 1km of the station"
+      description: "Close to within 5km of the station"
       required: true
       params:
         target: "target_station"
-        range: 1000
-        initial_range: 54000
+        range: 5000
+        initial_range: 427000
+
+    - id: "dock_with_station"
+      type: "dock_with"
+      description: "Request docking and dock with Tycho Station"
+      required: true
+      params:
+        target: "target_station"
 
   success_message: |
-    Excellent work! You've successfully intercepted Tycho Station.
+    Excellent work! You've successfully docked with Tycho Station.
 
     You've learned:
     - How to use passive sensors to detect contacts
     - How to lock a target
-    - How to engage the intercept autopilot
-    - How the autopilot automatically transitions between phases
+    - How to engage the rendezvous autopilot
+    - How to request and complete a docking maneuver
 
     Ready for the next mission?
 
@@ -90,10 +99,13 @@ mission:
 
   hints:
     - trigger: "start"
-      message: "Use the 'contacts' command to see detected ships"
-    - trigger: "range < 30000"
+      message: "Use the sensors panel to detect nearby contacts"
+    - trigger: "range < 200000"
       target: "target_station"
-      message: "You're getting close! The autopilot will automatically slow down as you approach"
+      message: "You're halfway there. The autopilot will handle the flip-and-burn deceleration automatically."
+    - trigger: "range < 50000"
+      target: "target_station"
+      message: "Getting close! The autopilot is decelerating for final approach."
     - trigger: "range < 5000"
       target: "target_station"
-      message: "Almost there! The autopilot is now in match velocity phase"
+      message: "Within docking range! Use the docking panel to request docking with the station."

--- a/server/config.py
+++ b/server/config.py
@@ -19,7 +19,7 @@ class ServerMode(Enum):
 
 # Default port assignments
 DEFAULT_TCP_PORT = 8765      # Main simulation server
-DEFAULT_WS_PORT = 8080       # WebSocket bridge
+DEFAULT_WS_PORT = 8081       # WebSocket bridge
 DEFAULT_HTTP_PORT = 3100     # GUI static file server
 DEFAULT_MOBILE_PORT = 5000   # Mobile UI (Flask)
 


### PR DESCRIPTION
## Summary
- **New RendezvousAutopilot** with physics-correct flip-and-burn (burn→flip→brake→stationkeep), braking distance calculation, and rich state output (phase, ETA, status text)
- **Tutorial scenario overhauled**: distance 54km→427km, passive sensor range boosted to 500km, docking added as win condition (detect→approach→dock)
- **Sensor flickering fixed**: smoothstep range curve replaces linear falloff, removed accuracy² double-penalty, confidence degradation reduced 20%→5%/scan (detection at 427km: 1.75%→24.2%)
- **Sensor table layout stabilized**: min-height prevents panel collapse, lost contacts show as "LOST" faded for 8s before removal
- **Tactical map fixed**: contact positions now included in telemetry (were missing, all contacts rendered at origin), auto-fit zoom added, scale options extended to 1000km
- **Autopilot GUI**: Rendezvous mode added to control panel, status panel shows real-time phase/range/ETA/status text for all autopilot types
- **WS bridge**: TCP reconnect loop fixes startup race condition; WS client port corrected 8080→8081

## Test plan
- [ ] Load tutorial scenario, verify station detected at ~427km on sensors (no flickering)
- [ ] Engage rendezvous autopilot, verify burn→flip→brake→stationkeep phases in status panel
- [ ] Verify tactical map shows station at correct distance with auto-fit zoom
- [ ] Verify sensor table doesn't resize/reflow when contacts appear/disappear
- [ ] Close to 5km, request docking, verify dock_with objective completes
- [ ] Restart launcher — verify WS bridge connects to TCP server automatically (no race condition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)