### PR TITLE
Fix 6 bugs: WSEnvelope, station claim, WS leak, overheat, autopilot disengage, contact loss

### DIFF
--- a/server/protocol.py
+++ b/server/protocol.py
@@ -197,17 +197,20 @@ class WSEnvelope:
         return cls(type=MessageType.ERROR, data=data)
 
     @classmethod
-    def status(cls, status: str, tcp_connected: bool, tcp_host: str, tcp_port: int) -> "WSEnvelope":
+    def status(cls, status: str, tcp_connected: bool, tcp_host: str, tcp_port: int,
+               client_id: Optional[str] = None, server_mode: Optional[str] = None) -> "WSEnvelope":
         """Create a connection status envelope."""
-        return cls(
-            type=MessageType.STATUS,
-            data={
-                "status": status,
-                "tcp_host": tcp_host,
-                "tcp_port": tcp_port,
-                "tcp_connected": tcp_connected,
-            }
-        )
+        data = {
+            "status": status,
+            "tcp_host": tcp_host,
+            "tcp_port": tcp_port,
+            "tcp_connected": tcp_connected,
+        }
+        if client_id is not None:
+            data["client_id"] = client_id
+        if server_mode is not None:
+            data["server_mode"] = server_mode
+        return cls(type=MessageType.STATUS, data=data)
 
     @classmethod
     def pong(cls, client_timestamp: Optional[float] = None) -> "WSEnvelope":


### PR DESCRIPTION
## Summary

### Connection & Session (commits 1-2)
- **WSEnvelope.status() crash** — added missing `client_id`/`server_mode` kwargs
- **Station claim lost on scenario load** — `assign_to_ship` and `register_client` now idempotent on same-ship re-assignment
- **WS client leak on reconnect** — ws_bridge sends `_resume_session` to migrate old session state

### Heat System (commit 2)
- **Propulsion/RCS overheat spam** — propulsion heat 0.00009→0.00005 (equilibrium at full thrust), RCS 0.5→0.002 (only combat overheats). 30s rate-limit on log warnings.

### Autopilot & Sensors (commit 3)
- **Autopilot silent disengage** — all 6 disengage paths now log a reason. Added FLIP phase timeout safety (4x estimated flip time) to prevent infinite coasting when RCS impaired.
- **Contact C001 lost from sensors** — three cooperating failures fixed:
  - Passive sensor confidence decayed below 0.1 and purged the contact (now floors at 0.05)
  - ContactTracker pruned contacts whose source ship still exists (now preserves them)
  - Autopilot fallback compared stable ID "C001" against ship ID "target_station" (now resolves via id_mapping)

## Test plan
- [x] 527 tests pass
- [x] Regression: re-assigning same ship preserves station claim
- [x] Regression: re-registering client preserves session
- [ ] Mission 1: load scenario, engage rendezvous autopilot, go AFK — should arrive near station
- [ ] Verify no overheat warnings during normal autopilot flight
- [ ] Verify autopilot disengage always logs a reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)