### PR TITLE
Fix missing ship assignment after connect

### DIFF
--- a/gui/components/station-selector.js
+++ b/gui/components/station-selector.js
@@ -212,6 +212,12 @@ class StationSelector extends HTMLElement {
   async _pollStatus() {
     if (!wsClient.isConnected) return;
 
+    // If registered but not yet assigned to a ship, retry assignment
+    // (stateManager may have auto-detected the player ship since last check)
+    if (this._registered && !this._assignedShipId) {
+      await this._tryAssignShip();
+    }
+
     try {
       const response = await wsClient.send("my_status", {});
       if (response && response.ok !== false) {

--- a/kill-server.sh
+++ b/kill-server.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Kill all running spaceship-sim server processes.
+# Usage: ./kill-server.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Looking for spaceship-sim processes..."
+
+killed=0
+
+# Kill the GUI stack launcher
+for pid in $(pgrep -f "start_gui_stack.py" 2>/dev/null || true); do
+    echo "  Killing GUI launcher (PID $pid)"
+    kill "$pid" 2>/dev/null && ((killed++)) || true
+done
+
+# Kill the main server
+for pid in $(pgrep -f "server\.main" 2>/dev/null || true); do
+    echo "  Killing server (PID $pid)"
+    kill "$pid" 2>/dev/null && ((killed++)) || true
+done
+
+# Kill the WS bridge
+for pid in $(pgrep -f "ws_bridge\.py" 2>/dev/null || true); do
+    echo "  Killing WS bridge (PID $pid)"
+    kill "$pid" 2>/dev/null && ((killed++)) || true
+done
+
+# Kill the HTTP server on port 3100
+for pid in $(pgrep -f "http\.server 3100" 2>/dev/null || true); do
+    echo "  Killing HTTP server (PID $pid)"
+    kill "$pid" 2>/dev/null && ((killed++)) || true
+done
+
+if [ "$killed" -eq 0 ]; then
+    echo "No spaceship-sim processes found."
+else
+    echo "Killed $killed process(es)."
+fi

--- a/server/station_server.py
+++ b/server/station_server.py
@@ -163,6 +163,18 @@ class StationServer:
         if requires_ship and not ship_id:
             return {"ok": False, "error": "missing ship"}
 
+        # Auto-assign ship and station if session exists but has none yet
+        if session and ship_id and ship_id in self.runner.simulator.ships:
+            if not session.ship_id:
+                self.station_manager.assign_to_ship(client_id, ship_id)
+                logger.info(f"Auto-assigned {client_id} to ship {ship_id}")
+            if not session.station and session.ship_id == ship_id:
+                from server.stations.station_types import StationType
+                self.station_manager.claim_station(
+                    client_id, ship_id, StationType.CAPTAIN, PermissionLevel.CAPTAIN
+                )
+                logger.info(f"Auto-claimed CAPTAIN station for {client_id} on {ship_id}")
+
         # Route through station-aware dispatcher
         args = {k: v for k, v in req.items() if k not in ["cmd", "command"]}
         if ship_id:


### PR DESCRIPTION
## Summary
- **Bug:** When server starts with `--fleet-dir` (no scenario), the GUI's station-selector called `_tryAssignShip()` before `stateManager` had auto-detected the player ship ID, then never retried. Every subsequent command failed with "Not assigned to this ship".
- **GUI fix:** Station-selector now retries ship assignment every poll cycle (5s) until assigned, catching the case where `stateManager` auto-detects the ship after initial registration.
- **Server fix:** Auto-assigns ship and auto-claims CAPTAIN station when a valid `ship_id` arrives in a command but the session has no assignment yet (single-player fast path).
- **Utility:** Added `kill-server.sh` script for remote server management.

## Test plan
- [x] All 491 existing tests pass
- [x] Server starts cleanly
- [ ] Connect via GUI without loading a scenario — verify station auto-assigns and commands execute
- [ ] Connect via GUI, load scenario — verify normal flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)