### PR TITLE
Helm UI refactor: merge panels, glass cockpit layout, tier visual identity

### DIFF
--- a/gui/README.md
+++ b/gui/README.md
@@ -41,7 +41,7 @@ python -m server.station_server --port 8765
 ### 3. Start the WebSocket Bridge
 
 ```bash
-python gui/ws_bridge.py --tcp-port 8765 --ws-port 8080
+python gui/ws_bridge.py --tcp-port 8765 --ws-port 8081
 ```
 
 ### 4. Open the GUI
@@ -61,7 +61,7 @@ python -m http.server 3000
 
 ```
 --ws-host    WebSocket bind host (default: 0.0.0.0)
---ws-port    WebSocket port (default: 8080)
+--ws-port    WebSocket port (default: 8081)
 --tcp-host   TCP server host (default: 127.0.0.1)
 --tcp-port   TCP server port (default: 8765)
 ```

--- a/gui/components/flight-computer-panel.js
+++ b/gui/components/flight-computer-panel.js
@@ -1,12 +1,32 @@
 /**
- * Flight Computer Panel
- * Displays server-side flight computer status and provides quick command buttons.
- * Subscribes to stateManager for flight_computer state.
- * Sends flight_computer commands via wsClient.sendShipCommand().
+ * Flight Computer Panel — Unified Command Panel
+ * Combines autopilot mode selection, coordinate navigation, inline status,
+ * and course options into a single command interface.
+ *
+ * Command mapping:
+ *   Navigate  -> sendShipCommand("set_course", {x, y, z, stop, tolerance, max_thrust})
+ *   Rendezvous, Intercept, Match Vel -> sendShipCommand("autopilot", {program, target})
+ *   Hold, Cruise, Orbit, Evasive     -> sendShipCommand("autopilot", {program})
+ *   Manual / Abort                    -> sendShipCommand("autopilot", {program: "off"})
+ *
+ * Tier awareness:
+ *   ARCADE:     full command grid
+ *   CPU-ASSIST: hides Match Vel, Orbit, Evasive (too granular)
+ *   RAW:        hidden by tiers.css; shows collapsed disabled-reason if forced visible
  */
 
 import { stateManager } from "../js/state-manager.js";
 import { wsClient } from "../js/ws-client.js";
