### PR TITLE
Fix nav solutions cards not appearing in GUI

### DIFF
--- a/gui/components/flight-computer-panel.js
+++ b/gui/components/flight-computer-panel.js
@@ -595,9 +595,11 @@ class FlightComputerPanel extends HTMLElement {
     }
 
     try {
-      const resp = await wsClient.send("get_nav_solutions", params);
-      if (resp?.error) {
-        content.innerHTML = `<div class="nav-sol-error">${resp.error}</div>`;
+      const raw = await wsClient.sendShipCommand("get_nav_solutions", params);
+      // Station dispatcher wraps in {ok, message, response: {solutions, range, ...}}
+      const resp = raw?.response || raw;
+      if (resp?.error || raw?.error) {
+        content.innerHTML = `<div class="nav-sol-error">${resp?.error || raw?.error}</div>`;
         this._navSolutions = null;
         return;
       }

--- a/hybrid/navigation/navigation_controller.py
+++ b/hybrid/navigation/navigation_controller.py
@@ -268,24 +268,23 @@ class NavigationController:
         }
 
     def calculate_nav_solutions(self, target_id: Optional[str] = None,
-                               target_position: Optional[Dict] = None) -> Optional[List[Dict]]:
+                               target_position: Optional[Dict] = None) -> Optional[Dict]:
         """Calculate all 3 nav solution profiles for a target.
 
         Returns aggressive, balanced, and conservative solutions with
         estimated time, fuel cost, accuracy, risk, and description.
-        Follows the same target-resolution pattern as
-        ``calculate_intercept_solution``.
 
         Args:
             target_id: Sensor contact ID of the target.
             target_position: Target position dict {x, y, z} (fallback).
 
         Returns:
-            List of 3 solution dicts, or None if target cannot be resolved.
+            Dict with 'solutions' (keyed by profile name), 'range',
+            'closing_speed', and 'target_id'; or None if target
+            cannot be resolved.
         """
         from hybrid.navigation.relative_motion import calculate_relative_motion
         from hybrid.navigation.autopilot.rendezvous import NAV_PROFILES
-        from hybrid.utils.math_utils import magnitude as vec_mag, subtract_vectors
 
         # -- resolve target --------------------------------------------------
         target = None
@@ -322,7 +321,7 @@ class NavigationController:
         else:
             flip_time = 20.0
 
-        solutions: List[Dict] = []
+        solutions: Dict = {}
 
         for profile_name, profile in NAV_PROFILES.items():
             thrust_frac = profile["max_thrust"]
@@ -331,37 +330,38 @@ class NavigationController:
             a_eff = ship_max_accel * thrust_frac
 
             # Brachistochrone estimate: burn half, brake half
-            # t_total ~ 2 * sqrt(d / a_eff) + flip_time * flip_safety
             if a_eff > 0 and distance > 0:
                 t_flight = 2.0 * math.sqrt(distance / a_eff)
             else:
                 t_flight = float("inf")
             t_total = t_flight + flip_time * flip_safety
 
-            # Delta-v: symmetric brachistochrone dv = 2 * sqrt(d * a_eff)
-            # Normalise to 0-1 scale relative to aggressive (highest dv).
+            # Delta-v normalised to 0-1 scale relative to max accel
             dv = 2.0 * math.sqrt(max(distance * a_eff, 0))
+            dv_max = 2.0 * math.sqrt(max(distance * ship_max_accel, 0))
 
-            # Accuracy estimate: how close the ship will stop.
-            # Higher margins and lower thrust -> better precision.
-            # Aggressive may overshoot by ~500m, conservative ~10m.
+            # Accuracy: higher margins + lower thrust -> better precision
             accuracy_map = {"aggressive": 500.0, "balanced": 50.0, "conservative": 10.0}
-            accuracy = accuracy_map.get(profile_name, 50.0)
 
-            solutions.append({
+            solutions[profile_name] = {
                 "profile": profile_name,
                 "total_time": round(t_total, 1),
-                "fuel_cost": round(min(dv / max(2.0 * math.sqrt(max(distance * ship_max_accel, 0)), 1.0), 1.0), 3),
-                "accuracy": accuracy,
+                "fuel_cost": round(min(dv / max(dv_max, 1.0), 1.0), 3),
+                "accuracy": accuracy_map.get(profile_name, 50.0),
                 "risk_level": profile["risk_level"],
                 "description": profile["description"],
                 "max_thrust": thrust_frac,
                 "brake_margin": brake_margin,
                 "flip_safety_factor": flip_safety,
                 "estimated_flip_time": round(flip_time * flip_safety, 1),
-            })
+            }
 
-        return solutions
+        return {
+            "solutions": solutions,
+            "target_id": target_id,
+            "range": round(distance, 1),
+            "closing_speed": round(closing_speed, 1),
+        }
 
     def get_nav_assistance(self) -> Dict:
         """Get current navigation computer assistance data.

--- a/hybrid/systems/navigation/navigation.py
+++ b/hybrid/systems/navigation/navigation.py
@@ -377,14 +377,14 @@ class NavigationSystem(BaseSystem):
             return error_dict("MISSING_TARGET",
                               "Provide target_id or target_position {x, y, z}")
 
-        solutions = self.controller.calculate_nav_solutions(
+        result = self.controller.calculate_nav_solutions(
             target_id=target_id, target_position=target_position)
 
-        if solutions is None:
+        if result is None:
             return error_dict("TARGET_NOT_FOUND",
                               "Could not resolve target for nav solutions")
 
-        return success_dict("Nav solutions calculated", solutions=solutions)
+        return success_dict("Nav solutions calculated", **result)
 
     def _cmd_set_plan(self, params: dict):
         """Set a queued flight plan.


### PR DESCRIPTION
## Summary
- **Bug:** Selecting a target for rendezvous showed no nav solution cards — 3 bugs working together
- **Fix 1:** GUI used `wsClient.send()` (meta) instead of `wsClient.sendShipCommand()` (ship-scoped). Command needs ship context for station dispatch routing.
- **Fix 2:** GUI read `resp.solutions` but station dispatcher wraps responses in `{ok, message, response: {data}}`. Fixed by unwrapping `resp.response`.
- **Fix 3:** Server returned solutions as a list, GUI expected a dict keyed by profile name. Changed to dict format. Added `range` and `closing_speed` to response.

## What was happening
User flow: Rendezvous > Select Target > C001 → expected 3 nav solution cards (aggressive/balanced/conservative). Got nothing. No errors in server logs because the command never reached the server (wrong send method) or the response was silently misread.

## Test plan
- [x] Server starts cleanly
- [x] `pytest tests/navigation/autopilot/test_rendezvous.py` — 19 pass
- [ ] Manual: Rendezvous > select C001 > verify 3 cards appear with ETA/fuel/accuracy/risk
- [ ] Manual: Click a card to select profile, click Engage, verify autopilot starts with chosen profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)