+import {
+  PHASE_SEGMENT_CSS,
+  buildPhaseProgressHtml,
+  extractAutopilotState,
+  formatDistance,
+  formatEta,
+} from "../js/autopilot-utils.js";
+
+// Modes hidden in CPU-ASSIST tier (too granular for order-based play)
+const GRANULAR_CMD_IDS = ["cmd-match", "cmd-orbit", "cmd-evasive"];
 
 class FlightComputerPanel extends HTMLElement {
   constructor() {
@@ -15,405 +35,155 @@ class FlightComputerPanel extends HTMLElement {
     this._unsubscribe = null;
     this._fcState = null;
     this._showCoordinateInput = false;
-    this._selectedTarget = null;
+    this._showAdvanced = false;
+    this._pendingAction = null;
+    this._keyHandler = null;
   }
 
   connectedCallback() {
     this.render();
     this._subscribe();
     this._setupInteraction();
+    this._applyTier();
+    // Listen for tier changes
+    this._tierHandler = () => this._applyTier();
+    document.addEventListener("tier-change", this._tierHandler);
   }
 
   disconnectedCallback() {
-    if (this._unsubscribe) {
-      this._unsubscribe();
-    }
-    if (this._keyHandler) {
-      document.removeEventListener("keydown", this._keyHandler);
-      this._keyHandler = null;
-    }
+    if (this._unsubscribe) { this._unsubscribe(); this._unsubscribe = null; }
+    if (this._keyHandler) { document.removeEventListener("keydown", this._keyHandler); this._keyHandler = null; }
+    if (this._tierHandler) { document.removeEventListener("tier-change", this._tierHandler); this._tierHandler = null; }
   }
 
   _subscribe() {
-    this._unsubscribe = stateManager.subscribe("*", (value, key, fullState) => {
-      this._fcState = fullState.flight_computer || this._extractFCState(fullState);
+    this._unsubscribe = stateManager.subscribe("*", () => {
+      this._fcState = extractAutopilotState();
       this._updateDisplay();
     });
   }
 
-  /**
-   * Try to extract flight computer state from various possible locations
-   */
-  _extractFCState(state) {
-    const ship = stateManager.getShipState();
-    if (!ship) return null;
-    return ship.flight_computer || ship.systems?.flight_computer || null;
+  /** Hide granular commands in CPU-ASSIST tier */
+  _applyTier() {
+    const tier = window.controlTier || "arcade";
+    const isCpuAssist = tier === "cpu-assist";
+    GRANULAR_CMD_IDS.forEach(id => {
+      const btn = this.shadowRoot.getElementById(id);
+      if (btn) btn.classList.toggle("hidden", isCpuAssist);
+    });
   }
 
   render() {
     this.shadowRoot.innerHTML = `
       <style>
-        :host {
-          display: block;
-          padding: 16px;
-          font-family: var(--font-sans, "Inter", sans-serif);
-        }
+        :host { display: block; padding: 16px; font-family: var(--font-sans, "Inter", sans-serif); }
 
-        /* Mode display */
-        .mode-display {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          gap: 12px;
-          margin-bottom: 16px;
-          padding: 12px;
-          background: var(--bg-input, #1a1a24);
-          border-radius: 8px;
-          border: 1px solid var(--border-default, #2a2a3a);
-        }
+        /* --- Inline autopilot status --- */
+        .inline-status { margin-bottom: 12px; padding: 10px; background: var(--bg-input, #1a1a24); border-radius: 8px; border: 1px solid var(--border-default, #2a2a3a); }
+        .inline-status.hidden { display: none !important; }
+        .status-header { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+        .mode-badge { font-family: var(--font-mono, "JetBrains Mono", monospace); font-size: 0.75rem; font-weight: 700; letter-spacing: 1px; padding: 2px 8px; border-radius: 4px; }
+        .mode-badge.idle { color: var(--text-dim, #555566); background: rgba(85,85,102,0.15); }
+        .mode-badge.executing { color: var(--status-nominal, #00ff88); background: rgba(0,255,136,0.1); animation: pulse-glow 2s ease-in-out infinite; }
+        @keyframes pulse-glow { 0%,100%{box-shadow:0 0 4px rgba(0,255,136,0.2)} 50%{box-shadow:0 0 12px rgba(0,255,136,0.4)} }
+        .status-command { font-size: 0.8rem; font-weight: 600; color: var(--text-primary, #e0e0e0); }
+        .status-target { font-size: 0.7rem; color: var(--text-dim, #555566); margin-left: auto; }
+        .status-text-line { font-size: 0.7rem; color: var(--text-secondary, #888899); font-style: italic; margin-bottom: 4px; }
+        .status-text-line:empty { display: none; }
 
-        .mode-badge {
-          font-family: var(--font-mono, "JetBrains Mono", monospace);
-          font-size: 1.1rem;
-          font-weight: 700;
-          letter-spacing: 2px;
-          padding: 4px 12px;
-          border-radius: 4px;
-        }
+        /* Phase bar (from autopilot-utils) */
+        .phase-progress { margin-bottom: 6px; }
+        ${PHASE_SEGMENT_CSS}
 
-        .mode-badge.idle {
-          color: var(--text-dim, #555566);
-          background: rgba(85, 85, 102, 0.15);
-        }
+        /* Compact info row: distance | closing | ETA */
+        .info-row { display: flex; gap: 12px; font-size: 0.7rem; }
+        .info-row .info-item { display: flex; gap: 4px; align-items: baseline; }
+        .info-row .info-lbl { color: var(--text-dim, #555566); text-transform: uppercase; font-size: 0.6rem; }
+        .info-row .info-val { font-family: var(--font-mono, "JetBrains Mono", monospace); color: var(--text-primary, #e0e0e0); }
 
-        .mode-badge.executing {
-          color: var(--status-nominal, #00ff88);
-          background: rgba(0, 255, 136, 0.1);
-          animation: pulse-glow 2s ease-in-out infinite;
-        }
+        /* --- Disengage bar --- */
+        .disengage-bar { display: none; margin-bottom: 12px; }
+        .disengage-bar.visible { display: block; }
+        .disengage-btn { width: 100%; padding: 10px; border-radius: 6px; font-size: 0.8rem; font-weight: 600; cursor: pointer; background: transparent; border: 1px solid var(--status-warning, #ffaa00); color: var(--status-warning, #ffaa00); font-family: var(--font-sans, "Inter", sans-serif); }
+        .disengage-btn:hover { background: rgba(255,170,0,0.1); }
 
-        .mode-badge.manual {
-          color: var(--status-info, #00aaff);
-          background: rgba(0, 170, 255, 0.1);
-        }
+        /* --- Command grid --- */
+        .section-title { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-secondary, #888899); margin-bottom: 8px; }
+        .command-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 6px; margin-bottom: 12px; }
+        .cmd-btn { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 2px; padding: 10px 6px; background: var(--bg-input, #1a1a24); border: 1px solid var(--border-default, #2a2a3a); border-radius: 6px; color: var(--text-secondary, #888899); font-family: var(--font-sans, "Inter", sans-serif); font-size: 0.65rem; font-weight: 600; text-transform: uppercase; cursor: pointer; transition: all 0.1s ease; min-height: 44px; letter-spacing: 0.3px; }
+        .cmd-label { font-size: 0.7rem; font-weight: 600; }
+        .cmd-subtitle { font-size: 0.55rem; font-weight: 400; opacity: 0.6; letter-spacing: 0.3px; text-transform: lowercase; }
+        .cmd-btn:hover:not(:disabled) { background: var(--bg-hover, #22222e); border-color: var(--status-info, #00aaff); color: var(--text-primary, #e0e0e0); }
+        .cmd-btn:active:not(:disabled) { transform: scale(0.96); }
+        .cmd-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+        .cmd-btn.active { background: var(--status-info, #00aaff); border-color: var(--status-info, #00aaff); color: var(--bg-primary, #0a0a0f); }
+        .cmd-btn.danger { border-color: var(--status-critical, #ff4444); color: var(--status-critical, #ff4444); }
+        .cmd-btn.danger:hover:not(:disabled) { background: rgba(255,68,68,0.15); border-color: var(--status-critical, #ff4444); }
+        .cmd-btn.wide { grid-column: span 2; }
+        .cmd-btn.hidden { display: none !important; }
 
-        @keyframes pulse-glow {
-          0%, 100% { box-shadow: 0 0 4px rgba(0, 255, 136, 0.2); }
-          50% { box-shadow: 0 0 12px rgba(0, 255, 136, 0.4); }
-        }
+        /* --- Coordinate input + advanced options --- */
+        .coord-input-section { display: none; padding: 12px; background: var(--bg-input, #1a1a24); border: 1px solid var(--border-default, #2a2a3a); border-radius: 8px; margin-bottom: 12px; }
+        .coord-input-section.visible { display: block; }
+        .coord-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; margin-bottom: 10px; }
+        .coord-group { display: flex; flex-direction: column; gap: 4px; }
+        .coord-group label { font-size: 0.65rem; color: var(--text-dim, #555566); text-transform: uppercase; text-align: center; }
+        .coord-group input { padding: 8px; background: var(--bg-primary, #0a0a0f); border: 1px solid var(--border-default, #2a2a3a); border-radius: 4px; color: var(--text-primary, #e0e0e0); font-family: var(--font-mono, "JetBrains Mono", monospace); font-size: 0.8rem; text-align: center; min-height: 36px; }
+        .coord-group input:focus { outline: none; border-color: var(--status-info, #00aaff); }
 
-        .mode-info {
-          flex: 1;
-          font-size: 0.8rem;
-        }
+        /* Advanced course options */
+        .advanced-toggle { font-size: 0.65rem; color: var(--text-dim, #555566); cursor: pointer; margin-bottom: 8px; user-select: none; }
+        .advanced-toggle:hover { color: var(--text-secondary, #888899); }
+        .advanced-opts { display: none; margin-bottom: 10px; padding: 8px; background: var(--bg-primary, #0a0a0f); border-radius: 6px; }
+        .advanced-opts.visible { display: block; }
+        .opt-row { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+        .opt-row:last-child { margin-bottom: 0; }
+        .opt-label { font-size: 0.65rem; color: var(--text-secondary, #888899); min-width: 70px; }
+        .opt-input { width: 60px; padding: 4px 6px; background: var(--bg-input, #1a1a24); border: 1px solid var(--border-default, #2a2a3a); border-radius: 4px; color: var(--text-primary, #e0e0e0); font-family: var(--font-mono, "JetBrains Mono", monospace); font-size: 0.75rem; text-align: center; }
+        .opt-checkbox { width: 16px; height: 16px; accent-color: var(--status-info, #00aaff); }
+        .opt-slider { flex: 1; accent-color: var(--status-info, #00aaff); }
+        .opt-val { font-family: var(--font-mono, "JetBrains Mono", monospace); font-size: 0.7rem; color: var(--text-primary, #e0e0e0); min-width: 30px; text-align: right; }
 
-        .mode-command {
-          color: var(--text-primary, #e0e0e0);
-          font-weight: 600;
-        }
+        .coord-actions { display: flex; gap: 8px; }
+        .coord-actions button { flex: 1; padding: 8px; border-radius: 4px; font-size: 0.75rem; font-weight: 600; cursor: pointer; min-height: 36px; font-family: var(--font-sans, "Inter", sans-serif); }
+        .coord-go-btn { background: var(--status-nominal, #00ff88); border: none; color: var(--bg-primary, #0a0a0f); }
+        .coord-cancel-btn { background: transparent; border: 1px solid var(--border-default, #2a2a3a); color: var(--text-secondary, #888899); }
 
-        .mode-phase {
-          color: var(--text-secondary, #888899);
-          font-size: 0.75rem;
-        }
+        /* --- Target select --- */
+        .target-section { display: none; margin-bottom: 12px; }
+        .target-section.visible { display: block; }
+        .target-select { width: 100%; padding: 8px 12px; background: var(--bg-input, #1a1a24); border: 1px solid var(--border-default, #2a2a3a); border-radius: 6px; color: var(--text-primary, #e0e0e0); font-family: var(--font-mono, "JetBrains Mono", monospace); font-size: 0.8rem; min-height: 36px; }
+        .target-select:focus { outline: none; border-color: var(--status-info, #00aaff); }
 
-        .mode-status-text {
-          color: var(--text-dim, #555566);
-          font-size: 0.7rem;
-          margin-top: 2px;
-        }
-
-        /* Progress bar */
-        .progress-section {
-          margin-bottom: 16px;
-        }
-
-        .progress-header {
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          margin-bottom: 4px;
-          font-size: 0.75rem;
-        }
-
-        .progress-label {
-          color: var(--text-secondary, #888899);
-        }
-
-        .progress-eta {
-          font-family: var(--font-mono, "JetBrains Mono", monospace);
-          color: var(--status-info, #00aaff);
-          font-weight: 600;
-        }
-
-        .progress-bar {
-          height: 8px;
-          background: var(--bg-input, #1a1a24);
-          border-radius: 4px;
-          overflow: hidden;
-        }
-
-        .progress-fill {
-          height: 100%;
-          background: var(--status-info, #00aaff);
-          border-radius: 4px;
-          transition: width 0.5s ease;
-        }
-
-        /* Burn plan details */
-        .burn-details {
-          display: grid;
-          grid-template-columns: repeat(3, 1fr);
-          gap: 8px;
-          margin-bottom: 16px;
-          padding: 10px;
-          background: rgba(0, 170, 255, 0.05);
-          border: 1px solid rgba(0, 170, 255, 0.15);
-          border-radius: 6px;
-        }
-
-        .burn-item {
-          text-align: center;
-        }
-
-        .burn-label {
-          font-size: 0.6rem;
-          color: var(--text-dim, #555566);
-          text-transform: uppercase;
-          letter-spacing: 0.5px;
-        }
-
-        .burn-value {
-          font-family: var(--font-mono, "JetBrains Mono", monospace);
-          font-size: 0.85rem;
-          color: var(--text-primary, #e0e0e0);
-          font-weight: 600;
-        }
-
-        /* Quick command buttons */
-        .section-title {
-          font-size: 0.7rem;
-          font-weight: 600;
-          text-transform: uppercase;
-          letter-spacing: 0.5px;
-          color: var(--text-secondary, #888899);
-          margin-bottom: 8px;
-        }
-
-        .command-grid {
-          display: grid;
-          grid-template-columns: repeat(4, 1fr);
-          gap: 6px;
-          margin-bottom: 12px;
-        }
-
-        .cmd-btn {
-          padding: 10px 6px;
-          background: var(--bg-input, #1a1a24);
-          border: 1px solid var(--border-default, #2a2a3a);
-          border-radius: 6px;
-          color: var(--text-secondary, #888899);
-          font-family: var(--font-sans, "Inter", sans-serif);
-          font-size: 0.65rem;
-          font-weight: 600;
-          text-transform: uppercase;
-          cursor: pointer;
-          transition: all 0.1s ease;
-          min-height: 44px;
-          letter-spacing: 0.3px;
-        }
-
-        .cmd-btn:hover:not(:disabled) {
-          background: var(--bg-hover, #22222e);
-          border-color: var(--status-info, #00aaff);
-          color: var(--text-primary, #e0e0e0);
-        }
-
-        .cmd-btn:active:not(:disabled) {
-          transform: scale(0.96);
-        }
-
-        .cmd-btn:disabled {
-          opacity: 0.4;
-          cursor: not-allowed;
-        }
-
-        .cmd-btn.active {
-          background: var(--status-info, #00aaff);
-          border-color: var(--status-info, #00aaff);
-          color: var(--bg-primary, #0a0a0f);
-        }
-
-        .cmd-btn.danger {
-          border-color: var(--status-critical, #ff4444);
-          color: var(--status-critical, #ff4444);
-        }
-
-        .cmd-btn.danger:hover:not(:disabled) {
-          background: rgba(255, 68, 68, 0.15);
-          border-color: var(--status-critical, #ff4444);
-        }
-
-        .cmd-btn.wide {
-          grid-column: span 2;
-        }
-
-        /* Coordinate input overlay */
-        .coord-input-section {
-          display: none;
-          padding: 12px;
-          background: var(--bg-input, #1a1a24);
-          border: 1px solid var(--border-default, #2a2a3a);
-          border-radius: 8px;
-          margin-bottom: 12px;
-        }
-
-        .coord-input-section.visible {
-          display: block;
-        }
-
-        .coord-grid {
-          display: grid;
-          grid-template-columns: repeat(3, 1fr);
-          gap: 8px;
-          margin-bottom: 10px;
-        }
-
-        .coord-group {
-          display: flex;
-          flex-direction: column;
-          gap: 4px;
-        }
-
-        .coord-group label {
-          font-size: 0.65rem;
-          color: var(--text-dim, #555566);
-          text-transform: uppercase;
-          text-align: center;
-        }
-
-        .coord-group input {
-          padding: 8px;
-          background: var(--bg-primary, #0a0a0f);
-          border: 1px solid var(--border-default, #2a2a3a);
-          border-radius: 4px;
-          color: var(--text-primary, #e0e0e0);
-          font-family: var(--font-mono, "JetBrains Mono", monospace);
-          font-size: 0.8rem;
-          text-align: center;
-          min-height: 36px;
-        }
-
-        .coord-group input:focus {
-          outline: none;
-          border-color: var(--status-info, #00aaff);
-        }
-
-        .coord-actions {
-          display: flex;
-          gap: 8px;
-        }
-
-        .coord-actions button {
-          flex: 1;
-          padding: 8px;
-          border-radius: 4px;
-          font-size: 0.75rem;
-          font-weight: 600;
-          cursor: pointer;
-          min-height: 36px;
-          font-family: var(--font-sans, "Inter", sans-serif);
-        }
-
-        .coord-go-btn {
-          background: var(--status-nominal, #00ff88);
-          border: none;
-          color: var(--bg-primary, #0a0a0f);
-        }
-
-        .coord-cancel-btn {
-          background: transparent;
-          border: 1px solid var(--border-default, #2a2a3a);
-          color: var(--text-secondary, #888899);
-        }
-
-        /* Target select for intercept */
-        .target-section {
-          display: none;
-          margin-bottom: 12px;
-        }
-
-        .target-section.visible {
-          display: block;
-        }
-
-        .target-select {
-          width: 100%;
-          padding: 8px 12px;
-          background: var(--bg-input, #1a1a24);
-          border: 1px solid var(--border-default, #2a2a3a);
-          border-radius: 6px;
-          color: var(--text-primary, #e0e0e0);
-          font-family: var(--font-mono, "JetBrains Mono", monospace);
-          font-size: 0.8rem;
-          min-height: 36px;
-        }
-
-        .target-select:focus {
-          outline: none;
-          border-color: var(--status-info, #00aaff);
-        }
-
-        .hidden {
-          display: none !important;
-        }
+        .hidden { display: none !important; }
 
         @media (max-width: 768px) {
-          .command-grid {
-            grid-template-columns: repeat(3, 1fr);
-          }
-
-          .burn-details {
-            grid-template-columns: repeat(2, 1fr);
-          }
+          .command-grid { grid-template-columns: repeat(3, 1fr); }
         }
       </style>
 
-      <!-- Flight Computer Mode Display -->
-      <div class="mode-display" id="mode-display">
-        <span class="mode-badge idle" id="mode-badge">IDLE</span>
-        <div class="mode-info">
-          <div class="mode-command" id="mode-command">No active command</div>
-          <div class="mode-phase" id="mode-phase"></div>
-          <div class="mode-status-text" id="mode-status-text"></div>
+      <!-- Inline autopilot status (compact, from autopilot-status data) -->
+      <div class="inline-status hidden" id="inline-status">
+        <div class="status-header">
+          <span class="mode-badge executing" id="mode-badge">AUTOPILOT</span>
+          <span class="status-command" id="status-command">--</span>
+          <span class="status-target" id="status-target"></span>
+        </div>
+        <div class="status-text-line" id="status-text"></div>
+        <div class="phase-progress" id="phase-progress">
+          <div class="phase-bar" id="phase-bar"></div>
+          <div class="phase-labels" id="phase-labels"></div>
+        </div>
+        <div class="info-row">
+          <div class="info-item"><span class="info-lbl">Dist</span><span class="info-val" id="info-dist">--</span></div>
+          <div class="info-item"><span class="info-lbl">Close</span><span class="info-val" id="info-close">--</span></div>
+          <div class="info-item"><span class="info-lbl">ETA</span><span class="info-val" id="info-eta">--</span></div>
         </div>
       </div>
 
-      <!-- Progress bar (visible when executing) -->
-      <div class="progress-section hidden" id="progress-section">
-        <div class="progress-header">
-          <span class="progress-label">Progress</span>
-          <span class="progress-eta" id="progress-eta">ETA: --</span>
-        </div>
-        <div class="progress-bar">
-          <div class="progress-fill" id="progress-fill" style="width: 0%"></div>
-        </div>
-      </div>
-
-      <!-- Burn plan details (visible when executing) -->
-      <div class="burn-details hidden" id="burn-details">
-        <div class="burn-item">
-          <div class="burn-label">Delta-V</div>
-          <div class="burn-value" id="burn-dv">--</div>
-        </div>
-        <div class="burn-item">
-          <div class="burn-label">Fuel Cost</div>
-          <div class="burn-value" id="burn-fuel">--</div>
-        </div>
-        <div class="burn-item">
-          <div class="burn-label">Confidence</div>
-          <div class="burn-value" id="burn-confidence">--</div>
-        </div>
+      <!-- Disengage bar (visible when autopilot active) -->
+      <div class="disengage-bar" id="disengage-bar">
+        <button class="disengage-btn" id="disengage-btn" title="Disengage autopilot and return to manual control (Esc)">DISENGAGE AUTOPILOT</button>
       </div>
 
       <!-- Quick Commands -->
@@ -422,17 +192,25 @@ class FlightComputerPanel extends HTMLElement {
       <!-- Coordinate input (shown on Navigate click) -->
       <div class="coord-input-section" id="coord-section">
         <div class="coord-grid">
-          <div class="coord-group">
-            <label>X (m)</label>
-            <input type="number" id="nav-x" value="0" step="100" />
+          <div class="coord-group"><label>X (m)</label><input type="number" id="nav-x" value="0" step="100" /></div>
+          <div class="coord-group"><label>Y (m)</label><input type="number" id="nav-y" value="0" step="100" /></div>
+          <div class="coord-group"><label>Z (m)</label><input type="number" id="nav-z" value="0" step="100" /></div>
+        </div>
+        <div class="advanced-toggle" id="adv-toggle">+ Advanced options</div>
+        <div class="advanced-opts" id="adv-opts">
+          <div class="opt-row">
+            <span class="opt-label">Tolerance</span>
+            <input type="number" class="opt-input" id="opt-tolerance" value="100" min="1" step="10" />
+            <span class="opt-label" style="min-width:auto">m</span>
           </div>
-          <div class="coord-group">
-            <label>Y (m)</label>
-            <input type="number" id="nav-y" value="0" step="100" />
+          <div class="opt-row">
+            <span class="opt-label">Max thrust</span>
+            <input type="range" class="opt-slider" id="opt-thrust" min="0" max="100" value="100" />
+            <span class="opt-val" id="opt-thrust-val">100%</span>
           </div>
-          <div class="coord-group">
-            <label>Z (m)</label>
-            <input type="number" id="nav-z" value="0" step="100" />
+          <div class="opt-row">
+            <input type="checkbox" class="opt-checkbox" id="opt-stop" checked />
+            <span class="opt-label" style="min-width:auto">Stop at target</span>
           </div>
         </div>
         <div class="coord-actions">
@@ -441,75 +219,78 @@ class FlightComputerPanel extends HTMLElement {
         </div>
       </div>
 
-      <!-- Target select for intercept/match_velocity -->
+      <!-- Target select for intercept/match_velocity/rendezvous -->
       <div class="target-section" id="target-section">
         <select class="target-select" id="target-select">
           <option value="">-- Select Target --</option>
         </select>
       </div>
 
-      <div class="command-grid">
-        <button class="cmd-btn" id="cmd-navigate" title="Navigate to coordinates">Navigate</button>
-        <button class="cmd-btn" id="cmd-intercept" title="Intercept a target">Intercept</button>
-        <button class="cmd-btn" id="cmd-match" title="Match velocity with target">Match Vel</button>
-        <button class="cmd-btn" id="cmd-hold" title="Hold current position (H)">Hold</button>
-        <button class="cmd-btn" id="cmd-orbit" title="Enter orbit">Orbit</button>
-        <button class="cmd-btn" id="cmd-evasive" title="Evasive maneuvers">Evasive</button>
-        <button class="cmd-btn" id="cmd-manual" title="Switch to manual control (M)">Manual</button>
-        <button class="cmd-btn danger" id="cmd-abort" title="Abort current command (Esc)">Abort</button>
+      <div class="command-grid" id="command-grid">
+        <button class="cmd-btn wide" id="cmd-rendezvous" title="Approach and arrive at target with zero velocity (flip-and-burn). Requires target.">
+          <span class="cmd-label">Rendezvous</span><span class="cmd-subtitle">flip & arrive</span>
+        </button>
+        <button class="cmd-btn" id="cmd-navigate" title="Navigate to coordinates (x, y, z). Uses autopilot course-following.">
+          <span class="cmd-label">Navigate</span><span class="cmd-subtitle">go to coords</span>
+        </button>
+        <button class="cmd-btn" id="cmd-intercept" title="Chase a moving target using lead pursuit. Requires target selected.">
+          <span class="cmd-label">Intercept</span><span class="cmd-subtitle">chase target</span>
+        </button>
+        <button class="cmd-btn" id="cmd-match" title="Match speed and direction with target. Zeroes relative velocity. Requires target.">
+          <span class="cmd-label">Match Vel</span><span class="cmd-subtitle">zero rel-v</span>
+        </button>
+        <button class="cmd-btn" id="cmd-hold" title="Station-keep at current position. Fires thrusters to counteract drift. (H)">
+          <span class="cmd-label">Hold</span><span class="cmd-subtitle">station-keep</span>
+        </button>
+        <button class="cmd-btn" id="cmd-orbit" title="Maintain circular orbit around a point. Best for surveillance or patrol.">
+          <span class="cmd-label">Orbit</span><span class="cmd-subtitle">circle point</span>
+        </button>
+        <button class="cmd-btn" id="cmd-evasive" title="Random jinking pattern to avoid incoming fire. Unpredictable thrust changes.">
+          <span class="cmd-label">Evasive</span><span class="cmd-subtitle">jink & dodge</span>
+        </button>
+        <button class="cmd-btn danger" id="cmd-abort" title="Abort current autopilot program and return to manual control. (Esc)">
+          <span class="cmd-label">Abort</span><span class="cmd-subtitle">disengage AP</span>
+        </button>
       </div>
     `;
   }
 
   _setupInteraction() {
+    const $ = (id) => this.shadowRoot.getElementById(id);
+
     // Navigate button - toggles coordinate input
-    this.shadowRoot.getElementById("cmd-navigate").addEventListener("click", () => {
-      this._toggleCoordInput();
+    $("cmd-navigate").addEventListener("click", () => this._toggleCoordInput());
+    $("nav-go-btn").addEventListener("click", () => this._sendNavigate());
+    $("nav-cancel-btn").addEventListener("click", () => this._hideCoordInput());
+
+    // Advanced options toggle
+    $("adv-toggle").addEventListener("click", () => {
+      this._showAdvanced = !this._showAdvanced;
+      $("adv-opts").classList.toggle("visible", this._showAdvanced);
+      $("adv-toggle").textContent = this._showAdvanced ? "- Advanced options" : "+ Advanced options";
     });
 
-    // Navigate go
-    this.shadowRoot.getElementById("nav-go-btn").addEventListener("click", () => {
-      this._sendNavigate();
+    // Max thrust slider label
+    $("opt-thrust").addEventListener("input", (e) => {
+      $("opt-thrust-val").textContent = `${e.target.value}%`;
     });
 
-    // Navigate cancel
-    this.shadowRoot.getElementById("nav-cancel-btn").addEventListener("click", () => {
-      this._hideCoordInput();
-    });
+    // Target-requiring commands
+    $("cmd-rendezvous").addEventListener("click", () => this._showTargetSelect("rendezvous"));
+    $("cmd-intercept").addEventListener("click", () => this._showTargetSelect("intercept"));
+    $("cmd-match").addEventListener("click", () => this._showTargetSelect("match"));
 
-    // Intercept - show target select then send
-    this.shadowRoot.getElementById("cmd-intercept").addEventListener("click", () => {
-      this._showTargetSelect("intercept");
-    });
+    // Simple autopilot programs
+    $("cmd-hold").addEventListener("click", () => this._sendAutopilot("hold"));
+    $("cmd-orbit").addEventListener("click", () => this._sendAutopilot("orbit"));
+    $("cmd-evasive").addEventListener("click", () => this._sendAutopilot("evasive"));
 
-    // Match velocity - show target select then send
-    this.shadowRoot.getElementById("cmd-match").addEventListener("click", () => {
-      this._showTargetSelect("match_velocity");
-    });
+    // Abort / disengage
+    $("cmd-abort").addEventListener("click", () => this._sendAutopilot("off"));
+    $("disengage-btn").addEventListener("click", () => this._sendAutopilot("off"));
 
-    // Simple commands
-    this.shadowRoot.getElementById("cmd-hold").addEventListener("click", () => {
-      this._sendCommand("hold");
-    });
-
-    this.shadowRoot.getElementById("cmd-orbit").addEventListener("click", () => {
-      this._sendCommand("orbit");
-    });
-
-    this.shadowRoot.getElementById("cmd-evasive").addEventListener("click", () => {
-      this._sendCommand("evasive");
-    });
-
-    this.shadowRoot.getElementById("cmd-manual").addEventListener("click", () => {
-      this._sendCommand("manual");
-    });
-
-    this.shadowRoot.getElementById("cmd-abort").addEventListener("click", () => {
-      this._sendCommand("abort");
-    });
-
-    // Target select change - auto-send if a pending action
-    this.shadowRoot.getElementById("target-select").addEventListener("change", (e) => {
+    // Target select change - auto-send if pending action
+    $("target-select").addEventListener("change", (e) => {
       if (e.target.value && this._pendingAction) {
         this._sendTargetCommand(this._pendingAction, e.target.value);
         this._hideTargetSelect();
@@ -518,38 +299,29 @@ class FlightComputerPanel extends HTMLElement {
 
     // Keyboard shortcuts
     this._keyHandler = (e) => {
-      const tag = e.target.tagName?.toLowerCase();
-      if (tag === "input" || tag === "textarea" || tag === "select") return;
+      // Skip if focus is in an input field
       if (e.composedPath().some(el => {
         const t = el.tagName?.toLowerCase();
         return t === "input" || t === "textarea" || t === "select";
       })) return;
 
       switch (e.key.toUpperCase()) {
-        case "H":
-          e.preventDefault();
-          this._sendCommand("hold");
-          break;
-        case "M":
-          e.preventDefault();
-          this._sendCommand("manual");
-          break;
+        case "H": e.preventDefault(); this._sendAutopilot("hold"); break;
+        case "M": e.preventDefault(); this._sendAutopilot("off"); break;
         case "ESCAPE":
-          if (this._showCoordinateInput) {
-            this._hideCoordInput();
-          } else {
-            this._sendCommand("abort");
-          }
+          if (this._showCoordinateInput) this._hideCoordInput();
+          else this._sendAutopilot("off");
           break;
       }
     };
     document.addEventListener("keydown", this._keyHandler);
   }
 
+  // --- UI toggles ---
+
   _toggleCoordInput() {
     this._showCoordinateInput = !this._showCoordinateInput;
-    const section = this.shadowRoot.getElementById("coord-section");
-    section.classList.toggle("visible", this._showCoordinateInput);
+    this.shadowRoot.getElementById("coord-section").classList.toggle("visible", this._showCoordinateInput);
     this._hideTargetSelect();
   }
 
@@ -561,8 +333,6 @@ class FlightComputerPanel extends HTMLElement {
   _showTargetSelect(action) {
     this._pendingAction = action;
     this._hideCoordInput();
-
-    // Update target dropdown
     const contacts = stateManager.getContacts();
     const select = this.shadowRoot.getElementById("target-select");
     select.innerHTML = '<option value="">-- Select Target --</option>';
@@ -573,7 +343,6 @@ class FlightComputerPanel extends HTMLElement {
       option.textContent = `${id} — ${contact.name || contact.classification || "UNKNOWN"}`;
       select.appendChild(option);
     });
-
     this.shadowRoot.getElementById("target-section").classList.add("visible");
   }
 
@@ -582,13 +351,15 @@ class FlightComputerPanel extends HTMLElement {
     this.shadowRoot.getElementById("target-section").classList.remove("visible");
   }
 
-  async _sendCommand(action) {
+  // --- Commands ---
+
+  async _sendAutopilot(program) {
     try {
-      const response = await wsClient.sendShipCommand("flight_computer", { action });
+      const response = await wsClient.sendShipCommand("autopilot", { program });
       if (response?.error) {
-        this._showMessage(`Flight computer error: ${response.error}`, "error");
+        this._showMessage(`Autopilot error: ${response.error}`, "error");
       } else {
-        this._showMessage(`Flight computer: ${action}`, "success");
+        this._showMessage(`Autopilot: ${program === "off" ? "disengaged" : program}`, "success");
       }
     } catch (error) {
       this._showMessage(`Command failed: ${error.message}`, "error");
@@ -596,15 +367,16 @@ class FlightComputerPanel extends HTMLElement {
   }
 
   async _sendNavigate() {
-    const x = parseFloat(this.shadowRoot.getElementById("nav-x").value) || 0;
-    const y = parseFloat(this.shadowRoot.getElementById("nav-y").value) || 0;
-    const z = parseFloat(this.shadowRoot.getElementById("nav-z").value) || 0;
+    const $ = (id) => this.shadowRoot.getElementById(id);
+    const x = parseFloat($("nav-x").value) || 0;
+    const y = parseFloat($("nav-y").value) || 0;
+    const z = parseFloat($("nav-z").value) || 0;
+    const tolerance = parseFloat($("opt-tolerance").value) || 100;
+    const max_thrust = (parseFloat($("opt-thrust").value) || 100) / 100;
+    const stop = $("opt-stop").checked;
 
     try {
-      const response = await wsClient.sendShipCommand("flight_computer", {
-        action: "navigate_to",
-        position: { x, y, z }
-      });
+      const response = await wsClient.sendShipCommand("set_course", { x, y, z, tolerance, max_thrust, stop });
       if (response?.error) {
         this._showMessage(`Navigate error: ${response.error}`, "error");
       } else {
@@ -618,10 +390,7 @@ class FlightComputerPanel extends HTMLElement {
 
   async _sendTargetCommand(action, targetId) {
     try {
-      const response = await wsClient.sendShipCommand("flight_computer", {
-        action,
-        target: targetId
-      });
+      const response = await wsClient.sendShipCommand("autopilot", { program: action, target: targetId });
       if (response?.error) {
         this._showMessage(`${action} error: ${response.error}`, "error");
       } else {
@@ -632,75 +401,70 @@ class FlightComputerPanel extends HTMLElement {
     }
   }
 
+  // --- Display update ---
+
   _updateDisplay() {
     const fc = this._fcState;
-    const badge = this.shadowRoot.getElementById("mode-badge");
-    const command = this.shadowRoot.getElementById("mode-command");
-    const phase = this.shadowRoot.getElementById("mode-phase");
-    const statusText = this.shadowRoot.getElementById("mode-status-text");
-    const progressSection = this.shadowRoot.getElementById("progress-section");
-    const burnDetails = this.shadowRoot.getElementById("burn-details");
+    const inlineStatus = this.shadowRoot.getElementById("inline-status");
+    const disengageBar = this.shadowRoot.getElementById("disengage-bar");
 
     if (!fc) {
-      badge.className = "mode-badge idle";
-      badge.textContent = "IDLE";
-      command.textContent = "No active command";
-      phase.textContent = "";
-      statusText.textContent = "";
-      progressSection.classList.add("hidden");
-      burnDetails.classList.add("hidden");
+      inlineStatus.classList.add("hidden");
+      disengageBar.classList.remove("visible");
+      this._clearActiveButtons();
       return;
     }
 
-    // Mode badge
-    const mode = (fc.mode || "idle").toLowerCase();
-    badge.className = `mode-badge ${mode}`;
-    badge.textContent = (fc.mode || "IDLE").toUpperCase();
+    // Show inline status section
+    inlineStatus.classList.remove("hidden");
+    disengageBar.classList.add("visible");
 
-    // Command info
-    command.textContent = fc.command || "No active command";
-    phase.textContent = fc.phase ? `Phase: ${fc.phase}` : "";
-    statusText.textContent = fc.status_text || "";
+    // Header: badge, command, target
+    const programLabel = (fc.program || "").toUpperCase().replace(/_/g, " ");
+    this.shadowRoot.getElementById("status-command").textContent = programLabel || "AUTOPILOT";
+    this.shadowRoot.getElementById("status-target").textContent = fc.target ? `-> ${fc.target}` : "";
+    this.shadowRoot.getElementById("status-text").textContent = fc.statusText || "";
 
-    // Progress
-    if (mode === "executing" && fc.progress !== undefined) {
-      progressSection.classList.remove("hidden");
-      const progressFill = this.shadowRoot.getElementById("progress-fill");
-      const progressEta = this.shadowRoot.getElementById("progress-eta");
-      const percent = Math.min(100, Math.max(0, (fc.progress || 0) * 100));
-      progressFill.style.width = `${percent}%`;
-      progressEta.textContent = fc.eta ? `ETA: ${this._formatTime(fc.eta)}` : "ETA: --";
-    } else {
-      progressSection.classList.add("hidden");
-    }
+    // Phase progress bar
+    const { segmentsHtml, labelsHtml } = buildPhaseProgressHtml(fc.program, fc.phase);
+    this.shadowRoot.getElementById("phase-bar").innerHTML = segmentsHtml;
+    this.shadowRoot.getElementById("phase-labels").innerHTML = labelsHtml;
 
-    // Burn plan details
-    if (fc.burn_plan || fc.delta_v !== undefined) {
-      burnDetails.classList.remove("hidden");
-      const plan = fc.burn_plan || fc;
-      this.shadowRoot.getElementById("burn-dv").textContent =
-        plan.delta_v !== undefined ? `${plan.delta_v.toFixed(1)} m/s` : "--";
-      this.shadowRoot.getElementById("burn-fuel").textContent =
-        plan.fuel_cost !== undefined ? `${plan.fuel_cost.toFixed(1)} kg` : "--";
-      this.shadowRoot.getElementById("burn-confidence").textContent =
-        plan.confidence !== undefined ? `${(plan.confidence * 100).toFixed(0)}%` : "--";
-    } else {
-      burnDetails.classList.add("hidden");
-    }
+    // Compact info row
+    this.shadowRoot.getElementById("info-dist").textContent = formatDistance(fc.range);
+    this.shadowRoot.getElementById("info-close").textContent =
+      fc.closingSpeed != null ? `${fc.closingSpeed.toFixed(1)} m/s` : "--";
+    this.shadowRoot.getElementById("info-eta").textContent = formatEta(fc.eta);
+
+    // Highlight the active command button
+    this._highlightActiveButton(fc.program);
   }
 
-  _formatTime(seconds) {
-    if (seconds === null || seconds === undefined || !isFinite(seconds)) return "--";
-    if (seconds < 60) return `${seconds.toFixed(0)}s`;
-    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.floor(seconds % 60)}s`;
-    return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+  _highlightActiveButton(program) {
+    // Map program names to button IDs
+    const programToBtnId = {
+      rendezvous: "cmd-rendezvous",
+      intercept: "cmd-intercept",
+      match: "cmd-match",
+      hold: "cmd-hold",
+      orbit: "cmd-orbit",
+      evasive: "cmd-evasive",
+      goto_position: "cmd-navigate",
+      set_course: "cmd-navigate",
+    };
+    const activeId = programToBtnId[program?.toLowerCase()] || null;
+    this.shadowRoot.querySelectorAll(".cmd-btn").forEach(btn => {
+      btn.classList.toggle("active", btn.id === activeId);
+    });
+  }
+
+  _clearActiveButtons() {
+    this.shadowRoot.querySelectorAll(".cmd-btn.active").forEach(btn => btn.classList.remove("active"));
   }
 
   _showMessage(text, type) {
     const systemMessages = document.getElementById("system-messages");
-    if (systemMessages?.show) {
-      systemMessages.show({ type, text });
-    }
+    if (systemMessages?.show) systemMessages.show({ type, text });
   }
 }
 

--- a/gui/components/flight-data-panel.js
+++ b/gui/components/flight-data-panel.js
@@ -1,0 +1,211 @@
+/**
+ * Flight Data Panel — merged nav display + delta-V budget.
+ * Read-only. Tier-aware: raw (m/m/s/kg, component vectors),
+ * arcade (friendly km/km/s, combined velocity+heading),
+ * cpu-assist (speed + fuel % only).
+ */
+import { stateManager } from "../js/state-manager.js";
+
+const G0 = 9.81;
+const BINGO_PCT = 0.10;
+
+class FlightDataPanel extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._unsub = null;
+    this._tier = window.controlTier || "arcade";
+    this._onTier = (e) => {
+      const t = e.detail?.tier || "arcade";
+      if (t !== this._tier) { this._tier = t; this._init(); this._update(); }
+    };
+  }
+
+  connectedCallback() {
+    this._init();
+    this._unsub = stateManager.subscribe("*", () => this._update());
+    document.addEventListener("tier-change", this._onTier);
+  }
+
+  disconnectedCallback() {
+    if (this._unsub) { this._unsub(); this._unsub = null; }
+    document.removeEventListener("tier-change", this._onTier);
+  }
+
+  _init() {
+    this.shadowRoot.innerHTML = `<style>
+:host { display:block; font-family:var(--font-mono,"JetBrains Mono",monospace); font-size:.8rem; font-variant-numeric:tabular-nums; }
+.s { padding:10px 14px; }
+.s+.s { border-top:1px solid var(--border-default,#2a2a3a); }
+.st { font-family:var(--font-sans,"Inter",sans-serif); font-size:.65rem; font-weight:600; text-transform:uppercase; letter-spacing:.5px; color:var(--text-secondary,#888899); margin-bottom:6px; }
+.kv { display:flex; justify-content:space-between; align-items:baseline; padding:2px 0; }
+.kl { font-family:var(--font-sans,"Inter",sans-serif); font-size:.7rem; color:var(--text-dim,#555566); }
+.kv-v { font-variant-numeric:tabular-nums; color:var(--text-primary,#e0e0e0); text-align:right; }
+.kv-v.i { color:var(--status-info,#00aaff); }
+.kv-v.c { color:var(--status-critical,#ff4444); }
+.fb { height:14px; background:var(--bg-input,#1a1a24); border-radius:3px; overflow:hidden; position:relative; margin-top:4px; }
+.ff { height:100%; transition:width .3s ease; border-radius:3px; }
+.ff.g { background:var(--status-nominal,#00ff88); }
+.ff.a { background:var(--status-warning,#ffaa00); }
+.ff.r { background:var(--status-critical,#ff4444); }
+.ft { position:absolute; right:6px; top:50%; transform:translateY(-50%); font-size:.65rem; color:var(--text-bright,#fff); text-shadow:0 1px 2px rgba(0,0,0,.5); }
+.bingo { padding:6px; background:rgba(255,68,68,.15); border:1px solid var(--status-critical,#ff4444); border-radius:4px; text-align:center; font-weight:700; font-size:.75rem; color:var(--status-critical,#ff4444); letter-spacing:2px; animation:bp 1.5s ease-in-out infinite; margin-bottom:6px; }
+@keyframes bp { 0%,100%{opacity:1} 50%{opacity:.5} }
+.empty { text-align:center; color:var(--text-dim,#555566); padding:24px; font-style:italic; font-size:.75rem; }
+.hero { text-align:center; padding:14px; }
+.hero .hv { font-size:1.6rem; font-weight:700; color:var(--status-info,#00aaff); }
+.hero .hs { font-size:.75rem; color:var(--text-secondary,#888899); margin-top:2px; }
+:host(.tier-raw) .s+.s { border-color:#00ff8833; }
+:host(.tier-raw) .st { font-family:"Courier New",monospace; color:#00ff8866; border-bottom:1px solid #00ff8822; padding-bottom:3px; }
+:host(.tier-raw) .kl { font-family:"Courier New",monospace; color:#00ff8888; }
+:host(.tier-raw) .kv-v { font-family:"Courier New",monospace; color:#00ff88; text-shadow:0 0 4px #00ff8844; }
+@media(max-width:400px) { .s{padding:8px 10px} .kl{font-size:.65rem} }
+</style><div id="c"><div class="empty">Waiting for flight data...</div></div>`;
+    this.classList.remove("tier-raw", "tier-arcade", "tier-cpu-assist");
+    this.classList.add(`tier-${this._tier}`);
+  }
+
+  _gather() {
+    const nav = stateManager.getNavigation();
+    const ship = stateManager.getShipState();
+    if (!ship || Object.keys(ship).length === 0) return null;
+    const pos = nav.position || [0, 0, 0];
+    const vel = nav.velocity || [0, 0, 0];
+    const hdg = nav.heading || { pitch: 0, yaw: 0 };
+    const vmag = ship.navigation?.velocity_magnitude || this._mag(vel);
+    const prop = ship.systems?.propulsion || {};
+    const fuel = ship.fuel || {};
+    const fm = prop.fuel_mass ?? fuel.current ?? 0;
+    const fc = prop.fuel_capacity ?? fuel.capacity ?? 0;
+    const fp = fc > 0 ? fm / fc : 0;
+    const dm = prop.dry_mass ?? ship.mass ?? 0;
+    const wm = dm + fm;
+    const mt = prop.max_thrust_n ?? prop.max_thrust ?? 0;
+    const ve = prop.exhaust_velocity ?? (prop.isp ? prop.isp * G0 : 0);
+    let dv = prop.delta_v ?? null;
+    if (dv === null && ve > 0 && dm > 0 && wm > dm) dv = ve * Math.log(wm / dm);
+    dv = dv ?? 0;
+    const tg = prop.thrust_g || 0;
+    const th = prop.throttle ?? 0;
+    const ct = mt * th;
+    let bt = null;
+    if (ct > 0 && ve > 0) { const r = ct / ve; bt = r > 0 ? fm / r : null; }
+    return { pos, vel, hdg, vmag, fm, fc, fp, dm, wm, dv, tg, bt };
+  }
+
+  _update() {
+    const el = this.shadowRoot.getElementById("c");
+    const d = this._gather();
+    if (!d) { el.innerHTML = '<div class="empty">Waiting for flight data...</div>'; return; }
+    const fn = this._tier === "raw" ? this._rawHTML(d)
+      : this._tier === "cpu-assist" ? this._assistHTML(d) : this._arcadeHTML(d);
+    el.innerHTML = fn;
+  }
+
+  // -- kv-inline helper to reduce template repetition --
+  _kv(label, value, cls = "") {
+    return `<div class="kv"><span class="kl">${label}</span><span class="kv-v ${cls}">${value}</span></div>`;
+  }
+
+  _fuelBar(fp, fmLabel) {
+    const cc = fp > .5 ? "g" : fp > .25 ? "a" : "r";
+    return `<div class="fb"><div class="ff ${cc}" style="width:${(fp*100).toFixed(1)}%"></div>${fmLabel ? `<span class="ft">${fmLabel}</span>` : ""}</div>`;
+  }
+
+  _bingoHTML(fp, fc) {
+    return (fp < BINGO_PCT && fc > 0) ? '<div class="bingo">BINGO FUEL</div>' : "";
+  }
+
+  // -- ARCADE --
+  _arcadeHTML(d) {
+    return `<div class="s"><div class="st">Position</div>${
+      this._kv("X", this._fmtDist(d.pos[0]))}${
+      this._kv("Y", this._fmtDist(d.pos[1]))}${
+      this._kv("Z", this._fmtDist(d.pos[2]))
+    }</div><div class="s"><div class="st">Velocity</div>${
+      this._kv("Speed", this._fmtSpd(d.vmag), "i")}${
+      this._kv("Heading", this._fmtAng(d.hdg.yaw ?? 0))}${
+      d.tg > 0 ? this._kv("Accel", d.tg.toFixed(2) + " G") : ""
+    }</div><div class="s">${this._bingoHTML(d.fp, d.fc)}${
+      this._kv("\u0394v", this._fmtSpd(d.dv), "i")}${
+      this._kv("Fuel", (d.fp*100).toFixed(1) + "%", d.fp < .25 ? "c" : "")}${
+      this._fuelBar(d.fp, this._fmtMass(d.fm))}${
+      d.bt !== null ? this._kv("Burn time", this._fmtDur(d.bt)) : ""}${
+      this._kv("Mass", this._fmtMass(d.wm))
+    }</div>`;
+  }
+
+  // -- RAW --
+  _rawHTML(d) {
+    const ac = (d.tg * G0).toFixed(2);
+    return `<div class="s"><div class="st">VELOCITY (m/s)</div>${
+      this._kv("Vx", this._sf(d.vel[0]))}${
+      this._kv("Vy", this._sf(d.vel[1]))}${
+      this._kv("Vz", this._sf(d.vel[2]))}${
+      this._kv("MAG", d.vmag.toFixed(1), "i")
+    }</div><div class="s"><div class="st">POSITION (m)</div>${
+      this._kv("X", this._sf(d.pos[0]))}${
+      this._kv("Y", this._sf(d.pos[1]))}${
+      this._kv("Z", this._sf(d.pos[2]))
+    }</div><div class="s"><div class="st">ACCEL</div>${
+      this._kv("FWD", ac + " m/s\u00B2")
+    }</div><div class="s">${this._bingoHTML(d.fp, d.fc)}<div class="st">DELTA-V / FUEL</div>${
+      this._kv("dV", d.dv.toFixed(1) + " m/s", "i")}${
+      this._kv("FUEL", d.fm.toFixed(1) + " kg")}${
+      this._fuelBar(d.fp, (d.fp*100).toFixed(1) + "%")}${
+      d.bt !== null ? this._kv("BURN", this._fmtDur(d.bt)) : ""}${
+      this._kv("DRY", d.dm.toFixed(1) + " kg")}${
+      this._kv("WET", d.wm.toFixed(1) + " kg")
+    }</div>`;
+  }
+
+  // -- CPU-ASSIST --
+  _assistHTML(d) {
+    return `<div class="hero"><div class="hv">${this._fmtSpd(d.vmag)}</div><div class="hs">current speed</div></div><div class="s">${
+      this._bingoHTML(d.fp, d.fc)}${
+      this._kv("\u0394v", this._fmtSpd(d.dv), "i")}${
+      this._kv("Fuel", (d.fp*100).toFixed(0) + "%", d.fp < .25 ? "c" : "")}${
+      this._fuelBar(d.fp, null)
+    }</div>`;
+  }
+
+  // -- Format helpers --
+  _mag(v) { return Math.sqrt(v[0]**2 + v[1]**2 + v[2]**2); }
+
+  /** Distance: <1000 -> "850 m", >=1000 -> "1.2 km", >=1e6 -> "1,234 km" */
+  _fmtDist(m) {
+    const a = Math.abs(m);
+    if (a >= 1e6) return (a/1000).toLocaleString(undefined, {maximumFractionDigits:0}) + " km";
+    if (a >= 1000) return (a/1000).toFixed(1) + " km";
+    return a.toFixed(0) + " m";
+  }
+
+  /** Speed: <100 -> "42.3 m/s", >=100 -> "142 m/s", >=1000 -> "1.24 km/s" */
+  _fmtSpd(v) {
+    const a = Math.abs(v);
+    if (a >= 1000) return (a/1000).toFixed(2) + " km/s";
+    if (a >= 100) return a.toFixed(0) + " m/s";
+    return a.toFixed(1) + " m/s";
+  }
+
+  _fmtAng(deg) { return `${deg >= 0 ? "+" : ""}${deg.toFixed(1)}\u00B0`; }
+
+  _fmtMass(kg) {
+    if (kg >= 1000) return (kg/1000).toLocaleString(undefined, {maximumFractionDigits:1}) + " t";
+    return kg.toLocaleString(undefined, {maximumFractionDigits:0}) + " kg";
+  }
+
+  _fmtDur(s) {
+    const t = Math.max(0, Math.floor(s));
+    const h = Math.floor(t/3600), m = Math.floor((t%3600)/60), sc = t%60;
+    if (h > 0) return `${h}h ${String(m).padStart(2,"0")}m ${String(sc).padStart(2,"0")}s`;
+    if (m > 0) return `${m}m ${String(sc).padStart(2,"0")}s`;
+    return `${sc}s`;
+  }
+
+  /** Signed fixed-point: "+1234.5" / "-42.0" */
+  _sf(v, d = 1) { return `${v >= 0 ? "+" : ""}${v.toFixed(d)}`; }
+}
+
+customElements.define("flight-data-panel", FlightDataPanel);
+export { FlightDataPanel };

--- a/gui/components/helm-queue-panel.js
+++ b/gui/components/helm-queue-panel.js
@@ -3,12 +3,16 @@
  * Displays the helm command queue status (active + pending commands)
  * and provides interrupt/clear controls.
  *
+ * Also shows pending inter-station helm requests (from tactical, ops, etc.)
+ * above the command queue, with execute/dismiss controls.
+ *
  * Subscribes to stateManager for helm queue data via ship state.
  * Falls back to polling helm_queue_status if state data is unavailable.
  */
 
 import { stateManager } from "../js/state-manager.js";
 import { wsClient } from "../js/ws-client.js";
+import { helmRequests } from "../js/helm-requests.js";
 
 class HelmQueuePanel extends HTMLElement {
   constructor() {
@@ -20,11 +24,14 @@ class HelmQueuePanel extends HTMLElement {
     // Track whether stateManager provides queue data so we know
     // whether to fall back to explicit polling.
     this._stateHasQueueData = false;
+    this._boundRequestUpdate = this._updateRequestsDisplay.bind(this);
   }
 
   connectedCallback() {
     this.render();
     this._subscribe();
+    this._setupRequestListeners();
+    this._updateRequestsDisplay();
   }
 
   disconnectedCallback() {
@@ -33,6 +40,7 @@ class HelmQueuePanel extends HTMLElement {
       this._unsubscribe = null;
     }
     this._stopPolling();
+    this._teardownRequestListeners();
   }
 
   // ---------------------------------------------------------------------------
@@ -142,6 +150,116 @@ class HelmQueuePanel extends HTMLElement {
     } catch (error) {
       this._showMessage(`Clear failed: ${error.message}`, "error");
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Inter-station request handling
+  // ---------------------------------------------------------------------------
+
+  _setupRequestListeners() {
+    window.addEventListener("helm:request_created", this._boundRequestUpdate);
+    window.addEventListener("helm:request_executed", this._boundRequestUpdate);
+    window.addEventListener("helm:request_dismissed", this._boundRequestUpdate);
+
+    // Delegate click events within the requests container
+    const reqList = this.shadowRoot.getElementById("requests-list");
+    if (reqList) {
+      reqList.addEventListener("click", (e) => {
+        const btn = e.target.closest(".req-action-btn");
+        if (!btn) return;
+        const requestId = parseInt(btn.dataset.requestId, 10);
+        if (btn.classList.contains("req-execute")) {
+          this._executeHelmRequest(requestId);
+        } else if (btn.classList.contains("req-dismiss")) {
+          this._dismissHelmRequest(requestId);
+        }
+      });
+    }
+  }
+
+  _teardownRequestListeners() {
+    window.removeEventListener("helm:request_created", this._boundRequestUpdate);
+    window.removeEventListener("helm:request_executed", this._boundRequestUpdate);
+    window.removeEventListener("helm:request_dismissed", this._boundRequestUpdate);
+  }
+
+  async _executeHelmRequest(requestId) {
+    const request = helmRequests.getAllRequests().find(r => r.id === requestId);
+    if (!request || request.status !== "pending") return;
+
+    try {
+      if (request.type === "point_at" || request.type === "set_heading") {
+        await wsClient.sendShipCommand("set_orientation", {
+          pitch: request.params.pitch || 0,
+          yaw: request.params.yaw || 0,
+          roll: request.params.roll || 0
+        });
+      } else if (request.type === "intercept") {
+        await wsClient.sendShipCommand("set_autopilot", {
+          mode: "intercept",
+          target: request.targetId
+        });
+      } else if (request.type === "match_velocity") {
+        await wsClient.sendShipCommand("set_autopilot", {
+          mode: "match",
+          target: request.targetId
+        });
+      }
+
+      helmRequests.executeRequest(requestId);
+      this._showMessage(`Executed: ${request.description}`, "success");
+    } catch (error) {
+      console.error("Failed to execute helm request:", error);
+      this._showMessage(`Failed: ${error.message}`, "error");
+    }
+  }
+
+  _dismissHelmRequest(requestId) {
+    const request = helmRequests.dismissRequest(requestId);
+    if (request) {
+      this._showMessage(`Dismissed: ${request.description}`, "info");
+    }
+  }
+
+  _updateRequestsDisplay() {
+    const pending = helmRequests.getPendingRequests();
+    const section = this.shadowRoot.getElementById("requests-section");
+    const listEl = this.shadowRoot.getElementById("requests-list");
+    const badge = this.shadowRoot.getElementById("requests-badge");
+
+    if (!section || !listEl || !badge) return;
+
+    badge.textContent = String(pending.length);
+    badge.classList.toggle("hidden", pending.length === 0);
+
+    if (pending.length === 0) {
+      section.style.display = "none";
+      return;
+    }
+
+    section.style.display = "";
+    listEl.innerHTML = pending.map(req => this._renderRequest(req)).join("");
+  }
+
+  _renderRequest(req) {
+    const typeLabels = {
+      point_at: "POINT AT",
+      intercept: "INTERCEPT",
+      match_velocity: "MATCH VEL",
+      set_heading: "SET HEADING"
+    };
+    const typeLabel = typeLabels[req.type] || req.type.toUpperCase();
+    const target = req.targetId ? ` ${req.targetId}` : "";
+    const source = req.source || "unknown";
+
+    return `
+      <div class="request-item ${req.type}">
+        <span class="request-source">${source.toUpperCase()}</span>
+        <span class="request-desc">${typeLabel}${target}</span>
+        <button class="req-action-btn req-execute" data-request-id="${req.id}" title="Execute this request">&#10003;</button>
+        <button class="req-action-btn req-dismiss" data-request-id="${req.id}" title="Dismiss this request">&#10007;</button>
+      </div>
+    `;
   }
 
   // ---------------------------------------------------------------------------
@@ -355,6 +473,128 @@ class HelmQueuePanel extends HTMLElement {
           border-color: var(--status-warning, #ffaa00);
         }
 
+        /* Pending requests section */
+        .requests-section {
+          margin-bottom: 12px;
+        }
+
+        .requests-header {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          margin-bottom: 6px;
+        }
+
+        .requests-title {
+          font-size: 0.7rem;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.5px;
+          color: var(--status-warning, #ffaa00);
+        }
+
+        .requests-badge {
+          background: var(--status-warning, #ffaa00);
+          color: var(--bg-primary, #0a0a0f);
+          padding: 1px 6px;
+          border-radius: 8px;
+          font-size: 0.65rem;
+          font-weight: 700;
+          line-height: 1.4;
+          animation: pulse-badge 1.5s ease-in-out infinite;
+        }
+
+        .requests-badge.hidden {
+          display: none;
+        }
+
+        @keyframes pulse-badge {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.6; }
+        }
+
+        .requests-list {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+        }
+
+        .request-item {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          padding: 8px 10px;
+          background: rgba(255, 170, 0, 0.06);
+          border: 1px solid rgba(255, 170, 0, 0.2);
+          border-radius: 6px;
+        }
+
+        .request-item.point_at,
+        .request-item.set_heading {
+          border-left: 3px solid var(--status-info, #00aaff);
+        }
+
+        .request-item.intercept {
+          border-left: 3px solid var(--status-warning, #ffaa00);
+        }
+
+        .request-item.match_velocity {
+          border-left: 3px solid var(--status-nominal, #00ff88);
+        }
+
+        .request-source {
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+          font-size: 0.65rem;
+          font-weight: 600;
+          color: var(--status-info, #00aaff);
+          min-width: 32px;
+        }
+
+        .request-desc {
+          flex: 1;
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+          font-size: 0.75rem;
+          color: var(--text-primary, #e0e0e0);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .req-action-btn {
+          width: 28px;
+          height: 28px;
+          border-radius: 4px;
+          border: 1px solid var(--border-default, #2a2a3a);
+          background: var(--bg-input, #1a1a24);
+          color: var(--text-secondary, #888899);
+          font-size: 0.85rem;
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 0;
+          transition: all 0.1s ease;
+          flex-shrink: 0;
+        }
+
+        .req-action-btn.req-execute:hover {
+          background: var(--status-nominal, #00ff88);
+          border-color: var(--status-nominal, #00ff88);
+          color: var(--bg-primary, #0a0a0f);
+        }
+
+        .req-action-btn.req-dismiss:hover {
+          background: rgba(255, 68, 68, 0.15);
+          border-color: var(--status-critical, #ff4444);
+          color: var(--status-critical, #ff4444);
+        }
+
+        .requests-divider {
+          border: none;
+          border-top: 1px solid var(--border-default, #2a2a3a);
+          margin: 12px 0;
+        }
+
         @media (max-width: 768px) {
           :host {
             padding: 10px;
@@ -366,7 +606,17 @@ class HelmQueuePanel extends HTMLElement {
         }
       </style>
 
-      <div class="section-title">Helm Queue</div>
+      <!-- Pending inter-station requests (hidden when empty) -->
+      <div class="requests-section" id="requests-section" style="display:none;">
+        <div class="requests-header">
+          <span class="requests-title">Pending Requests</span>
+          <span class="requests-badge hidden" id="requests-badge">0</span>
+        </div>
+        <div class="requests-list" id="requests-list"></div>
+        <hr class="requests-divider" />
+      </div>
+
+      <div class="section-title">Command Queue</div>
 
       <!-- Active command (visible when one is executing) -->
       <div class="active-command" id="active-section" style="display:none;">

--- a/gui/components/helm-requests.js
+++ b/gui/components/helm-requests.js
@@ -317,13 +317,13 @@ class HelmRequestsPanel extends HTMLElement {
         });
       } else if (request.type === 'intercept') {
         // Could trigger autopilot intercept mode
-        await wsClient.sendShipCommand("set_autopilot", {
-          mode: "intercept",
+        await wsClient.sendShipCommand("autopilot", {
+          program: "intercept",
           target: request.targetId
         });
       } else if (request.type === 'match_velocity') {
-        await wsClient.sendShipCommand("set_autopilot", {
-          mode: "match",
+        await wsClient.sendShipCommand("autopilot", {
+          program: "match",
           target: request.targetId
         });
       }

--- a/gui/components/helm-workflow-strip.js
+++ b/gui/components/helm-workflow-strip.js
@@ -1,0 +1,142 @@
+/**
+ * Helm Workflow Strip
+ * Breadcrumb bar showing the current workflow step for the active tier.
+ * Sits above the helm view grid.
+ *
+ * Steps vary by tier:
+ *   RAW:        PLAN -> ORIENT -> BURN -> CHECK
+ *   ARCADE:     DETECT -> TARGET -> COMMAND -> MONITOR
+ *   CPU-ASSIST: ASSESS -> ORDER -> QUEUE -> MONITOR
+ *
+ * Auto-detects current step from game state via stateManager.
+ */
+
+import { stateManager } from "../js/state-manager.js";
+
+const TIER_STEPS = {
+  raw:        ["PLAN", "ORIENT", "BURN", "CHECK"],
+  arcade:     ["DETECT", "TARGET", "COMMAND", "MONITOR"],
+  "cpu-assist": ["ASSESS", "ORDER", "QUEUE", "MONITOR"],
+};
+
+const ARROW = "\u2500\u2500\u25B6";
+
+class HelmWorkflowStrip extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._tier = window.controlTier || "arcade";
+    this._currentStep = 0;
+    this._pollId = null;
+    this._onTierChange = null;
+  }
+
+  connectedCallback() {
+    this._onTierChange = (e) => {
+      this._tier = e.detail?.tier || "arcade";
+      this._currentStep = 0;
+      this._render();
+    };
+    document.addEventListener("tier-change", this._onTierChange);
+
+    this._pollId = setInterval(() => this._detectStep(), 2000);
+    this._detectStep();
+    this._render();
+  }
+
+  disconnectedCallback() {
+    if (this._onTierChange) {
+      document.removeEventListener("tier-change", this._onTierChange);
+      this._onTierChange = null;
+    }
+    if (this._pollId) {
+      clearInterval(this._pollId);
+      this._pollId = null;
+    }
+  }
+
+  /** Determine how many steps are completed based on game state. */
+  _detectStep() {
+    let step = 0;
+    const contacts = stateManager.getContacts();
+    if (contacts && Object.keys(contacts).length > 0) step = 1;
+
+    const targeting = stateManager.getTargeting();
+    if (targeting?.target_id) step = 2;
+
+    const nav = stateManager.getNavigation();
+    if (nav?.autopilot?.active) step = 3;
+
+    if (step !== this._currentStep) {
+      this._currentStep = step;
+      this._render();
+    }
+  }
+
+  _render() {
+    const steps = TIER_STEPS[this._tier] || TIER_STEPS.arcade;
+    const accent = "var(--strip-accent, #4488ff)";
+
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          height: 32px;
+          user-select: none;
+        }
+        .strip {
+          display: flex;
+          align-items: center;
+          gap: 4px;
+          height: 100%;
+          font-family: "Courier New", monospace;
+          font-size: 11px;
+          text-transform: uppercase;
+          letter-spacing: 0.5px;
+          color: #556;
+        }
+        .step {
+          cursor: pointer;
+          padding: 2px 6px;
+          border-radius: 2px;
+          transition: color 0.2s, text-shadow 0.2s;
+          white-space: nowrap;
+        }
+        .step:hover { color: #99aacc; }
+        .step.done { color: #6a8; }
+        .step.current {
+          color: ${accent};
+          text-shadow: 0 0 6px ${accent};
+        }
+        .arrow { color: #334; padding: 0 2px; }
+      </style>
+      <div class="strip">
+        ${steps.map((name, i) => {
+          let cls = "step";
+          let label = `${i + 1}. ${name}`;
+          if (i < this._currentStep) { cls += " done"; label = `\u2713 ${name}`; }
+          else if (i === this._currentStep) { cls += " current"; }
+          const arrow = i < steps.length - 1
+            ? `<span class="arrow">${ARROW}</span>` : "";
+          return `<span class="${cls}" data-step="${i}">${label}</span>${arrow}`;
+        }).join("")}
+      </div>
+    `;
+
+    this.shadowRoot.querySelector(".strip").addEventListener("click", (e) => {
+      const stepEl = e.target.closest(".step");
+      if (!stepEl) return;
+      const idx = parseInt(stepEl.dataset.step, 10);
+      const stepId = steps[idx]?.toLowerCase();
+      if (stepId) {
+        this.dispatchEvent(new CustomEvent("workflow-step-click", {
+          bubbles: true, composed: true,
+          detail: { step: stepId },
+        }));
+      }
+    });
+  }
+}
+
+customElements.define("helm-workflow-strip", HelmWorkflowStrip);
+export { HelmWorkflowStrip };

--- a/gui/components/maneuver-planner.js
+++ b/gui/components/maneuver-planner.js
@@ -1,0 +1,1183 @@
+/**
+ * Maneuver Planner - Physics Estimation Engine
+ * Provides time-to-intercept, flip-and-burn calculations, waypoint navigation.
+ * Renamed from flight-computer.js; the old file is kept for backward compatibility.
+ * Inspired by The Expanse / Empty Epsilon style navigation assistance
+ */
+
+import { stateManager } from "../js/state-manager.js";
+import { wsClient } from "../js/ws-client.js";
+
+// Constants
+const G_ACCEL = 9.81; // m/s^2
+
+class ManeuverPlanner extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._unsubscribe = null;
+    this._mode = "waypoint"; // "waypoint", "intercept", "flip_burn"
+    this._targetContact = null;
+    this._waypoint = { x: 0, y: 0, z: 0 };
+    this._computedSolution = null;
+    this._waypointExecutionMode = "point";
+  }
+
+  connectedCallback() {
+    this.render();
+    this._subscribe();
+    this._setupInteraction();
+  }
+
+  disconnectedCallback() {
+    if (this._unsubscribe) {
+      this._unsubscribe();
+    }
+  }
+
+  _subscribe() {
+    this._unsubscribe = stateManager.subscribe("*", () => {
+      this._updateDisplay();
+    });
+  }
+
+  render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          padding: 16px;
+          font-family: var(--font-sans, "Inter", sans-serif);
+        }
+
+        .section-title {
+          font-size: 0.7rem;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.5px;
+          color: var(--text-secondary, #888899);
+          margin-bottom: 8px;
+        }
+
+        .mode-toggle {
+          display: flex;
+          gap: 4px;
+          margin-bottom: 12px;
+        }
+
+        .mode-btn {
+          flex: 1;
+          padding: 6px 8px;
+          background: var(--bg-input, #1a1a24);
+          border: 1px solid var(--border-default, #2a2a3a);
+          border-radius: 4px;
+          color: var(--text-secondary, #888899);
+          font-size: 0.65rem;
+          cursor: pointer;
+          transition: all 0.15s ease;
+        }
+
+        .mode-btn.active {
+          background: var(--status-info, #00aaff);
+          border-color: var(--status-info, #00aaff);
+          color: var(--bg-primary, #0a0a0f);
+        }
+
+        .waypoint-toggle {
+          display: flex;
+          gap: 4px;
+          margin-bottom: 12px;
+        }
+
+        .toggle-btn {
+          flex: 1;
+          padding: 6px 8px;
+          background: var(--bg-input, #1a1a24);
+          border: 1px solid var(--border-default, #2a2a3a);
+          border-radius: 4px;
+          color: var(--text-secondary, #888899);
+          font-size: 0.65rem;
+          cursor: pointer;
+          transition: all 0.15s ease;
+        }
+
+        .toggle-btn.active {
+          background: var(--status-nominal, #00ff88);
+          border-color: var(--status-nominal, #00ff88);
+          color: var(--bg-primary, #0a0a0f);
+        }
+
+        /* Waypoint Input */
+        .waypoint-input {
+          display: grid;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 8px;
+          margin-bottom: 12px;
+        }
+
+        .input-group {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+        }
+
+        .input-group label {
+          font-size: 0.65rem;
+          color: var(--text-dim, #555566);
+          text-transform: uppercase;
+          text-align: center;
+        }
+
+        .input-group input, .input-group select {
+          padding: 8px;
+          background: var(--bg-primary, #0a0a0f);
+          border: 1px solid var(--border-default, #2a2a3a);
+          border-radius: 4px;
+          color: var(--text-primary, #e0e0e0);
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+          font-size: 0.8rem;
+          text-align: center;
+        }
+
+        .input-group input:focus, .input-group select:focus {
+          outline: none;
+          border-color: var(--status-info, #00aaff);
+        }
+
+        .autopilot-options {
+          display: grid;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 8px;
+          margin-bottom: 12px;
+        }
+
+        /* Solution Display */
+        .solution-panel {
+          background: var(--bg-input, #1a1a24);
+          border-radius: 8px;
+          padding: 12px;
+          margin-bottom: 12px;
+        }
+
+        .solution-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          margin-bottom: 8px;
+        }
+
+        .solution-status {
+          font-size: 0.7rem;
+          font-weight: 600;
+          padding: 2px 8px;
+          border-radius: 3px;
+        }
+
+        .solution-status.valid {
+          background: var(--status-nominal, #00ff88);
+          color: #000;
+        }
+
+        .solution-status.computing {
+          background: var(--status-warning, #ffaa00);
+          color: #000;
+        }
+
+        .solution-status.invalid {
+          background: var(--status-critical, #ff4444);
+          color: #fff;
+        }
+
+        .solution-grid {
+          display: grid;
+          grid-template-columns: repeat(2, 1fr);
+          gap: 8px;
+        }
+
+        .solution-item {
+          padding: 8px;
+          background: rgba(0, 0, 0, 0.3);
+          border-radius: 4px;
+        }
+
+        .solution-label {
+          font-size: 0.65rem;
+          color: var(--text-dim, #555566);
+          text-transform: uppercase;
+          margin-bottom: 4px;
+        }
+
+        .solution-value {
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+          font-size: 0.9rem;
+          color: var(--text-primary, #e0e0e0);
+        }
+
+        .solution-value.highlight {
+          color: var(--status-info, #00aaff);
+          font-weight: 600;
+        }
+
+        .solution-item.full-width {
+          grid-column: span 2;
+        }
+
+        /* Maneuver Plan */
+        .maneuver-plan {
+          background: rgba(0, 170, 255, 0.1);
+          border: 1px solid var(--status-info, #00aaff);
+          border-radius: 8px;
+          padding: 12px;
+          margin-bottom: 12px;
+        }
+
+        .maneuver-step {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          padding: 8px 0;
+          border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .maneuver-step:last-child {
+          border-bottom: none;
+        }
+
+        .step-number {
+          width: 24px;
+          height: 24px;
+          background: var(--status-info, #00aaff);
+          color: #000;
+          border-radius: 50%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-size: 0.75rem;
+          font-weight: 600;
+        }
+
+        .step-content {
+          flex: 1;
+        }
+
+        .step-action {
+          font-size: 0.8rem;
+          color: var(--text-primary, #e0e0e0);
+        }
+
+        .step-detail {
+          font-size: 0.7rem;
+          color: var(--text-dim, #555566);
+        }
+
+        .step-countdown {
+          font-size: 0.65rem;
+          color: var(--status-info, #00aaff);
+          margin-top: 2px;
+        }
+
+        .plan-options {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          margin-bottom: 10px;
+        }
+
+        .plan-options label {
+          font-size: 0.7rem;
+          color: var(--text-secondary, #888899);
+          display: flex;
+          align-items: center;
+          gap: 6px;
+        }
+
+        .plan-feedback {
+          margin: 6px 0 12px;
+          font-size: 0.7rem;
+          min-height: 1em;
+          color: var(--status-critical, #ff4444);
+        }
+
+        .plan-feedback.success {
+          color: var(--status-nominal, #00ff88);
+        }
+
+        .plan-feedback.warning {
+          color: var(--status-warning, #ffaa00);
+        }
+
+        /* Actions */
+        .actions {
+          display: flex;
+          gap: 8px;
+        }
+
+        .btn {
+          flex: 1;
+          padding: 10px 16px;
+          background: var(--bg-input, #1a1a24);
+          border: 1px solid var(--border-default, #2a2a3a);
+          border-radius: 6px;
+          color: var(--text-primary, #e0e0e0);
+          font-size: 0.8rem;
+          cursor: pointer;
+          min-height: 44px;
+        }
+
+        .btn:hover:not(:disabled) {
+          background: var(--bg-hover, #22222e);
+          border-color: var(--status-info, #00aaff);
+        }
+
+        .btn:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+
+        .btn.primary {
+          background: var(--status-nominal, #00ff88);
+          border-color: var(--status-nominal, #00ff88);
+          color: var(--bg-primary, #0a0a0f);
+          font-weight: 600;
+        }
+
+        .btn.primary:hover:not(:disabled) {
+          filter: brightness(1.1);
+        }
+
+        .hidden {
+          display: none !important;
+        }
+      </style>
+
+      <div class="section-title">Maneuver Planner</div>
+
+      <!-- Mode Toggle -->
+      <div class="mode-toggle">
+        <button class="mode-btn active" data-mode="waypoint">Waypoint</button>
+        <button class="mode-btn" data-mode="intercept">Intercept</button>
+        <button class="mode-btn" data-mode="flip_burn">Flip & Burn</button>
+      </div>
+
+      <!-- Waypoint Mode -->
+      <div id="waypoint-section">
+        <div class="waypoint-input">
+          <div class="input-group">
+            <label>X (m)</label>
+            <input type="number" id="waypoint-x" value="0" step="100" />
+          </div>
+          <div class="input-group">
+            <label>Y (m)</label>
+            <input type="number" id="waypoint-y" value="0" step="100" />
+          </div>
+          <div class="input-group">
+            <label>Z (m)</label>
+            <input type="number" id="waypoint-z" value="0" step="100" />
+          </div>
+        </div>
+        <div class="input-group" style="margin-bottom: 12px;">
+          <label>Approach G-Force</label>
+          <input type="number" id="approach-g" value="1.0" min="0.1" max="10" step="0.1" style="width: 100%;" />
+        </div>
+        <div class="waypoint-toggle">
+          <button class="toggle-btn active" data-waypoint-mode="point">Point At</button>
+          <button class="toggle-btn" data-waypoint-mode="autopilot">Fly To</button>
+        </div>
+        <div class="autopilot-options hidden" id="autopilot-options">
+          <div class="input-group">
+            <label>Stop at Target</label>
+            <select id="course-stop">
+              <option value="true" selected>Yes</option>
+              <option value="false">No</option>
+            </select>
+          </div>
+          <div class="input-group">
+            <label>Tolerance (m)</label>
+            <input type="number" id="course-tolerance" value="50" min="1" step="1" />
+          </div>
+          <div class="input-group">
+            <label>Max Thrust (0-1)</label>
+            <input type="number" id="course-max-thrust" min="0" max="1" step="0.05" placeholder="Auto" />
+          </div>
+        </div>
+      </div>
+
+      <!-- Intercept Mode -->
+      <div id="intercept-section" class="hidden">
+        <div class="input-group" style="margin-bottom: 12px;">
+          <label>Target Contact</label>
+          <select id="target-select">
+            <option value="">-- Select Target --</option>
+          </select>
+        </div>
+        <div class="input-group" style="margin-bottom: 12px;">
+          <label>Intercept G-Force</label>
+          <input type="number" id="intercept-g" value="2.0" min="0.1" max="10" step="0.1" style="width: 100%;" />
+        </div>
+      </div>
+
+      <!-- Flip & Burn Mode -->
+      <div id="flip-burn-section" class="hidden">
+        <div class="input-group" style="margin-bottom: 12px;">
+          <label>Braking G-Force</label>
+          <input type="number" id="brake-g" value="1.0" min="0.1" max="10" step="0.1" style="width: 100%;" />
+        </div>
+      </div>
+
+      <!-- Solution Display -->
+      <div class="solution-panel">
+        <div class="solution-header">
+          <span class="section-title" style="margin-bottom: 0;">Computed Solution</span>
+          <span class="solution-status" id="solution-status">READY</span>
+        </div>
+        <div class="solution-grid" id="solution-grid">
+          <div class="solution-item">
+            <div class="solution-label">Range</div>
+            <div class="solution-value" id="sol-range">--</div>
+          </div>
+          <div class="solution-item">
+            <div class="solution-label">Closing Rate</div>
+            <div class="solution-value" id="sol-closing">--</div>
+          </div>
+          <div class="solution-item">
+            <div class="solution-label">Time to Target</div>
+            <div class="solution-value highlight" id="sol-tti">--</div>
+          </div>
+          <div class="solution-item">
+            <div class="solution-label">Required Delta-V</div>
+            <div class="solution-value highlight" id="sol-dv">--</div>
+          </div>
+          <div class="solution-item">
+            <div class="solution-label">Burn Duration</div>
+            <div class="solution-value" id="sol-burn">--</div>
+          </div>
+          <div class="solution-item">
+            <div class="solution-label">Flip Point</div>
+            <div class="solution-value" id="sol-flip">--</div>
+          </div>
+          <div class="solution-item full-width">
+            <div class="solution-label">Suggested Heading</div>
+            <div class="solution-value highlight" id="sol-heading">P: -- | Y: --</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Maneuver Plan -->
+      <div class="maneuver-plan" id="maneuver-plan" style="display: none;">
+        <div class="section-title" style="margin-bottom: 8px;">Maneuver Plan</div>
+        <div id="maneuver-steps"></div>
+      </div>
+
+      <div class="plan-options">
+        <label>
+          <input type="checkbox" id="queue-plan" />
+          Queue plan
+        </label>
+      </div>
+      <div class="plan-feedback" id="plan-feedback"></div>
+
+      <!-- Actions -->
+      <div class="actions">
+        <button class="btn" id="compute-btn">Compute</button>
+        <button class="btn primary" id="execute-btn" disabled>Execute</button>
+      </div>
+    `;
+  }
+
+  _setupInteraction() {
+    // Mode toggle
+    this.shadowRoot.querySelectorAll(".mode-btn").forEach(btn => {
+      btn.addEventListener("click", () => {
+        this._setMode(btn.dataset.mode);
+      });
+    });
+
+    this.shadowRoot.querySelectorAll(".toggle-btn").forEach(btn => {
+      btn.addEventListener("click", () => {
+        this._setWaypointExecutionMode(btn.dataset.waypointMode);
+      });
+    });
+
+    // Input changes trigger recompute
+    this.shadowRoot.querySelectorAll("input, select").forEach(input => {
+      input.addEventListener("change", () => {
+        this._compute();
+      });
+    });
+
+    // Compute button
+    this.shadowRoot.getElementById("compute-btn").addEventListener("click", () => {
+      this._compute();
+    });
+
+    // Execute button
+    this.shadowRoot.getElementById("execute-btn").addEventListener("click", () => {
+      this._execute();
+    });
+  }
+
+  _setMode(mode) {
+    this._mode = mode;
+
+    // Update button states
+    this.shadowRoot.querySelectorAll(".mode-btn").forEach(btn => {
+      btn.classList.toggle("active", btn.dataset.mode === mode);
+    });
+
+    // Show/hide sections
+    this.shadowRoot.getElementById("waypoint-section").classList.toggle("hidden", mode !== "waypoint");
+    this.shadowRoot.getElementById("intercept-section").classList.toggle("hidden", mode !== "intercept");
+    this.shadowRoot.getElementById("flip-burn-section").classList.toggle("hidden", mode !== "flip_burn");
+
+    // Reset solution
+    this._computedSolution = null;
+    this._updateSolutionDisplay();
+
+    // Update target dropdown if intercept mode
+    if (mode === "intercept") {
+      this._updateTargetDropdown();
+    }
+  }
+
+  _setWaypointExecutionMode(mode) {
+    if (!mode) return;
+    this._waypointExecutionMode = mode;
+    this.shadowRoot.querySelectorAll(".toggle-btn").forEach(btn => {
+      btn.classList.toggle("active", btn.dataset.waypointMode === mode);
+    });
+    const autopilotOptions = this.shadowRoot.getElementById("autopilot-options");
+    autopilotOptions.classList.toggle("hidden", mode !== "autopilot");
+    if (this._computedSolution) {
+      this._compute();
+    }
+  }
+
+  _updateTargetDropdown() {
+    const contacts = stateManager.getContacts();
+    const select = this.shadowRoot.getElementById("target-select");
+
+    select.innerHTML = '<option value="">-- Select Target --</option>';
+    contacts.forEach(contact => {
+      const id = contact.contact_id || contact.id;
+      const option = document.createElement("option");
+      option.value = id;
+      option.textContent = `${id} (${contact.classification || "UNKNOWN"})`;
+      select.appendChild(option);
+    });
+  }
+
+  _updateDisplay() {
+    // Update target dropdown in intercept mode
+    if (this._mode === "intercept") {
+      this._updateTargetDropdown();
+    }
+
+    // Recompute if we have a solution
+    if (this._computedSolution) {
+      this._compute();
+    }
+  }
+
+  _compute() {
+    const nav = stateManager.getNavigation();
+    const ship = stateManager.getShipState();
+
+    const position = nav.position || [0, 0, 0];
+    const velocity = nav.velocity || [0, 0, 0];
+
+    const statusEl = this.shadowRoot.getElementById("solution-status");
+    statusEl.className = "solution-status computing";
+    statusEl.textContent = "COMPUTING";
+
+    let solution = null;
+
+    try {
+      switch (this._mode) {
+        case "waypoint":
+          solution = this._computeWaypointSolution(position, velocity, ship);
+          break;
+        case "intercept":
+          solution = this._computeInterceptSolution(position, velocity, ship);
+          break;
+        case "flip_burn":
+          solution = this._computeFlipBurnSolution(position, velocity, ship);
+          break;
+      }
+
+      if (solution) {
+        this._computedSolution = solution;
+        statusEl.className = "solution-status valid";
+        statusEl.textContent = "VALID";
+        this.shadowRoot.getElementById("execute-btn").disabled = false;
+      } else {
+        statusEl.className = "solution-status invalid";
+        statusEl.textContent = "NO SOLUTION";
+        this.shadowRoot.getElementById("execute-btn").disabled = true;
+      }
+    } catch (error) {
+      console.error("Flight computer error:", error);
+      statusEl.className = "solution-status invalid";
+      statusEl.textContent = "ERROR";
+      this.shadowRoot.getElementById("execute-btn").disabled = true;
+      this._showMessage(`Flight computer error: ${error.message}`, "error");
+    }
+
+    this._updateSolutionDisplay();
+  }
+
+  _computeWaypointSolution(position, velocity, ship) {
+    const targetX = parseFloat(this.shadowRoot.getElementById("waypoint-x").value) || 0;
+    const targetY = parseFloat(this.shadowRoot.getElementById("waypoint-y").value) || 0;
+    const targetZ = parseFloat(this.shadowRoot.getElementById("waypoint-z").value) || 0;
+    const approachG = parseFloat(this.shadowRoot.getElementById("approach-g").value) || 1.0;
+    const stopValue = this.shadowRoot.getElementById("course-stop")?.value ?? "true";
+    const stop = stopValue !== "false";
+    const tolerance = parseFloat(this.shadowRoot.getElementById("course-tolerance")?.value) || 50;
+    const maxThrustValue = parseFloat(this.shadowRoot.getElementById("course-max-thrust")?.value);
+    const maxThrust = Number.isFinite(maxThrustValue) ? maxThrustValue : null;
+
+    // Calculate relative vector
+    const dx = targetX - position[0];
+    const dy = targetY - position[1];
+    const dz = targetZ - position[2];
+    const range = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+    if (range < 1) {
+      return null; // Already at target
+    }
+
+    // Current velocity magnitude
+    const velMag = Math.sqrt(velocity[0]**2 + velocity[1]**2 + velocity[2]**2);
+
+    // Closing rate (velocity towards target)
+    const dirX = dx / range;
+    const dirY = dy / range;
+    const dirZ = dz / range;
+    const closingRate = velocity[0] * dirX + velocity[1] * dirY + velocity[2] * dirZ;
+
+    // Acceleration for approach
+    const accel = approachG * G_ACCEL;
+
+    // Calculate brachistochrone trajectory (constant thrust)
+    // For point-to-point: accelerate halfway, then decelerate
+    const flipDistance = range / 2;
+
+    // Time to flip point using kinematic equation: d = v0*t + 0.5*a*t^2
+    // Solving for t when accelerating from current velocity
+    // For simplicity, use: t = sqrt(2*d/a) for starting from rest approach
+    const timeToFlip = Math.sqrt(2 * flipDistance / accel);
+    const totalTime = timeToFlip * 2;
+
+    // Velocity at flip point
+    const flipVelocity = accel * timeToFlip;
+
+    // Total delta-v required (accelerate + decelerate)
+    const deltaV = flipVelocity * 2 - closingRate;
+
+    // Calculate heading to target
+    const yaw = Math.atan2(dy, dx) * (180 / Math.PI);
+    const horizontalDist = Math.sqrt(dx * dx + dy * dy);
+    const pitch = Math.atan2(dz, horizontalDist) * (180 / Math.PI);
+
+    // Build maneuver plan
+    const maneuverPlan = [
+      {
+        action: "Point prograde",
+        detail: `Heading: P=${pitch.toFixed(1)} Y=${yaw.toFixed(1)}`,
+        trigger: { distance_remaining: range }
+      },
+      {
+        action: `Burn at ${approachG}G`,
+        detail: `Duration: ${this._formatTime(timeToFlip)}`,
+        trigger: { time_to_target: totalTime }
+      },
+      {
+        action: "Flip 180 degrees",
+        detail: `At ${this._formatDistance(flipDistance)} from start`,
+        trigger: { distance_remaining: range - flipDistance }
+      },
+      {
+        action: `Brake at ${approachG}G`,
+        detail: `Duration: ${this._formatTime(timeToFlip)}`,
+        trigger: { distance_remaining: range - flipDistance }
+      },
+      {
+        action: "Arrival",
+        detail: "Zero relative velocity",
+        trigger: { distance_remaining: 0, time_to_target: 0 }
+      }
+    ];
+
+    const plan = {
+      name: "Waypoint Plan",
+      type: "waypoint",
+      source: "flight_computer",
+      target: { position: { x: targetX, y: targetY, z: targetZ } },
+      steps: maneuverPlan.map(step => ({
+        action: step.action,
+        detail: step.detail,
+        trigger: step.trigger
+      }))
+    };
+
+    return {
+      range,
+      closingRate,
+      timeToIntercept: totalTime,
+      deltaV: Math.abs(deltaV),
+      burnDuration: timeToFlip,
+      flipPoint: flipDistance,
+      heading: { pitch, yaw },
+      targetPosition: { x: targetX, y: targetY, z: targetZ },
+      maneuverPlan,
+      plan,
+      command: {
+        type: "waypoint",
+        position: { x: targetX, y: targetY, z: targetZ },
+        g: approachG,
+        executionMode: this._waypointExecutionMode,
+        stop,
+        tolerance,
+        max_thrust: maxThrust
+      }
+    };
+  }
+
+  _computeInterceptSolution(position, velocity, ship) {
+    const targetId = this.shadowRoot.getElementById("target-select").value;
+    const interceptG = parseFloat(this.shadowRoot.getElementById("intercept-g").value) || 2.0;
+
+    if (!targetId) return null;
+
+    // Get target contact
+    const contacts = stateManager.getContacts();
+    const target = contacts.find(c => (c.contact_id || c.id) === targetId);
+
+    if (!target) return null;
+
+    const targetPos = target.position || [0, 0, 0];
+    const targetVel = target.velocity || [0, 0, 0];
+
+    // Calculate relative motion
+    const dx = targetPos[0] - position[0];
+    const dy = targetPos[1] - position[1];
+    const dz = targetPos[2] - position[2];
+    const range = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+    // Relative velocity
+    const dvx = targetVel[0] - velocity[0];
+    const dvy = targetVel[1] - velocity[1];
+    const dvz = targetVel[2] - velocity[2];
+    const closingRate = -(dx * dvx + dy * dvy + dz * dvz) / range;
+
+    // For intercept, use lead pursuit
+    // Estimate time to intercept assuming constant acceleration
+    const accel = interceptG * G_ACCEL;
+
+    // Simple estimate: t = sqrt(2*range/accel) for stationary target
+    // For moving target, iterate or use approximation
+    let timeToIntercept;
+    if (closingRate > 0) {
+      // Already closing, adjust for that
+      timeToIntercept = range / closingRate;
+    } else {
+      timeToIntercept = Math.sqrt(2 * range / accel);
+    }
+
+    // Predicted intercept point
+    const interceptX = targetPos[0] + targetVel[0] * timeToIntercept;
+    const interceptY = targetPos[1] + targetVel[1] * timeToIntercept;
+    const interceptZ = targetPos[2] + targetVel[2] * timeToIntercept;
+
+    // Heading to intercept point
+    const interceptDx = interceptX - position[0];
+    const interceptDy = interceptY - position[1];
+    const interceptDz = interceptZ - position[2];
+    const yaw = Math.atan2(interceptDy, interceptDx) * (180 / Math.PI);
+    const horizontalDist = Math.sqrt(interceptDx * interceptDx + interceptDy * interceptDy);
+    const pitch = Math.atan2(interceptDz, horizontalDist) * (180 / Math.PI);
+
+    // Delta-v to match velocity at intercept
+    const deltaV = Math.sqrt(dvx * dvx + dvy * dvy + dvz * dvz);
+    const burnDuration = deltaV / accel;
+
+    // Build maneuver plan
+    const maneuverPlan = [
+      {
+        action: "Point at lead",
+        detail: `Heading: P=${pitch.toFixed(1)} Y=${yaw.toFixed(1)}`,
+        trigger: { distance_remaining: range }
+      },
+      {
+        action: `Burn at ${interceptG}G`,
+        detail: `Intercept in ${this._formatTime(timeToIntercept)}`,
+        trigger: { time_to_target: timeToIntercept }
+      },
+      {
+        action: "Match velocity",
+        detail: `Delta-V: ${deltaV.toFixed(1)} m/s`,
+        trigger: { distance_remaining: 0, time_to_target: 0 }
+      }
+    ];
+
+    const plan = {
+      name: "Intercept Plan",
+      type: "intercept",
+      source: "flight_computer",
+      target: { contact_id: targetId },
+      steps: maneuverPlan.map(step => ({
+        action: step.action,
+        detail: step.detail,
+        trigger: step.trigger
+      }))
+    };
+
+    return {
+      range,
+      closingRate,
+      timeToIntercept,
+      deltaV,
+      burnDuration,
+      flipPoint: range / 2,
+      heading: { pitch, yaw },
+      targetId,
+      maneuverPlan,
+      plan,
+      command: {
+        type: "intercept",
+        target: targetId,
+        g: interceptG
+      }
+    };
+  }
+
+  _computeFlipBurnSolution(position, velocity, ship) {
+    const brakeG = parseFloat(this.shadowRoot.getElementById("brake-g").value) || 1.0;
+
+    // Current velocity magnitude
+    const velMag = Math.sqrt(velocity[0]**2 + velocity[1]**2 + velocity[2]**2);
+
+    if (velMag < 1) {
+      return null; // Already stationary
+    }
+
+    // Deceleration
+    const accel = brakeG * G_ACCEL;
+
+    // Time to stop: v = a*t => t = v/a
+    const burnDuration = velMag / accel;
+
+    // Distance to stop: d = v^2 / (2*a)
+    const stoppingDistance = (velMag * velMag) / (2 * accel);
+
+    // Retrograde heading (opposite of velocity)
+    const retroYaw = Math.atan2(-velocity[1], -velocity[0]) * (180 / Math.PI);
+    const retroHorizDist = Math.sqrt(velocity[0]**2 + velocity[1]**2);
+    const retroPitch = Math.atan2(-velocity[2], retroHorizDist) * (180 / Math.PI);
+
+    // Build maneuver plan
+    const maneuverPlan = [
+      {
+        action: "Flip to retrograde",
+        detail: `Heading: P=${retroPitch.toFixed(1)} Y=${retroYaw.toFixed(1)}`,
+        trigger: { time_to_target: burnDuration }
+      },
+      {
+        action: `Brake at ${brakeG}G`,
+        detail: `Duration: ${this._formatTime(burnDuration)}`,
+        trigger: { time_to_target: burnDuration }
+      },
+      {
+        action: "Full stop",
+        detail: `After ${this._formatDistance(stoppingDistance)}`,
+        trigger: { distance_remaining: 0, time_to_target: 0 }
+      }
+    ];
+
+    const plan = {
+      name: "Flip & Burn Plan",
+      type: "flip_burn",
+      source: "flight_computer",
+      target: { stop: true },
+      steps: maneuverPlan.map(step => ({
+        action: step.action,
+        detail: step.detail,
+        trigger: step.trigger
+      }))
+    };
+
+    return {
+      range: stoppingDistance,
+      closingRate: velMag,
+      timeToIntercept: burnDuration,
+      deltaV: velMag,
+      burnDuration,
+      flipPoint: 0,
+      heading: { pitch: retroPitch, yaw: retroYaw },
+      maneuverPlan,
+      plan,
+      command: {
+        type: "maneuver",
+        maneuver: "retrograde",
+        g: brakeG
+      }
+    };
+  }
+
+  _updateSolutionDisplay() {
+    const sol = this._computedSolution;
+
+    const rangeEl = this.shadowRoot.getElementById("sol-range");
+    const closingEl = this.shadowRoot.getElementById("sol-closing");
+    const ttiEl = this.shadowRoot.getElementById("sol-tti");
+    const dvEl = this.shadowRoot.getElementById("sol-dv");
+    const burnEl = this.shadowRoot.getElementById("sol-burn");
+    const flipEl = this.shadowRoot.getElementById("sol-flip");
+    const headingEl = this.shadowRoot.getElementById("sol-heading");
+    const maneuverPlan = this.shadowRoot.getElementById("maneuver-plan");
+    const maneuverSteps = this.shadowRoot.getElementById("maneuver-steps");
+
+    if (!sol) {
+      rangeEl.textContent = "--";
+      closingEl.textContent = "--";
+      ttiEl.textContent = "--";
+      dvEl.textContent = "--";
+      burnEl.textContent = "--";
+      flipEl.textContent = "--";
+      headingEl.textContent = "P: -- | Y: --";
+      maneuverPlan.style.display = "none";
+      return;
+    }
+
+    rangeEl.textContent = this._formatDistance(sol.range);
+    closingEl.textContent = `${sol.closingRate.toFixed(1)} m/s`;
+    ttiEl.textContent = this._formatTime(sol.timeToIntercept);
+    dvEl.textContent = `${sol.deltaV.toFixed(1)} m/s`;
+    burnEl.textContent = this._formatTime(sol.burnDuration);
+    flipEl.textContent = this._formatDistance(sol.flipPoint);
+    headingEl.textContent = `P: ${sol.heading.pitch.toFixed(1)} | Y: ${sol.heading.yaw.toFixed(1)}`;
+
+    // Show maneuver plan
+    if (sol.maneuverPlan && sol.maneuverPlan.length > 0) {
+      maneuverPlan.style.display = "block";
+      const liveMetrics = this._getLiveTargetMetrics(sol);
+      maneuverSteps.innerHTML = sol.maneuverPlan.map((step, i) => {
+        const countdown = this._formatTriggerCountdown(step.trigger, liveMetrics);
+        return `
+          <div class="maneuver-step">
+            <div class="step-number">${i + 1}</div>
+            <div class="step-content">
+              <div class="step-action">${step.action}</div>
+              <div class="step-detail">${step.detail}</div>
+              <div class="step-countdown">${countdown}</div>
+            </div>
+          </div>
+        `;
+      }).join("");
+    } else {
+      maneuverPlan.style.display = "none";
+    }
+  }
+
+  async _execute() {
+    if (!this._computedSolution) return;
+
+    const cmd = this._computedSolution.command;
+    const queuePlan = this.shadowRoot.getElementById("queue-plan")?.checked;
+
+    try {
+      let response;
+
+      if (queuePlan && this._computedSolution.plan) {
+        try {
+          await wsClient.sendShipCommand("set_plan", { plan: this._computedSolution.plan });
+          this._showMessage("Flight plan queued", "success");
+          this._setPlanFeedback("Flight plan queued.", "success");
+        } catch (error) {
+          this._showMessage(`Plan queue failed: ${error.message}`, "warning");
+          this._setPlanFeedback(`Plan queue failed: ${error.message}`, "warning");
+        }
+      } else {
+        this._setPlanFeedback("", "");
+      }
+
+      switch (cmd.type) {
+        case "waypoint":
+          if (cmd.executionMode === "autopilot") {
+            const payload = {
+              x: cmd.position.x,
+              y: cmd.position.y,
+              z: cmd.position.z,
+              stop: cmd.stop,
+              tolerance: cmd.tolerance
+            };
+            if (cmd.max_thrust !== null && cmd.max_thrust !== undefined) {
+              payload.max_thrust = cmd.max_thrust;
+            }
+            await wsClient.sendShipCommand("set_course", payload);
+            this._showMessage(`Course set to (${cmd.position.x.toFixed(0)}, ${cmd.position.y.toFixed(0)}, ${cmd.position.z.toFixed(0)})`, "success");
+          } else {
+            await wsClient.sendShipCommand("point_at", { position: cmd.position });
+            this._showMessage(`Pointing at waypoint (${cmd.position.x.toFixed(0)}, ${cmd.position.y.toFixed(0)}, ${cmd.position.z.toFixed(0)})`, "info");
+          }
+          break;
+
+        case "intercept":
+          response = await wsClient.sendShipCommand("autopilot", {
+            program: "intercept",
+            target: cmd.target
+          });
+          this._showMessage(`Intercept autopilot engaged: ${cmd.target}`, "success");
+          break;
+
+        case "maneuver":
+          response = await wsClient.sendShipCommand("maneuver", {
+            type: cmd.maneuver,
+            g: cmd.g
+          });
+          this._showMessage(`${cmd.maneuver} maneuver initiated at ${cmd.g}G`, "success");
+          break;
+      }
+    } catch (error) {
+      console.error("Execute failed:", error);
+      this._showMessage(`Execution failed: ${error.message}`, "error");
+    }
+  }
+
+  _getLiveTargetMetrics(solution) {
+    const nav = stateManager.getNavigation();
+    const position = nav.position || [0, 0, 0];
+    const velocity = nav.velocity || [0, 0, 0];
+    const mode = solution?.command?.type;
+
+    if (!mode) {
+      return { distanceRemaining: null, timeToTarget: null };
+    }
+
+    if (mode === "maneuver") {
+      const gForce = solution.command?.g || 1.0;
+      const accel = gForce * G_ACCEL;
+      const speed = Math.sqrt(velocity[0]**2 + velocity[1]**2 + velocity[2]**2);
+      if (accel <= 0) {
+        return { distanceRemaining: null, timeToTarget: null };
+      }
+      return {
+        distanceRemaining: (speed * speed) / (2 * accel),
+        timeToTarget: speed / accel,
+      };
+    }
+
+    let targetPos = null;
+    let targetVel = [0, 0, 0];
+
+    if (mode === "waypoint") {
+      const target = solution.command?.position;
+      if (target) {
+        targetPos = [target.x || 0, target.y || 0, target.z || 0];
+      }
+    } else if (mode === "intercept") {
+      const contacts = stateManager.getContacts();
+      const targetId = solution.command?.target;
+      const target = contacts.find(c => (c.contact_id || c.id) === targetId);
+      if (target) {
+        targetPos = target.position || [0, 0, 0];
+        targetVel = target.velocity || [0, 0, 0];
+      }
+    }
+
+    if (!targetPos) {
+      return { distanceRemaining: null, timeToTarget: null };
+    }
+
+    const dx = targetPos[0] - position[0];
+    const dy = targetPos[1] - position[1];
+    const dz = targetPos[2] - position[2];
+    const range = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (range <= 0) {
+      return { distanceRemaining: 0, timeToTarget: 0 };
+    }
+
+    let closingRate = 0;
+    if (mode === "waypoint") {
+      const dirX = dx / range;
+      const dirY = dy / range;
+      const dirZ = dz / range;
+      closingRate = velocity[0] * dirX + velocity[1] * dirY + velocity[2] * dirZ;
+    } else {
+      const dvx = targetVel[0] - velocity[0];
+      const dvy = targetVel[1] - velocity[1];
+      const dvz = targetVel[2] - velocity[2];
+      closingRate = -(dx * dvx + dy * dvy + dz * dvz) / range;
+    }
+
+    const timeToTarget = closingRate > 0 ? range / closingRate : null;
+
+    return {
+      distanceRemaining: range,
+      timeToTarget,
+    };
+  }
+
+  _formatTriggerCountdown(trigger, metrics) {
+    const hasDistance = metrics.distanceRemaining !== null && metrics.distanceRemaining !== undefined;
+    const hasTime = metrics.timeToTarget !== null && metrics.timeToTarget !== undefined;
+
+    if (!trigger || (!hasDistance && !hasTime)) {
+      return "Trigger: --";
+    }
+
+    const parts = [];
+
+    if (trigger.distance_remaining !== undefined && trigger.distance_remaining !== null && hasDistance) {
+      const delta = metrics.distanceRemaining - trigger.distance_remaining;
+      const label = delta <= 0 ? "dist: NOW" : `dist: ${this._formatDistance(delta)}`;
+      parts.push(label);
+    }
+
+    if (trigger.time_to_target !== undefined && trigger.time_to_target !== null && hasTime) {
+      const delta = metrics.timeToTarget - trigger.time_to_target;
+      const label = delta <= 0 ? "time: NOW" : `time: ${this._formatTime(delta)}`;
+      parts.push(label);
+    }
+
+    if (!parts.length) {
+      return "Trigger: --";
+    }
+
+    return `Trigger: ${parts.join(" • ")}`;
+  }
+
+  _formatTime(seconds) {
+    if (seconds === null || seconds === undefined || !isFinite(seconds)) return "--";
+    if (seconds < 60) return `${seconds.toFixed(1)}s`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.floor(seconds % 60)}s`;
+    return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+  }
+
+  _formatDistance(meters) {
+    if (meters === null || meters === undefined || !isFinite(meters)) return "--";
+    if (Math.abs(meters) >= 1000000) return `${(meters / 1000).toFixed(0)} km`;
+    if (Math.abs(meters) >= 1000) return `${(meters / 1000).toFixed(2)} km`;
+    return `${meters.toFixed(1)} m`;
+  }
+
+  _showMessage(text, type) {
+    const systemMessages = document.getElementById("system-messages");
+    if (systemMessages?.show) {
+      systemMessages.show({ type, text });
+    }
+  }
+
+  _setPlanFeedback(message, variant) {
+    const feedback = this.shadowRoot.getElementById("plan-feedback");
+    if (!feedback) return;
+    feedback.textContent = message || "";
+    feedback.classList.remove("success", "warning");
+    if (variant) {
+      feedback.classList.add(variant);
+    }
+  }
+}
+
+customElements.define("maneuver-planner", ManeuverPlanner);
+export { ManeuverPlanner };

--- a/gui/components/manual-flight-panel.js
+++ b/gui/components/manual-flight-panel.js
@@ -1,0 +1,266 @@
+/**
+ * Manual Flight Panel — unified throttle + heading + velocity readout.
+ * Tier-aware: RAW=full controls, ARCADE=throttle+readonly heading, CPU-ASSIST=hidden.
+ * Commands: set_thrust {thrust:0-1}, set_orientation {pitch,yaw,roll} (same as existing components).
+ */
+import { stateManager } from "../js/state-manager.js";
+import { wsClient } from "../js/ws-client.js";
+
+class ManualFlightPanel extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._unsub = null;
+    this._tier = window.controlTier || "arcade";
+    this._throttle = 0; this._isDragging = false; this._pendingThrottle = false;
+    this._pitch = 0; this._yaw = 0; this._roll = 0;
+    this._currentG = 0; this._maxForceN = 0; this._velocity = [0, 0, 0];
+    this._docHandlers = [];
+  }
+
+  connectedCallback() {
+    this._render();
+    this._unsub = stateManager.subscribe("*", () => { if (!this._isDragging) this._updateFromState(); });
+    this._setupInteraction();
+    this._onTier = (e) => { this._tier = e.detail?.tier || "arcade"; this._applyTier(); };
+    document.addEventListener("tier-change", this._onTier);
+    this._applyTier();
+  }
+
+  disconnectedCallback() {
+    if (this._unsub) { this._unsub(); this._unsub = null; }
+    if (this._onTier) { document.removeEventListener("tier-change", this._onTier); this._onTier = null; }
+    for (const h of this._docHandlers) document.removeEventListener(h.event, h.fn, h.opts);
+    this._docHandlers = [];
+  }
+
+  _render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host { display:block; font-family:var(--font-sans,"Inter",sans-serif); color:var(--text-primary,#e0e0e0); }
+        .p { display:grid; grid-template-columns:1fr 1fr; gap:12px; padding:12px; }
+        :host(.tier-arcade) .p { border:2px solid var(--status-warning,#ffaa00); border-radius:6px; }
+        .olbl { display:none; grid-column:1/-1; text-align:center; font-size:.75rem; font-weight:700;
+                 color:var(--status-warning,#ffaa00); text-transform:uppercase; letter-spacing:.1em; }
+        :host(.tier-arcade) .olbl { display:block; }
+        .sl { font-size:.65rem; text-transform:uppercase; color:var(--text-dim,#555566); margin-bottom:8px; letter-spacing:.08em; }
+        .ts { display:flex; flex-direction:column; gap:8px; }
+        .tr { display:flex; align-items:center; gap:8px; }
+        .tt { flex:1; height:24px; background:var(--bg-input,#1a1a24); border-radius:12px; position:relative; cursor:pointer; }
+        .tf { position:absolute; left:0; top:0; bottom:0; background:var(--status-info,#00aaff); border-radius:12px; transition:width .1s; pointer-events:none; }
+        .th { position:absolute; top:2px; width:20px; height:20px; background:var(--status-info,#00aaff); border-radius:50%; cursor:grab; transform:translateX(-50%); transition:background .1s; }
+        .th:hover { background:var(--text-bright,#fff); }
+        .th.drag { cursor:grabbing; background:var(--status-nominal,#00ff88); }
+        .tp { font-family:var(--font-mono,"JetBrains Mono",monospace); font-size:.9rem; min-width:3.5em; text-align:right; }
+        .ro { font-family:var(--font-mono,"JetBrains Mono",monospace); font-size:.75rem; color:var(--text-secondary,#888899); }
+        .ro strong { color:var(--text-primary,#e0e0e0); }
+        .gv { font-size:.85rem; font-weight:600; }
+        .gv.c1 { color:var(--status-nominal,#00ff88); } .gv.c2 { color:var(--status-info,#00aaff); }
+        .gv.c3 { color:var(--status-warning,#ffaa00); } .gv.c4 { color:var(--status-critical,#ff4444); }
+        .hs { display:flex; flex-direction:column; gap:8px; }
+        .hg { display:grid; grid-template-columns:auto 1fr; gap:4px 8px; align-items:center;
+               font-family:var(--font-mono,"JetBrains Mono",monospace); font-size:.8rem; }
+        .hg .al { font-size:.65rem; text-transform:uppercase; color:var(--text-dim,#555566); }
+        .hg input { width:100%; padding:4px 6px; background:var(--bg-primary,#0a0a0f); border:1px solid var(--border-default,#2a2a3a);
+                     border-radius:4px; color:var(--text-primary,#e0e0e0); font-family:inherit; font-size:.8rem; text-align:right; box-sizing:border-box; }
+        .hg input:focus { outline:none; border-color:var(--status-info,#00aaff); }
+        .cw { display:flex; justify-content:center; margin-top:4px; }
+        .cc { width:80px; height:80px; border-radius:50%; background:var(--bg-input,#1a1a24); border:2px solid var(--border-default,#2a2a3a); position:relative; }
+        .cl { position:absolute; font-size:.55rem; color:var(--text-dim,#555566); }
+        .cl.n{top:2px;left:50%;transform:translateX(-50%)} .cl.s{bottom:2px;left:50%;transform:translateX(-50%)}
+        .cl.e{right:2px;top:50%;transform:translateY(-50%)} .cl.w{left:2px;top:50%;transform:translateY(-50%)}
+        .cn { position:absolute; top:50%; left:50%; width:3px; height:32px;
+              background:linear-gradient(to top,var(--status-critical,#ff4444) 50%,var(--status-info,#00aaff) 50%);
+              border-radius:1.5px; transform-origin:center bottom; transform:translate(-50%,-100%) rotate(0deg); transition:transform .2s; }
+        .cd { position:absolute; top:50%; left:50%; width:8px; height:8px; background:var(--text-primary,#e0e0e0); border-radius:50%; transform:translate(-50%,-50%); }
+        .ab { margin-top:6px; padding:6px 10px; background:var(--bg-input,#1a1a24); border:1px solid var(--border-default,#2a2a3a);
+              border-radius:4px; color:var(--text-primary,#e0e0e0); font-size:.7rem; cursor:pointer; text-transform:uppercase; }
+        .ab:hover { background:var(--bg-hover,#22222e); border-color:var(--status-info,#00aaff); }
+        .vs { grid-column:1/-1; display:flex; justify-content:space-between; padding:8px 12px;
+              background:var(--bg-input,#1a1a24); border-radius:4px; font-family:var(--font-mono,"JetBrains Mono",monospace);
+              font-size:.75rem; color:var(--text-secondary,#888899); }
+        .vs strong { color:var(--text-primary,#e0e0e0); }
+        .rh { display:none; grid-column:1/-1; text-align:center; font-size:.6rem; color:var(--text-dim,#555566); padding-top:2px; }
+        :host(.tier-raw) .rh { display:block; }
+        :host(.tier-arcade) .hc { display:none; }
+        .hro { display:none; }
+        :host(.tier-arcade) .hro { display:block; font-family:var(--font-mono,"JetBrains Mono",monospace); font-size:.8rem; color:var(--text-secondary,#888899); padding:4px 0; }
+      </style>
+      <div class="p">
+        <div class="olbl">Manual Override</div>
+        <div class="ts">
+          <div class="sl">Throttle</div>
+          <div class="tr">
+            <div class="tt" id="tt"><div class="tf" id="tf"></div><div class="th" id="th"></div></div>
+            <span class="tp" id="tp">0%</span>
+          </div>
+          <div class="ro">G: <span class="gv" id="gv">0.0</span>g</div>
+          <div class="ro">Thrust: <strong id="tn">0</strong> N</div>
+        </div>
+        <div class="hs">
+          <div class="sl">Heading</div>
+          <div class="hc" id="hc">
+            <div class="hg">
+              <span class="al">Yaw</span><input type="number" id="yi" min="0" max="360" step="0.1" value="0"/>
+              <span class="al">Pitch</span><input type="number" id="pi" min="-90" max="90" step="0.1" value="0"/>
+              <span class="al">Roll</span><input type="number" id="ri" min="-180" max="180" step="0.1" value="0"/>
+            </div>
+            <button class="ab" id="ab">Apply Heading</button>
+          </div>
+          <div class="hro" id="hro">
+            P: <span id="rp">+0.0</span> | Y: <span id="ry">000.0</span> | R: <span id="rr">+0.0</span>
+            <div style="font-size:.6rem;color:var(--text-dim,#555566);margin-top:4px">Autopilot controlling heading</div>
+          </div>
+          <div class="cw"><div class="cc">
+            <span class="cl n">000</span><span class="cl e">090</span><span class="cl s">180</span><span class="cl w">270</span>
+            <div class="cn" id="cn"></div><div class="cd"></div>
+          </div></div>
+        </div>
+        <div class="vs">
+          <span>Vel: <strong id="vm">0.0</strong> m/s</span>
+          <span>Hdg: <strong id="vh">---</strong></span>
+          <span>Accel: <strong id="ag">0.0</strong>g</span>
+        </div>
+        <div class="rh">WASD/QE for RCS fine control</div>
+      </div>`;
+  }
+
+  // ── State ───────────────────────────────────────────────────────────
+  _updateFromState() {
+    const nav = stateManager.getNavigation();
+    const ship = stateManager.getShipState();
+    const prop = ship?.systems?.propulsion || {};
+    // Throttle
+    const thr = prop.throttle ?? nav.thrust ?? 0;
+    this._throttle = thr;
+    if (!this._isDragging && !this._pendingThrottle) this._setThrottleVis(thr);
+    // G-force
+    this._currentG = prop.thrust_g || 0;
+    const gEl = this.shadowRoot.getElementById("gv");
+    if (gEl) {
+      gEl.textContent = this._currentG.toFixed(1);
+      gEl.className = "gv " + (this._currentG < 0.3 ? "c1" : this._currentG < 1 ? "c2" : this._currentG < 3 ? "c3" : "c4");
+    }
+    // Thrust Newtons
+    this._maxForceN = prop.max_thrust_force || 0;
+    const fN = this._maxForceN * thr;
+    const tn = this.shadowRoot.getElementById("tn");
+    if (tn) tn.textContent = fN > 1000 ? `${(fN/1000).toFixed(1)}k` : Math.round(fN).toLocaleString();
+    // Heading
+    const h = nav.heading || {};
+    this._pitch = h.pitch || 0; this._yaw = h.yaw || 0; this._roll = h.roll || 0;
+    this._updateHeading();
+    // Velocity
+    this._velocity = nav.velocity || [0, 0, 0];
+    this._updateVelStrip();
+  }
+
+  _setThrottleVis(v) {
+    const pct = Math.max(0, Math.min(1, v)) * 100;
+    const f = this.shadowRoot.getElementById("tf");
+    const h = this.shadowRoot.getElementById("th");
+    const l = this.shadowRoot.getElementById("tp");
+    if (f) f.style.width = `${pct}%`;
+    if (h) h.style.left = `${pct}%`;
+    if (l) l.textContent = `${Math.round(pct)}%`;
+  }
+
+  _updateHeading() {
+    const cn = this.shadowRoot.getElementById("cn");
+    if (cn) cn.style.transform = `translate(-50%,-100%) rotate(${this._yaw}deg)`;
+    // Read-only (ARCADE)
+    const rp = this.shadowRoot.getElementById("rp");
+    const ry = this.shadowRoot.getElementById("ry");
+    const rr = this.shadowRoot.getElementById("rr");
+    const sign = (v) => (v >= 0 ? "+" : "") + v.toFixed(1);
+    if (rp) rp.textContent = sign(this._pitch);
+    if (ry) ry.textContent = this._yaw.toFixed(1).padStart(5, "0");
+    if (rr) rr.textContent = sign(this._roll);
+    // Editable inputs (RAW) -- skip if focused
+    const active = this.shadowRoot.activeElement;
+    const pi = this.shadowRoot.getElementById("pi");
+    const yi = this.shadowRoot.getElementById("yi");
+    const ri = this.shadowRoot.getElementById("ri");
+    if (pi && active !== pi) pi.value = this._pitch.toFixed(1);
+    if (yi && active !== yi) yi.value = this._yaw.toFixed(1);
+    if (ri && active !== ri) ri.value = this._roll.toFixed(1);
+  }
+
+  _updateVelStrip() {
+    const [vx, vy, vz] = this._velocity;
+    const mag = Math.sqrt(vx*vx + vy*vy + vz*vz);
+    const vm = this.shadowRoot.getElementById("vm");
+    if (vm) vm.textContent = mag.toFixed(1);
+    const vh = this.shadowRoot.getElementById("vh");
+    if (vh) vh.textContent = mag > 0.1 ? `${((Math.atan2(vx,vz)*180/Math.PI+360)%360).toFixed(0).padStart(3,"0")}` : "---";
+    const ag = this.shadowRoot.getElementById("ag");
+    if (ag) ag.textContent = this._currentG.toFixed(1);
+  }
+
+  // ── Interaction ─────────────────────────────────────────────────────
+  _setupInteraction() {
+    const track = this.shadowRoot.getElementById("tt");
+    const handle = this.shadowRoot.getElementById("th");
+    const valFromEvt = (e) => {
+      const r = track.getBoundingClientRect();
+      const cx = e.touches ? e.touches[0].clientX : e.clientX;
+      return Math.max(0, Math.min(1, (cx - r.left) / r.width));
+    };
+    const start = (e) => { e.preventDefault(); this._isDragging = true; handle.classList.add("drag"); this._setThrottleVis(valFromEvt(e)); };
+    const move = (e) => { if (!this._isDragging) return; e.preventDefault(); this._setThrottleVis(valFromEvt(e)); };
+    const end = () => {
+      if (!this._isDragging) return;
+      this._isDragging = false; handle.classList.remove("drag");
+      this._sendThrottle((parseFloat(handle.style.left) || 0) / 100);
+    };
+    track.addEventListener("mousedown", start);
+    track.addEventListener("touchstart", start, { passive: false });
+    const addDoc = (ev, fn, opts) => { document.addEventListener(ev, fn, opts); this._docHandlers.push({event:ev,fn,opts}); };
+    addDoc("mousemove", move); addDoc("touchmove", move, {passive:false});
+    addDoc("mouseup", end); addDoc("touchend", end);
+    // Heading apply
+    const ab = this.shadowRoot.getElementById("ab");
+    if (ab) ab.addEventListener("click", () => this._applyHeading());
+    ["pi","yi","ri"].forEach(id => {
+      const el = this.shadowRoot.getElementById(id);
+      if (el) el.addEventListener("keydown", (e) => { if (e.key === "Enter") this._applyHeading(); });
+    });
+  }
+
+  // ── Commands (same as throttle-control.js / heading-control.js) ────
+  async _sendThrottle(value) {
+    this._pendingThrottle = true;
+    try {
+      const r = await wsClient.sendShipCommand("set_thrust", { thrust: value });
+      if (r?.ok === false || r?.error) { this._setThrottleVis(this._throttle); }
+      else if (r?.ok === true) { const res = r.response || r; if (res?.throttle !== undefined) { this._throttle = res.throttle; this._setThrottleVis(this._throttle); } }
+    } catch { this._setThrottleVis(this._throttle); }
+    finally { this._pendingThrottle = false; }
+  }
+
+  async _applyHeading() {
+    const pitch = Math.max(-90, Math.min(90, parseFloat(this.shadowRoot.getElementById("pi")?.value) || 0));
+    const yaw = ((parseFloat(this.shadowRoot.getElementById("yi")?.value) || 0) % 360 + 360) % 360;
+    const roll = Math.max(-180, Math.min(180, parseFloat(this.shadowRoot.getElementById("ri")?.value) || 0));
+    try {
+      const r = await wsClient.sendShipCommand("set_orientation", { pitch, yaw, roll });
+      if (r?.ok === true) {
+        const t = (r.response || r)?.target;
+        if (t) { this._pitch = t.pitch ?? this._pitch; this._yaw = t.yaw ?? this._yaw; this._roll = t.roll ?? this._roll; this._updateHeading(); }
+      } else if (r?.ok === false || r?.error) {
+        this._showMsg(`Heading error: ${r.error || r.message || "Unknown"}`, "error");
+      }
+    } catch (err) { this._showMsg(`Heading failed: ${err.message}`, "error"); }
+  }
+
+  _showMsg(text, type) { const el = document.getElementById("system-messages"); if (el?.show) el.show({type,text}); }
+
+  // ── Tier ────────────────────────────────────────────────────────────
+  _applyTier() {
+    this.classList.remove("tier-raw", "tier-arcade", "tier-cpu-assist");
+    this.classList.add(`tier-${this._tier}`);
+  }
+}
+
+customElements.define("manual-flight-panel", ManualFlightPanel);
+export { ManualFlightPanel };

--- a/gui/components/panel.js
+++ b/gui/components/panel.js
@@ -1,11 +1,21 @@
 /**
  * Panel Container Component
  * Consistent header styling with optional collapse/expand
+ * Supports priority levels, domain color accents, and disabled state with reason overlay
  */
+
+const DOMAIN_COLORS = {
+  nav:     "--domain-nav",
+  sensor:  "--domain-sensor",
+  weapons: "--domain-weapons",
+  power:   "--domain-power",
+  comms:   "--domain-comms",
+  helm:    "--domain-helm",
+};
 
 class FlaxosPanel extends HTMLElement {
   static get observedAttributes() {
-    return ["title", "collapsible", "collapsed", "minimizable"];
+    return ["title", "collapsible", "collapsed", "minimizable", "priority", "domain", "disabled-reason"];
   }
 
   constructor() {
@@ -56,11 +66,41 @@ class FlaxosPanel extends HTMLElement {
     this._updateCollapsedState();
   }
 
+  get priority() {
+    const val = this.getAttribute("priority");
+    if (val === "primary" || val === "tertiary") return val;
+    return "secondary";
+  }
+
+  get domain() {
+    return this.getAttribute("domain") || null;
+  }
+
+  get disabledReason() {
+    return this.getAttribute("disabled-reason") || null;
+  }
+
   toggle() {
     this.collapsed = !this.collapsed;
   }
 
+  /**
+   * Build the domain color CSS variable assignment.
+   * When a valid domain is set, --panel-domain-color resolves to the
+   * corresponding --domain-* variable so other styles can reference it.
+   */
+  _getDomainColorRule() {
+    const d = this.domain;
+    if (d && DOMAIN_COLORS[d]) {
+      return `--panel-domain-color: var(${DOMAIN_COLORS[d]});`;
+    }
+    return `--panel-domain-color: transparent;`;
+  }
+
   render() {
+    const domainRule = this._getDomainColorRule();
+    const isDisabled = this.disabledReason !== null;
+
     this.shadowRoot.innerHTML = `
       <style>
         :host {
@@ -70,6 +110,27 @@ class FlaxosPanel extends HTMLElement {
           border: 1px solid var(--border-default, #2a2a3a);
           border-radius: var(--radius-md, 8px);
           overflow: hidden;
+          position: relative;
+          ${domainRule}
+        }
+
+        /* --- Priority: primary --- */
+        :host([priority="primary"]) {
+          background: var(--bg-panel-raised, #161622);
+          border-color: var(--border-active, #3a3a4a);
+          border-left: 3px solid var(--panel-domain-color, var(--border-active, #3a3a4a));
+          box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+        }
+
+        /* --- Priority: tertiary --- */
+        :host([priority="tertiary"]) {
+          border-color: var(--border-subtle, #1e1e2e);
+          opacity: 0.85;
+        }
+
+        /* --- Disabled state --- */
+        :host([disabled-reason]) {
+          opacity: 0.4;
         }
 
         .header {
@@ -116,10 +177,16 @@ class FlaxosPanel extends HTMLElement {
         .content {
           flex: 1;
           overflow-y: auto;
+          position: relative;
         }
 
         .content.collapsed {
           display: none;
+        }
+
+        /* Block interaction when panel is disabled */
+        .content.disabled {
+          pointer-events: none;
         }
 
         .collapse-icon {
@@ -133,6 +200,28 @@ class FlaxosPanel extends HTMLElement {
 
         ::slotted(*) {
           padding: 16px;
+        }
+
+        /* Disabled reason overlay — sits inside content area so title bar stays visible */
+        .disabled-overlay {
+          position: absolute;
+          inset: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 16px;
+          background: rgba(6, 6, 9, 0.6);
+          z-index: 5;
+          pointer-events: none;
+        }
+        .disabled-overlay .reason-text {
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+          font-size: 0.7rem;
+          color: var(--text-dim, #555570);
+          text-align: center;
+          text-transform: uppercase;
+          letter-spacing: 0.5px;
+          line-height: 1.4;
         }
       </style>
 
@@ -150,12 +239,24 @@ class FlaxosPanel extends HTMLElement {
           ` : ""}
         </div>
       </div>
-      <div class="content" id="content" part="content">
+      <div class="content${isDisabled ? " disabled" : ""}" id="content" part="content">
         <slot></slot>
+        ${isDisabled ? `
+          <div class="disabled-overlay">
+            <span class="reason-text">${this._escapeHtml(this.disabledReason)}</span>
+          </div>
+        ` : ""}
       </div>
     `;
 
     this._bindEvents();
+  }
+
+  /** Escape HTML entities to prevent XSS in disabled-reason text */
+  _escapeHtml(str) {
+    if (!str) return "";
+    const map = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#039;" };
+    return str.replace(/[&<>"']/g, (c) => map[c]);
   }
 
   _bindEvents() {

--- a/gui/components/touch-joystick.js
+++ b/gui/components/touch-joystick.js
@@ -319,10 +319,10 @@ class TouchJoystick extends HTMLElement {
     const pitchRate = this._y * 30; // -30 to +30 deg/s
     const yawRate = this._x * 30;
 
-    wsClient.send("set_angular_velocity", { 
-      pitch: pitchRate, 
-      yaw: yawRate, 
-      roll: 0 
+    wsClient.sendShipCommand("set_angular_velocity", {
+      pitch: pitchRate,
+      yaw: yawRate,
+      roll: 0
     });
   }
 
@@ -330,10 +330,10 @@ class TouchJoystick extends HTMLElement {
     const wsClient = window.flaxosApp?.wsClient;
     if (!wsClient) return;
 
-    wsClient.send("set_angular_velocity", { 
-      pitch: 0, 
-      yaw: 0, 
-      roll: 0 
+    wsClient.sendShipCommand("set_angular_velocity", {
+      pitch: 0,
+      yaw: 0,
+      roll: 0
     });
   }
 

--- a/gui/components/touch-throttle.js
+++ b/gui/components/touch-throttle.js
@@ -253,7 +253,7 @@ class TouchThrottle extends HTMLElement {
   _sendCommand() {
     const wsClient = window.flaxosApp?.wsClient;
     if (wsClient) {
-      wsClient.send("set_thrust", { thrust: this._value / 100 });
+      wsClient.sendShipCommand("set_thrust", { thrust: this._value / 100 });
     }
   }
 

--- a/gui/index.html
+++ b/gui/index.html
@@ -123,7 +123,35 @@
 
     /* ===== Panel sizing within views ===== */
 
-    /* Helm view panels */
+    /* --- Panel group wrappers (transparent to grid) --- */
+    .panel-group {
+      display: contents;
+    }
+
+    /* Panel group labels — dim monospace headers rendered via ::before */
+    .panel-group[data-label]::before {
+      content: attr(data-label);
+      display: block;
+      grid-column: span 4;
+      font-family: var(--font-mono, 'JetBrains Mono', monospace);
+      font-size: 0.65rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--text-dim, #555570);
+      padding: 6px 8px 2px;
+      border-bottom: 1px solid var(--border-subtle, #1a1a2a);
+      align-self: end;
+    }
+
+    /* Workflow strip (sits above the grid) */
+    helm-workflow-strip {
+      display: block;
+      padding: 4px 8px;
+      background: var(--bg-panel, #11111a);
+      border-bottom: 1px solid var(--border-subtle, #1a1a2a);
+    }
+
+    /* --- Helm view panels --- */
     .helm-fc-panel {
       grid-column: span 6;
       min-height: var(--panel-height-md);
@@ -134,13 +162,8 @@
       min-height: var(--panel-height-md);
     }
 
-    .helm-nav-panel {
-      grid-column: span 4;
-      min-height: var(--panel-height-sm);
-    }
-
-    .helm-autopilot-panel {
-      grid-column: span 4;
+    .helm-flight-data-panel {
+      grid-column: span 6;
       min-height: var(--panel-height-sm);
     }
 
@@ -149,34 +172,19 @@
       min-height: var(--panel-height-sm);
     }
 
-    .helm-throttle-panel {
-      grid-column: span 3;
+    .helm-manual-flight-panel {
+      grid-column: span 4;
       min-height: var(--panel-height-md);
-    }
-
-    .helm-heading-panel {
-      grid-column: span 3;
-      min-height: var(--panel-height-sm);
-    }
-
-    .helm-course-panel {
-      grid-column: span 3;
-      min-height: var(--panel-height-sm);
     }
 
     .helm-rcs-panel {
-      grid-column: span 3;
+      grid-column: span 4;
       min-height: var(--panel-height-sm);
     }
 
-    .helm-old-fc-panel {
+    .helm-maneuver-panel {
       grid-column: span 6;
       min-height: var(--panel-height-md);
-    }
-
-    .helm-requests-panel {
-      grid-column: span 6;
-      min-height: var(--panel-height-sm);
     }
 
     .helm-queue-panel {
@@ -185,11 +193,6 @@
     }
 
     .helm-docking-panel {
-      grid-column: span 4;
-      min-height: var(--panel-height-sm);
-    }
-
-    .helm-deltav-panel {
       grid-column: span 4;
       min-height: var(--panel-height-sm);
     }
@@ -333,8 +336,13 @@
         grid-template-columns: repeat(6, 1fr);
       }
 
-      .view-grid > flaxos-panel {
+      .view-grid > flaxos-panel,
+      .view-grid .panel-group > flaxos-panel {
         grid-column: span 6 !important;
+      }
+
+      .panel-group[data-label]::before {
+        grid-column: span 6;
       }
     }
 
@@ -344,9 +352,14 @@
         grid-template-columns: 1fr;
       }
 
-      .view-grid > flaxos-panel {
+      .view-grid > flaxos-panel,
+      .view-grid .panel-group > flaxos-panel {
         grid-column: span 1 !important;
         grid-row: span 1 !important;
+      }
+
+      .panel-group[data-label]::before {
+        grid-column: span 1;
       }
 
       .eng-log-panel {
@@ -383,73 +396,54 @@
 
     <!-- ===== HELM VIEW ===== -->
     <div class="view-container active" id="view-helm">
+      <!-- Workflow breadcrumb strip (above the grid) -->
+      <helm-workflow-strip></helm-workflow-strip>
+
       <div class="view-grid">
-        <!-- Flight Computer Panel (new, for server-side flight computer) -->
-        <flaxos-panel title="Flight Computer" collapsible class="helm-fc-panel">
-          <flight-computer-panel></flight-computer-panel>
-        </flaxos-panel>
+        <!-- LEFT: SITUATIONAL AWARENESS — "Where am I? What's around?" -->
+        <div class="panel-group" data-label="// SITUATIONAL AWARENESS">
+          <flaxos-panel title="Contacts" collapsible priority="primary" domain="sensor" class="helm-contacts-panel">
+            <sensor-contacts id="sensor-contacts"></sensor-contacts>
+          </flaxos-panel>
 
-        <!-- Compact contact list -->
-        <flaxos-panel title="Contacts" collapsible class="helm-contacts-panel">
-          <sensor-contacts id="sensor-contacts"></sensor-contacts>
-        </flaxos-panel>
+          <flaxos-panel title="Flight Data" collapsible priority="secondary" domain="nav" class="helm-flight-data-panel">
+            <flight-data-panel></flight-data-panel>
+          </flaxos-panel>
+        </div>
 
-        <!-- Navigation -->
-        <flaxos-panel title="Navigation" collapsible class="helm-nav-panel">
-          <navigation-display></navigation-display>
-        </flaxos-panel>
+        <!-- CENTER: COMMAND & CONTROL — "What do I want to do?" -->
+        <div class="panel-group" data-label="// COMMAND &amp; CONTROL">
+          <flaxos-panel title="Flight Computer" collapsible priority="primary" domain="nav" class="helm-fc-panel">
+            <flight-computer-panel></flight-computer-panel>
+          </flaxos-panel>
 
-        <!-- Autopilot -->
-        <flaxos-panel title="Autopilot" collapsible class="helm-autopilot-panel">
-          <autopilot-control></autopilot-control>
-        </flaxos-panel>
+          <flaxos-panel title="Manual Flight" collapsible priority="primary" domain="helm" class="helm-manual-flight-panel">
+            <manual-flight-panel></manual-flight-panel>
+          </flaxos-panel>
 
-        <!-- Autopilot Status -->
-        <flaxos-panel title="Autopilot Status" collapsible class="helm-autopilot-status-panel">
-          <autopilot-status></autopilot-status>
-        </flaxos-panel>
+          <flaxos-panel title="RCS / Attitude" collapsible domain="helm" class="helm-rcs-panel">
+            <rcs-controls></rcs-controls>
+          </flaxos-panel>
+        </div>
 
-        <!-- Manual Controls -->
-        <flaxos-panel title="Throttle" collapsible class="helm-throttle-panel">
-          <throttle-control></throttle-control>
-        </flaxos-panel>
+        <!-- RIGHT: SHIP STATUS — "What is my ship doing?" -->
+        <div class="panel-group" data-label="// SHIP STATUS">
+          <flaxos-panel title="Autopilot Status" collapsible priority="secondary" domain="nav" class="helm-autopilot-status-panel">
+            <autopilot-status></autopilot-status>
+          </flaxos-panel>
 
-        <flaxos-panel title="Heading" collapsible class="helm-heading-panel">
-          <heading-control></heading-control>
-        </flaxos-panel>
+          <flaxos-panel title="Helm Queue" collapsible priority="tertiary" domain="comms" class="helm-queue-panel">
+            <helm-queue-panel></helm-queue-panel>
+          </flaxos-panel>
 
-        <flaxos-panel title="Set Course" collapsible class="helm-course-panel">
-          <set-course-control></set-course-control>
-        </flaxos-panel>
+          <flaxos-panel title="Docking" collapsible domain="nav" class="helm-docking-panel">
+            <docking-panel></docking-panel>
+          </flaxos-panel>
 
-        <flaxos-panel title="RCS / Attitude" collapsible class="helm-rcs-panel">
-          <rcs-controls></rcs-controls>
-        </flaxos-panel>
-
-        <!-- Client-side flight computer (existing, with waypoint/intercept/flip-burn) -->
-        <flaxos-panel title="Flight Computer (Local)" collapsible class="helm-old-fc-panel">
-          <flight-computer></flight-computer>
-        </flaxos-panel>
-
-        <!-- Helm Requests -->
-        <flaxos-panel title="Helm Requests" collapsible class="helm-requests-panel">
-          <helm-requests></helm-requests>
-        </flaxos-panel>
-
-        <!-- Helm Queue -->
-        <flaxos-panel title="Helm Queue" collapsible class="helm-queue-panel">
-          <helm-queue-panel></helm-queue-panel>
-        </flaxos-panel>
-
-        <!-- Docking -->
-        <flaxos-panel title="Docking" collapsible class="helm-docking-panel">
-          <docking-panel></docking-panel>
-        </flaxos-panel>
-
-        <!-- Delta-V Budget -->
-        <flaxos-panel title="Delta-V Budget" collapsible class="helm-deltav-panel">
-          <delta-v-display></delta-v-display>
-        </flaxos-panel>
+          <flaxos-panel title="Maneuver Planner" collapsible priority="tertiary" domain="helm" class="helm-maneuver-panel">
+            <maneuver-planner></maneuver-planner>
+          </flaxos-panel>
+        </div>
       </div>
     </div>
 

--- a/gui/js/autopilot-utils.js
+++ b/gui/js/autopilot-utils.js
@@ -1,0 +1,209 @@
+/**
+ * Shared autopilot utilities for flight-computer-panel and autopilot-status.
+ * Extracted to keep both components under 300 lines.
+ *
+ * Provides:
+ *  - Phase definitions per autopilot program
+ *  - Phase progress HTML generation
+ *  - Formatting helpers (distance, ETA, time)
+ *  - State extraction from stateManager telemetry paths
+ */
+
+import { stateManager } from "./state-manager.js";
+
+// Phase lists for different autopilot programs
+const GOTO_PHASES = ["ACCELERATE", "COAST", "BRAKE", "HOLD"];
+const RENDEZVOUS_PHASES = ["BURN", "FLIP", "BRAKE", "STATIONKEEP"];
+const INTERCEPT_PHASES = ["INTERCEPT", "APPROACH", "MATCH"];
+
+const PROGRAM_PHASES = {
+  goto_position: GOTO_PHASES,
+  set_course: GOTO_PHASES,
+  rendezvous: RENDEZVOUS_PHASES,
+  intercept: INTERCEPT_PHASES,
+};
+
+const DEFAULT_PHASES = GOTO_PHASES;
+
+const SHORT_PHASE_LABELS = {
+  ACCELERATE: "Accel",
+  COAST: "Coast",
+  BRAKE: "Brake",
+  HOLD: "Hold",
+  BURN: "Burn",
+  FLIP: "Flip",
+  STATIONKEEP: "Stnkeep",
+  INTERCEPT: "Intrcpt",
+  APPROACH: "Approach",
+  MATCH: "Match",
+};
+
+/**
+ * Get the phase list for a given program name.
+ * @param {string|null} program - e.g. "rendezvous", "intercept", "goto_position"
+ * @returns {string[]}
+ */
+function getPhasesForProgram(program) {
+  const key = program?.toLowerCase() || "";
+  return PROGRAM_PHASES[key] || DEFAULT_PHASES;
+}
+
+/**
+ * Build phase progress bar HTML segments + labels.
+ * Returns { segmentsHtml, labelsHtml } strings.
+ * @param {string|null} program
+ * @param {string|null} currentPhase - uppercase phase name
+ */
+function buildPhaseProgressHtml(program, currentPhase) {
+  const phases = getPhasesForProgram(program);
+  const idx = currentPhase ? phases.indexOf(currentPhase) : -1;
+
+  const segmentsHtml = phases
+    .map((p, i) => {
+      let cls = `phase-segment ${p.toLowerCase()}`;
+      if (i < idx) cls += " completed";
+      else if (i === idx) cls += " active";
+      return `<div class="${cls}" data-phase="${p}"></div>`;
+    })
+    .join("");
+
+  const labelsHtml = phases
+    .map((p, i) => {
+      const active = i === idx ? " active" : "";
+      const label = SHORT_PHASE_LABELS[p] || p;
+      return `<span class="phase-label${active}" data-phase="${p}">${label}</span>`;
+    })
+    .join("");
+
+  return { segmentsHtml, labelsHtml };
+}
+
+/**
+ * CSS rules for phase segment coloring. Shared across components.
+ * Inject into a <style> block.
+ */
+const PHASE_SEGMENT_CSS = `
+  .phase-bar {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 4px;
+  }
+  .phase-segment {
+    flex: 1;
+    height: 6px;
+    background: var(--bg-primary, #0a0a0f);
+    border-radius: 3px;
+    transition: background 0.3s ease;
+  }
+  .phase-segment.active { background: var(--status-info, #00aaff); }
+  .phase-segment.completed { background: var(--status-nominal, #00ff88); }
+  .phase-segment.accelerate.active { background: var(--status-warning, #ffaa00); }
+  .phase-segment.coast.active { background: var(--status-info, #00aaff); }
+  .phase-segment.brake.active { background: var(--status-critical, #ff4444); }
+  .phase-segment.hold.active { background: var(--status-nominal, #00ff88); }
+  .phase-segment.burn.active { background: var(--status-warning, #ffaa00); }
+  .phase-segment.flip.active { background: #cc66ff; }
+  .phase-segment.stationkeep.active { background: var(--status-nominal, #00ff88); }
+  .phase-segment.intercept.active { background: var(--status-warning, #ffaa00); }
+  .phase-segment.approach.active { background: var(--status-info, #00aaff); }
+  .phase-segment.match.active { background: var(--status-nominal, #00ff88); }
+  .phase-labels {
+    display: flex;
+    justify-content: space-between;
+  }
+  .phase-label {
+    font-size: 0.55rem;
+    color: var(--text-dim, #555566);
+    text-transform: uppercase;
+  }
+  .phase-label.active {
+    color: var(--text-primary, #e0e0e0);
+    font-weight: 600;
+  }
+`;
+
+/** Format a distance in metres. Returns "X.X km" or "X m" or "--". */
+function formatDistance(metres) {
+  if (metres == null) return "--";
+  if (metres >= 1000) return `${(metres / 1000).toFixed(1)} km`;
+  return `${metres.toFixed(0)} m`;
+}
+
+/** Format seconds to human-readable ETA. */
+function formatEta(seconds) {
+  if (seconds == null || !isFinite(seconds)) return "--";
+  if (seconds <= 0) return "0s";
+  if (seconds < 60) return `${seconds.toFixed(0)}s`;
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  if (m < 60) return `${m}m ${String(s).padStart(2, "0")}s`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return `${h}h ${String(rm).padStart(2, "0")}m`;
+}
+
+/**
+ * Extract a unified autopilot state object from stateManager.
+ * Checks all known telemetry paths (top-level, station-filtered, systems).
+ * Returns null when no autopilot is active.
+ */
+function extractAutopilotState() {
+  const nav = stateManager.getNavigation();
+  const ship = stateManager.getShipState();
+  const ap = nav?.autopilot || ship?.autopilot || {};
+
+  const mode =
+    ap.mode || ship?.nav_mode || nav?.nav_mode || null;
+  const program =
+    ap.program || ship?.autopilot_program || nav?.current_program || null;
+
+  // Rich autopilot state dict
+  const apState =
+    ship?.autopilot_state ||
+    ap.autopilot_state ||
+    ship?.systems?.navigation?.autopilot_state ||
+    null;
+
+  const phase = apState?.phase?.toUpperCase() || ap.phase?.toUpperCase() || null;
+
+  const isActive =
+    program ||
+    (mode && mode !== "off" && mode !== "manual");
+
+  if (!isActive) return null;
+
+  return {
+    mode: mode || "autopilot",
+    program: program || mode,
+    phase,
+    target: ap.target || ap.course?.target || apState?.target || null,
+    status: apState?.status || null,
+    statusText: apState?.status_text || null,
+    range: apState?.range ?? apState?.distance ?? null,
+    closingSpeed: apState?.closing_speed ?? null,
+    brakingDistance: apState?.braking_distance ?? null,
+    eta: apState?.time_to_arrival ?? null,
+    progress: ap.progress ?? null,
+    burnPlan: ap.burn_plan ?? null,
+    deltaV: ap.delta_v ?? apState?.delta_v ?? null,
+  };
+}
+
+// Modes that should be hidden in CPU-ASSIST tier (too granular)
+const CPU_ASSIST_HIDDEN_MODES = ["match", "orbit", "evasive", "hold_velocity"];
+
+export {
+  PROGRAM_PHASES,
+  DEFAULT_PHASES,
+  GOTO_PHASES,
+  RENDEZVOUS_PHASES,
+  INTERCEPT_PHASES,
+  SHORT_PHASE_LABELS,
+  PHASE_SEGMENT_CSS,
+  CPU_ASSIST_HIDDEN_MODES,
+  getPhasesForProgram,
+  buildPhaseProgressHtml,
+  formatDistance,
+  formatEta,
+  extractAutopilotState,
+};

--- a/gui/js/main.js
+++ b/gui/js/main.js
@@ -41,6 +41,7 @@ import { mobileLayout } from "../layouts/mobile-layout.js";
 import { initMobileGestures } from "./gestures.js";
 // Phase 7: Enhanced Navigation & Multi-Crew
 import "../components/flight-computer.js";
+import "../components/maneuver-planner.js";
 import { stationManager } from "./station-manager.js";
 // Phase 8: Inter-Station Communication
 import "../components/helm-requests.js";
@@ -59,6 +60,10 @@ import "../components/tier-selector.js";
 import "../components/helm-queue-panel.js";
 import "../components/docking-panel.js";
 import "../components/delta-v-display.js";
+// GUI Refactor: Merged panels
+import "../components/flight-data-panel.js";
+import "../components/manual-flight-panel.js";
+import "../components/helm-workflow-strip.js";
 // Phase 11: Tactical Completion
 import "../components/subsystem-selector.js";
 import "../components/threat-board.js";

--- a/gui/styles/main.css
+++ b/gui/styles/main.css
@@ -58,6 +58,25 @@
   /* Transitions */
   --transition-fast: 0.1s ease;
   --transition-base: 0.2s ease;
+
+  /* Domain colors (functional category accents) */
+  --domain-nav:      #3399ff;
+  --domain-sensor:   #00ccaa;
+  --domain-weapons:  #cc4444;
+  --domain-power:    #cc8800;
+  --domain-comms:    #9977dd;
+  --domain-helm:     #6699cc;
+
+  /* Extended backgrounds */
+  --bg-void:         #060609;
+  --bg-panel-raised: #161622;
+  --bg-active:       #2a2a3a;
+
+  /* Extended borders */
+  --border-subtle:   #1e1e2e;
+
+  /* Extended text */
+  --text-bright:     #f0f0f4;
 }
 
 /* Reset and base */
@@ -460,5 +479,138 @@ button.success,
   #connection-bar {
     flex-direction: column;
     align-items: stretch;
+  }
+}
+
+/* === Data Display Utilities === */
+
+/* Status chip - inline pill with colored dot */
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px 2px 6px;
+  border-radius: 10px;
+  font-family: var(--font-mono, "JetBrains Mono", monospace);
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid transparent;
+}
+.status-chip::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-chip.nominal::before { background: var(--status-nominal, #00e878); box-shadow: 0 0 4px var(--status-nominal, #00e878); }
+.status-chip.nominal { color: var(--status-nominal, #00e878); border-color: rgba(0, 232, 120, 0.2); }
+.status-chip.warning::before { background: var(--status-warning, #f0a030); box-shadow: 0 0 4px var(--status-warning, #f0a030); }
+.status-chip.warning { color: var(--status-warning, #f0a030); border-color: rgba(240, 160, 48, 0.2); }
+.status-chip.critical::before { background: var(--status-critical, #e83838); box-shadow: 0 0 4px var(--status-critical, #e83838); animation: pulse 1.2s ease-in-out infinite; }
+.status-chip.critical { color: var(--status-critical, #e83838); border-color: rgba(232, 56, 56, 0.3); }
+.status-chip.offline::before { background: var(--status-offline, #444458); }
+.status-chip.offline { color: var(--text-dim, #555570); }
+.status-chip.info::before { background: var(--status-info, #3399ff); box-shadow: 0 0 4px var(--status-info, #3399ff); }
+.status-chip.info { color: var(--status-info, #3399ff); border-color: rgba(51, 153, 255, 0.2); }
+
+/* Dense data table */
+.data-table-dense {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-mono, "JetBrains Mono", monospace);
+  font-size: 0.7rem;
+  line-height: 1.3;
+}
+.data-table-dense th {
+  font-family: var(--font-sans, "Inter", sans-serif);
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-dim, #555570);
+  padding: 4px 8px;
+  text-align: left;
+  border-bottom: 1px solid var(--border-default, #2a2a3a);
+}
+.data-table-dense td {
+  padding: 3px 8px;
+  color: var(--text-primary, #d8d8e0);
+  border-bottom: 1px solid var(--border-subtle, #1e1e2e);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.data-table-dense tr:hover td { background: var(--bg-hover, #22222e); }
+
+/* Key-value inline pair */
+.kv-inline {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 2px 0;
+  min-height: 20px;
+}
+.kv-inline .label {
+  font-family: var(--font-sans, "Inter", sans-serif);
+  font-size: 0.7rem;
+  color: var(--text-secondary, #8888a0);
+  flex-shrink: 0;
+}
+.kv-inline .value {
+  font-family: var(--font-mono, "JetBrains Mono", monospace);
+  font-size: 0.75rem;
+  color: var(--text-primary, #d8d8e0);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Hero number display */
+.big-number {
+  font-family: var(--font-mono, "JetBrains Mono", monospace);
+  font-size: 1.6rem;
+  font-weight: 600;
+  line-height: 1.1;
+  letter-spacing: -0.5px;
+  color: var(--text-bright, #f0f0f4);
+  font-variant-numeric: tabular-nums;
+}
+.big-number .unit {
+  font-size: 0.7rem;
+  font-weight: 400;
+  color: var(--text-secondary, #8888a0);
+  margin-left: 4px;
+}
+.big-number.nominal { color: var(--status-nominal, #00e878); }
+.big-number.warning { color: var(--status-warning, #f0a030); }
+.big-number.critical { color: var(--status-critical, #e83838); }
+
+/* Panel group header */
+.panel-group {
+  display: contents;
+}
+.panel-group-header {
+  font-family: var(--font-mono, "JetBrains Mono", monospace);
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--text-dim, #555570);
+  padding: 12px 4px 4px;
+  border-bottom: 1px solid var(--border-subtle, #1e1e2e);
+  grid-column: 1 / -1;
+}
+
+/* Tabular nums for all mono data */
+[data-mono] { font-variant-numeric: tabular-nums; }
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/gui/styles/tiers.css
+++ b/gui/styles/tiers.css
@@ -1,19 +1,33 @@
-/* tiers.css — Panel visibility rules per control tier.
+/* tiers.css — Per-tier visual identity, panel visibility, and layout rules.
  *
  * The tier-selector component sets one of these classes on <body>:
- *   .tier-raw        — manual flight, raw vectors
- *   .tier-arcade     — balanced (DEFAULT)
- *   .tier-cpu-assist — order-based, ship handles execution
+ *   .tier-raw        — manual flight, raw vectors ("You ARE the flight computer")
+ *   .tier-arcade     — balanced, DEFAULT ("Point and shoot")
+ *   .tier-cpu-assist — order-based, ship handles execution ("Captain's chair")
  *
  * Panels use view-specific class names (helm-*, eng-*) so hiding
  * targets the right panel in the right view without :has() issues.
+ *
+ * New panel classes (post-refactor):
+ *   helm-flight-data-panel      (merged nav + delta-v)
+ *   helm-manual-flight-panel    (merged throttle + heading)
+ *   helm-maneuver-panel         (renamed from helm-old-fc-panel)
+ *   helm-fc-panel               (unified flight computer)
+ *   helm-contacts-panel
+ *   helm-rcs-panel
+ *   helm-autopilot-status-panel
+ *   helm-queue-panel            (expanded, absorbed requests)
+ *   helm-docking-panel
  */
 
-/* --- Tier accent colors ------------------------------------------------- */
 
-body.tier-raw        { --tier-accent: #ff4444; }
-body.tier-arcade     { --tier-accent: #4488ff; }
-body.tier-cpu-assist { --tier-accent: #00ff88; }
+/* =========================================================================
+   1. TIER ACCENT COLORS
+   ========================================================================= */
+
+body.tier-raw        { --tier-accent: #ff4444; }  /* Red — danger, manual */
+body.tier-arcade     { --tier-accent: #4488ff; }  /* Blue — guided */
+body.tier-cpu-assist { --tier-accent: #c0a0ff; }  /* Purple — bridge command */
 
 /* Status bar and bridge controls pick up the accent */
 .status-bar,
@@ -21,55 +35,235 @@ body.tier-cpu-assist { --tier-accent: #00ff88; }
   border-bottom: 2px solid var(--tier-accent, #4488ff);
 }
 
-/* --- Smooth transitions on all panels ----------------------------------- */
+
+/* =========================================================================
+   2. PER-TIER VISUAL IDENTITY
+   ========================================================================= */
+
+/* --- RAW: Terminal aesthetic, monospace everything, sharp edges ---------- */
+
+body.tier-raw {
+  font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', 'Consolas', monospace);
+}
+
+body.tier-raw flaxos-panel {
+  border-radius: 2px;
+}
+
+/* Subtle green scanline tint via pseudo-element on the body.
+ * Pointer-events: none so it never blocks interaction. */
+body.tier-raw::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0px,
+    transparent 3px,
+    rgba(0, 255, 64, 0.015) 3px,
+    rgba(0, 255, 64, 0.015) 4px
+  );
+}
+
+/* --- ARCADE: Mixed fonts, rounded, blue glow on interactives ------------ */
+
+body.tier-arcade flaxos-panel {
+  border-radius: 8px;
+}
+
+/* Blue glow on buttons, inputs, selects inside arcade tier */
+body.tier-arcade button:focus,
+body.tier-arcade button:hover,
+body.tier-arcade select:focus,
+body.tier-arcade input:focus {
+  box-shadow: 0 0 6px 1px rgba(68, 136, 255, 0.4);
+  outline: none;
+}
+
+/* --- CPU-ASSIST: Sans-serif, larger text, lighter panels ---------------- */
+
+body.tier-cpu-assist {
+  font-family: var(--font-sans, 'Inter', 'Segoe UI', system-ui, sans-serif);
+  font-size: 1rem;
+}
+
+body.tier-cpu-assist flaxos-panel {
+  border-radius: 6px;
+  background: var(--bg-panel-raised, #161622);
+}
+
+
+/* =========================================================================
+   3. SMOOTH TRANSITIONS ON ALL PANELS
+   ========================================================================= */
 
 flaxos-panel {
   transition: opacity 0.2s ease, max-height 0.3s ease;
 }
 
-/* --- RAW tier: manual only, hide automation & queues -------------------- */
 
-body.tier-raw .helm-fc-panel,
-body.tier-raw .helm-old-fc-panel,
-body.tier-raw .helm-autopilot-panel,
+/* =========================================================================
+   4. HELM PANEL VISIBILITY — RAW TIER
+   "You ARE the flight computer" (~7 panels)
+
+   Show:     Contacts, Flight Data, Manual Flight (HERO), RCS, Maneuver Planner
+   Disabled: Flight Computer (collapsed, autopilot message)
+   Hidden:   Autopilot Status, Helm Queue, Docking
+   ========================================================================= */
+
+/* Hidden panels */
 body.tier-raw .helm-autopilot-status-panel,
+body.tier-raw .helm-queue-panel,
+body.tier-raw .helm-docking-panel {
+  display: none;
+}
+
+/* Disabled: Flight Computer — visible but inert.
+ * The disabled-reason attribute on <flaxos-panel> handles the overlay message. */
+body.tier-raw .helm-fc-panel {
+  opacity: 0.5;
+  pointer-events: none;
+  position: relative;
+  order: 99; /* Push to end of grid */
+}
+
+/* Legacy panels that should not appear (in case markup still references them) */
+body.tier-raw .helm-autopilot-panel,
 body.tier-raw .helm-course-panel,
 body.tier-raw .helm-requests-panel,
-body.tier-raw .helm-queue-panel,
-body.tier-raw .helm-docking-panel { display: none; }
+body.tier-raw .helm-old-fc-panel,
+body.tier-raw .helm-nav-panel,
+body.tier-raw .helm-throttle-panel,
+body.tier-raw .helm-heading-panel,
+body.tier-raw .helm-deltav-panel {
+  display: none;
+}
 
+
+/* =========================================================================
+   5. HELM PANEL VISIBILITY — ARCADE TIER
+   "Point and shoot" (~7 panels)
+
+   Show:     Contacts, Flight Computer (HERO), Flight Data, Autopilot Status,
+             Docking (when near)
+   Disabled: RCS (autopilot handles attitude)
+   Hidden:   Manual Flight, Maneuver Planner, Helm Queue
+   ========================================================================= */
+
+/* Hidden panels */
+body.tier-arcade .helm-manual-flight-panel,
+body.tier-arcade .helm-maneuver-panel,
+body.tier-arcade .helm-queue-panel {
+  display: none;
+}
+
+/* Disabled: RCS — visible but inert */
+body.tier-arcade .helm-rcs-panel {
+  opacity: 0.5;
+  pointer-events: none;
+  position: relative;
+}
+
+/* Legacy panels */
+body.tier-arcade .helm-old-fc-panel,
+body.tier-arcade .helm-requests-panel,
+body.tier-arcade .helm-autopilot-panel,
+body.tier-arcade .helm-course-panel,
+body.tier-arcade .helm-nav-panel,
+body.tier-arcade .helm-throttle-panel,
+body.tier-arcade .helm-heading-panel,
+body.tier-arcade .helm-deltav-panel,
+body.tier-arcade .helm-micro-rcs-panel {
+  display: none;
+}
+
+
+/* =========================================================================
+   6. HELM PANEL VISIBILITY — CPU-ASSIST TIER
+   "Captain's chair" (~6 panels)
+
+   Show:     Contacts, Flight Computer, Flight Data,
+             Autopilot Status (HERO), Helm Queue, Docking
+   Hidden:   Manual Flight, RCS, Maneuver Planner
+   ========================================================================= */
+
+/* Hidden panels */
+body.tier-cpu-assist .helm-manual-flight-panel,
+body.tier-cpu-assist .helm-rcs-panel,
+body.tier-cpu-assist .helm-maneuver-panel {
+  display: none;
+}
+
+/* Legacy panels */
+body.tier-cpu-assist .helm-old-fc-panel,
+body.tier-cpu-assist .helm-requests-panel,
+body.tier-cpu-assist .helm-autopilot-panel,
+body.tier-cpu-assist .helm-course-panel,
+body.tier-cpu-assist .helm-nav-panel,
+body.tier-cpu-assist .helm-throttle-panel,
+body.tier-cpu-assist .helm-heading-panel,
+body.tier-cpu-assist .helm-deltav-panel {
+  display: none;
+}
+
+
+/* =========================================================================
+   7. HERO PANEL SIZING PER TIER
+   Grid assumes 12 columns. Hero panels span more to dominate the layout.
+   ========================================================================= */
+
+body.tier-raw .helm-manual-flight-panel {
+  grid-column: span 8;
+}
+
+body.tier-arcade .helm-fc-panel {
+  grid-column: span 6;
+}
+
+body.tier-cpu-assist .helm-autopilot-status-panel {
+  grid-column: span 6;
+}
+
+
+/* =========================================================================
+   8. WORKFLOW STRIP
+   Visible in all tiers, accent color matches tier.
+   ========================================================================= */
+
+body.tier-raw helm-workflow-strip        { --strip-accent: #ff4444; }
+body.tier-arcade helm-workflow-strip     { --strip-accent: #4488ff; }
+body.tier-cpu-assist helm-workflow-strip { --strip-accent: #c0a0ff; }
+
+
+/* =========================================================================
+   9. ENGINEERING PANEL VISIBILITY (unchanged from pre-refactor)
+   Eng view has its own panel set. These rules are preserved as-is
+   until engineering gets its own refactor pass.
+   ========================================================================= */
+
+/* RAW: hide automation/profile panels, show raw systems */
 body.tier-raw .eng-profiles-panel,
 body.tier-raw .eng-draw-panel,
 body.tier-raw .eng-crew-panel,
 body.tier-raw .eng-nav-panel,
 body.tier-raw .eng-log-panel,
-body.tier-raw .eng-pos-heading-panel { display: none; }
+body.tier-raw .eng-pos-heading-panel {
+  display: none;
+}
 
-/* --- ARCADE tier: guided, hide expert & low-level controls -------------- */
-
-body.tier-arcade .helm-old-fc-panel,
-body.tier-arcade .helm-requests-panel,
-body.tier-arcade .helm-queue-panel,
-body.tier-arcade .helm-rcs-panel,
-body.tier-arcade .helm-micro-rcs-panel,
-body.tier-arcade .helm-docking-panel { display: none; }
-
+/* ARCADE: hide low-level engineering, show balanced set */
 body.tier-arcade .eng-draw-panel,
 body.tier-arcade .eng-crew-panel,
 body.tier-arcade .eng-micro-rcs-panel,
 body.tier-arcade .eng-thrust-panel,
 body.tier-arcade .eng-pos-heading-panel,
-body.tier-arcade .eng-nav-panel { display: none; }
+body.tier-arcade .eng-nav-panel {
+  display: none;
+}
 
-/* --- CPU ASSIST tier: minimal, order-based ------------------------------ */
-
-body.tier-cpu-assist .helm-throttle-panel,
-body.tier-cpu-assist .helm-heading-panel,
-body.tier-cpu-assist .helm-rcs-panel,
-body.tier-cpu-assist .helm-old-fc-panel,
-body.tier-cpu-assist .helm-requests-panel,
-body.tier-cpu-assist .helm-docking-panel { display: none; }
-
+/* CPU-ASSIST: minimal engineering — just status and profiles */
 body.tier-cpu-assist .eng-systems-panel,
 body.tier-cpu-assist .eng-power-panel,
 body.tier-cpu-assist .eng-draw-panel,
@@ -77,9 +271,14 @@ body.tier-cpu-assist .eng-crew-panel,
 body.tier-cpu-assist .eng-nav-panel,
 body.tier-cpu-assist .eng-pos-heading-panel,
 body.tier-cpu-assist .eng-micro-rcs-panel,
-body.tier-cpu-assist .eng-thrust-panel { display: none; }
+body.tier-cpu-assist .eng-thrust-panel {
+  display: none;
+}
 
-/* --- Tutorial highlight glow -------------------------------------------- */
+
+/* =========================================================================
+   10. TUTORIAL HIGHLIGHT GLOW
+   ========================================================================= */
 
 @keyframes tutorial-pulse {
   0%, 100% { box-shadow: 0 0 8px 2px var(--status-info, #4488ff); }
@@ -91,4 +290,24 @@ flaxos-panel.tutorial-highlight {
   border-color: var(--status-info, #4488ff) !important;
   z-index: 10;
   position: relative;
+}
+
+/* During active tutorial, dim all non-highlighted panels */
+body.tutorial-active flaxos-panel:not(.tutorial-highlight) {
+  opacity: 0.4;
+}
+
+
+/* =========================================================================
+   11. REDUCED MOTION
+   ========================================================================= */
+
+@media (prefers-reduced-motion: reduce) {
+  flaxos-panel {
+    transition: none;
+  }
+  flaxos-panel.tutorial-highlight {
+    animation: none;
+    box-shadow: 0 0 8px 2px var(--status-info, #4488ff);
+  }
 }

--- a/hybrid/commands/validators.py
+++ b/hybrid/commands/validators.py
@@ -294,7 +294,7 @@ def validate_autopilot_program(program):
     Returns:
         Tuple[bool, str, Optional[str]]: (is_valid, program, error_message)
     """
-    valid_programs = ["match", "intercept", "approach", "hold", "hold_velocity", "orbit", "evasive", "jink", "rendezvous", "dock_approach", "off"]
+    valid_programs = ["match", "intercept", "approach", "hold", "hold_velocity", "orbit", "evasive", "jink", "rendezvous", "dock_approach", "cruise", "goto_position", "off"]
 
     program_str = str(program).lower()
 


### PR DESCRIPTION
## Summary
- **Panel merges (14 → 10):** Flight Data (nav+delta-v), Manual Flight (throttle+heading), expanded Flight Computer (absorbs autopilot-control+set-course), expanded Helm Queue (absorbs helm-requests), Maneuver Planner (renamed flight-computer)
- **3-column glass cockpit layout:** Left=Situational Awareness, Center=Command & Control, Right=Ship Status with semantic panel-group headers
- **Per-tier visual identity:** RAW (red/monospace/sharp/scanlines), ARCADE (blue/mixed/rounded/glow), CPU-ASSIST (purple/sans-serif/large)
- **New components:** flight-data-panel, manual-flight-panel, maneuver-planner, helm-workflow-strip, autopilot-utils
- **Panel component enhanced:** priority/domain/disabled-reason attributes with visual hierarchy
- **CSS foundation:** Domain color system, utility classes (.status-chip, .big-number, .kv-inline, .data-table-dense)
- **Bug fixes:** helm-requests wrong command name, touch controls wrong send method, autopilot validator missing programs

## Files changed (17)
- **New:** flight-data-panel.js, manual-flight-panel.js, maneuver-planner.js, helm-workflow-strip.js, autopilot-utils.js
- **Modified:** flight-computer-panel.js, helm-queue-panel.js, panel.js, index.html, main.js, main.css, tiers.css, helm-requests.js, touch-joystick.js, touch-throttle.js, validators.py

## Test plan
- [ ] Load GUI at localhost:3100, verify helm view shows 10 panels in 3 groups
- [ ] Switch tiers (RAW/ARCADE/CPU-ASSIST) — verify correct panels show/hide per tier
- [ ] RAW: Manual Flight is hero (8-col), Flight Computer disabled with overlay message
- [ ] ARCADE: Flight Computer is hero (6-col), RCS disabled with overlay
- [ ] CPU-ASSIST: Autopilot Status is hero (6-col), no manual controls
- [ ] Workflow strip shows tier-appropriate steps and auto-detects progress
- [ ] Flight Computer panel: engage/disengage autopilot, all modes work
- [ ] Flight Data panel: shows nav data + delta-V budget in single panel
- [ ] Manual Flight panel: throttle slider + heading inputs work
- [ ] Helm Queue panel: shows pending requests section
- [ ] Panel domain colors visible as left-border accents on primary panels
- [ ] Mobile: verify responsive breakpoints at 1200px and 768px
- [ ] Verify touch controls (joystick/throttle) still send commands correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)