### PR TITLE
Crew fatigue wired to gameplay — human players only

### DIFF
--- a/gui/components/crew-fatigue-overlay.js
+++ b/gui/components/crew-fatigue-overlay.js
@@ -1,0 +1,276 @@
+/**
+ * Crew Fatigue Overlay Component
+ *
+ * Full-screen overlay that appears during crew blackout and shows
+ * impairment warnings when performance degrades. This is a safety
+ * display — it tells the player their crew is physically compromised.
+ *
+ * States:
+ * - Hidden: performance >= 0.85, no blackout
+ * - Amber warning: performance < 0.85 (vignette + status text)
+ * - Blackout: is_blacked_out === true (dark overlay, pulsing text, recovery bar)
+ */
+
+import { stateManager } from "../js/state-manager.js";
+
+const IMPAIRMENT_THRESHOLD = 0.85;
+
+class CrewFatigueOverlay extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._unsubscribe = null;
+    this._lastState = "hidden";
+  }
+
+  connectedCallback() {
+    this._render();
+    this._unsubscribe = stateManager.subscribe("*", () => this._update());
+  }
+
+  disconnectedCallback() {
+    if (this._unsubscribe) {
+      this._unsubscribe();
+      this._unsubscribe = null;
+    }
+  }
+
+  _render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100vw;
+          height: 100vh;
+          pointer-events: none;
+          z-index: 9000;
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+        }
+
+        .overlay {
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          display: none;
+          justify-content: center;
+          align-items: center;
+          flex-direction: column;
+          transition: opacity 0.5s ease;
+        }
+
+        /* Amber impairment vignette */
+        .overlay.warning {
+          display: flex;
+          background: radial-gradient(
+            ellipse at center,
+            transparent 40%,
+            rgba(255, 170, 0, 0.08) 70%,
+            rgba(255, 170, 0, 0.15) 100%
+          );
+          border: 2px solid transparent;
+          box-shadow: inset 0 0 80px rgba(255, 170, 0, 0.06);
+        }
+
+        /* Blackout: dark overlay blocks visibility */
+        .overlay.blackout {
+          display: flex;
+          background: radial-gradient(
+            ellipse at center,
+            rgba(0, 0, 0, 0.75) 20%,
+            rgba(0, 0, 0, 0.92) 60%,
+            rgba(0, 0, 0, 0.98) 100%
+          );
+          pointer-events: auto;
+        }
+
+        .blackout-content {
+          text-align: center;
+          color: #ff4444;
+        }
+
+        .blackout-title {
+          font-size: 2.5rem;
+          font-weight: 700;
+          text-transform: uppercase;
+          letter-spacing: 6px;
+          animation: pulse-text 1.2s ease-in-out infinite;
+          margin-bottom: 16px;
+        }
+
+        .blackout-subtitle {
+          font-size: 0.9rem;
+          color: #ff8888;
+          letter-spacing: 2px;
+          text-transform: uppercase;
+          margin-bottom: 32px;
+        }
+
+        .g-readout {
+          font-size: 3rem;
+          font-weight: 700;
+          color: #ff6666;
+          margin-bottom: 8px;
+        }
+
+        .g-label {
+          font-size: 0.7rem;
+          color: #666;
+          text-transform: uppercase;
+          letter-spacing: 1px;
+          margin-bottom: 32px;
+        }
+
+        .recovery-container {
+          width: 300px;
+        }
+
+        .recovery-label {
+          font-size: 0.7rem;
+          color: #888;
+          text-transform: uppercase;
+          letter-spacing: 1px;
+          margin-bottom: 8px;
+          display: flex;
+          justify-content: space-between;
+        }
+
+        .recovery-bar {
+          height: 6px;
+          background: rgba(255, 255, 255, 0.1);
+          border-radius: 3px;
+          overflow: hidden;
+        }
+
+        .recovery-fill {
+          height: 100%;
+          background: #ff4444;
+          border-radius: 3px;
+          transition: width 0.3s ease;
+        }
+
+        /* Warning banner (shown during impairment, not blackout) */
+        .warning-banner {
+          position: absolute;
+          top: 48px;
+          left: 50%;
+          transform: translateX(-50%);
+          background: rgba(255, 170, 0, 0.12);
+          border: 1px solid rgba(255, 170, 0, 0.4);
+          border-radius: 6px;
+          padding: 8px 24px;
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          backdrop-filter: blur(4px);
+        }
+
+        .warning-icon {
+          font-size: 1.1rem;
+          color: #ffaa00;
+        }
+
+        .warning-text {
+          font-size: 0.75rem;
+          color: #ffaa00;
+          text-transform: uppercase;
+          letter-spacing: 1px;
+        }
+
+        .warning-perf {
+          font-weight: 700;
+          font-size: 0.85rem;
+        }
+
+        @keyframes pulse-text {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.3; }
+        }
+      </style>
+
+      <div class="overlay" id="overlay">
+        <!-- Blackout content (shown during blackout) -->
+        <div class="blackout-content" id="blackout-content" style="display:none;">
+          <div class="blackout-title">CREW BLACKOUT</div>
+          <div class="blackout-subtitle">Manual operations suspended</div>
+          <div class="g-readout" id="g-readout">0.0g</div>
+          <div class="g-label">Current G-Load</div>
+          <div class="recovery-container">
+            <div class="recovery-label">
+              <span>RECOVERY</span>
+              <span id="recovery-time">0s</span>
+            </div>
+            <div class="recovery-bar">
+              <div class="recovery-fill" id="recovery-fill" style="width:0%"></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Warning banner (shown during impairment) -->
+        <div class="warning-banner" id="warning-banner" style="display:none;">
+          <span class="warning-icon">!</span>
+          <span class="warning-text">
+            CREW IMPAIRED — G-LOAD/FATIGUE DEGRADING PERFORMANCE TO
+            <span class="warning-perf" id="warning-perf">0%</span>
+          </span>
+        </div>
+      </div>
+    `;
+  }
+
+  _update() {
+    const ship = stateManager.getShipState();
+    if (!ship) return;
+
+    const cf = ship.crew_fatigue || ship.systems?.crew_fatigue;
+    const overlay = this.shadowRoot.getElementById("overlay");
+    const blackoutContent = this.shadowRoot.getElementById("blackout-content");
+    const warningBanner = this.shadowRoot.getElementById("warning-banner");
+
+    if (!cf || !cf.enabled) {
+      overlay.className = "overlay";
+      blackoutContent.style.display = "none";
+      warningBanner.style.display = "none";
+      return;
+    }
+
+    const isBlackedOut = cf.is_blacked_out ?? false;
+    const perf = cf.performance ?? 1;
+    const gLoad = cf.g_load ?? 0;
+    const recovery = cf.blackout_recovery ?? 0;
+    const blackoutTimer = cf.blackout_timer ?? 0;
+
+    if (isBlackedOut) {
+      overlay.className = "overlay blackout";
+      blackoutContent.style.display = "block";
+      warningBanner.style.display = "none";
+
+      this.shadowRoot.getElementById("g-readout").textContent =
+        `${gLoad.toFixed(1)}g`;
+      this.shadowRoot.getElementById("recovery-time").textContent =
+        `${recovery.toFixed(0)}s`;
+
+      // Recovery bar: 15s max recovery time
+      const maxRecovery = 15;
+      const pct = Math.max(0, Math.min(100, (1 - recovery / maxRecovery) * 100));
+      this.shadowRoot.getElementById("recovery-fill").style.width = `${pct}%`;
+    } else if (perf < IMPAIRMENT_THRESHOLD) {
+      overlay.className = "overlay warning";
+      blackoutContent.style.display = "none";
+      warningBanner.style.display = "flex";
+
+      this.shadowRoot.getElementById("warning-perf").textContent =
+        `${(perf * 100).toFixed(0)}%`;
+    } else {
+      overlay.className = "overlay";
+      blackoutContent.style.display = "none";
+      warningBanner.style.display = "none";
+    }
+  }
+}
+
+customElements.define("crew-fatigue-overlay", CrewFatigueOverlay);
+export { CrewFatigueOverlay };

--- a/gui/index.html
+++ b/gui/index.html
@@ -683,6 +683,7 @@
     <!-- System Messages (Toast Notifications) -->
     <system-messages id="system-messages"></system-messages>
     <tutorial-overlay></tutorial-overlay>
+    <crew-fatigue-overlay></crew-fatigue-overlay>
 
     <!-- ===== HELM VIEW ===== -->
     <div class="view-container active" id="view-helm">

--- a/gui/js/main.js
+++ b/gui/js/main.js
@@ -79,6 +79,7 @@ import "../components/engineering-control-panel.js";
 import "../components/comms-control-panel.js";
 // Crew Fatigue System
 import "../components/crew-fatigue-display.js";
+import "../components/crew-fatigue-overlay.js";
 // Science Station Analysis
 import "../components/science-analysis-panel.js";
 // Tutorial System
@@ -93,6 +94,8 @@ import "../components/multi-track-panel.js";
 import "../components/target-assessment.js";
 // Damage visualization
 import { damageStateManager } from "./damage-state-manager.js";
+// Keyboard flight controls (MANUAL tier)
+import * as keyboardFlight from "./keyboard-flight.js";
 
 // App state
 const app = {
@@ -159,6 +162,9 @@ async function init() {
 
   // Initialize damage visualization (reacts to subsystem_health in telemetry)
   damageStateManager.init();
+
+  // Initialize keyboard flight controls (activates in MANUAL tier)
+  keyboardFlight.init();
 
   // Debug mode logging
   if (app.config.debugMode) {

--- a/hybrid/systems/crew_fatigue_system.py
+++ b/hybrid/systems/crew_fatigue_system.py
@@ -146,6 +146,12 @@ class CrewFatigueSystem(BaseSystem):
         # Current crew state
         self.crew = CrewState()
 
+        # Whether this ship has human crew at the controls.
+        # When False, get_performance_factor() / get_station_performance()
+        # return 1.0 so AI ships are never penalized. Set to True by the
+        # server station system when a human claims a station on this ship.
+        self.has_human_crew: bool = False
+
         # Combat detection (driven by events)
         self._in_combat = False
         self._combat_cooldown = 0.0
@@ -345,9 +351,14 @@ class CrewFatigueSystem(BaseSystem):
         Combines fatigue degradation and current g-load impairment.
         Used by targeting, helm, ops systems to scale their effectiveness.
 
+        Returns 1.0 (no penalty) when has_human_crew is False, ensuring
+        AI ships are never penalized by crew fatigue.
+
         Returns:
             Performance multiplier (0.0 = incapacitated, 1.0 = peak)
         """
+        if not self.has_human_crew:
+            return 1.0
         if self.crew.is_blacked_out:
             return 0.0
 
@@ -370,12 +381,16 @@ class CrewFatigueSystem(BaseSystem):
         - ENGINEERING: Mildly impacted (physical repair work)
         - SENSORS/SCIENCE: Least impacted (cognitive, sitting work)
 
+        Returns 1.0 when has_human_crew is False (AI ships unaffected).
+
         Args:
             station: Station name (helm, tactical, ops, engineering, etc.)
 
         Returns:
             Performance multiplier (0.0 to 1.0)
         """
+        if not self.has_human_crew:
+            return 1.0
         base = self.get_performance_factor()
         if base == 0.0:
             return 0.0
@@ -504,6 +519,7 @@ class CrewFatigueSystem(BaseSystem):
             "performance": round(perf, 3),
             "is_blacked_out": self.crew.is_blacked_out,
             "blackout_timer": round(self.crew.blackout_timer, 1),
+            "blackout_recovery": round(self.crew.blackout_recovery, 1),
             "rest_ordered": self._rest_ordered,
             "in_combat": self._in_combat,
             "crew_experience": self.crew_experience,

--- a/hybrid/systems/rcs_system.py
+++ b/hybrid/systems/rcs_system.py
@@ -213,6 +213,15 @@ class RCSSystem(BaseSystem):
             ship.id, StationType.HELM
         )
 
+        # Crew fatigue: under high-G or fatigue, human crew responds
+        # more sluggishly to manual helm commands. AI ships have no
+        # crew_fatigue system so this returns 1.0 for them.
+        crew_fatigue = ship.systems.get("crew_fatigue")
+        if crew_fatigue is not None:
+            fatigue_perf = crew_fatigue.get_station_performance("helm")
+            if fatigue_perf < 1.0:
+                self.total_torque *= fatigue_perf
+
         # Apply torque to ship angular velocity
         # τ = I * α  =>  α = τ / I
         moment_of_inertia = getattr(ship, 'moment_of_inertia', ship.mass * 10.0)

--- a/hybrid/systems/targeting/targeting_system.py
+++ b/hybrid/systems/targeting/targeting_system.py
@@ -293,6 +293,11 @@ class TargetingSystem(BaseSystem):
             from server.stations.station_types import StationType
             lock_rate *= CrewBindingSystem.get_multiplier(ship.id, StationType.TACTICAL)
 
+            # Crew fatigue: human operator G-load and fatigue degrades
+            # lock acquisition speed. Only affects player ships with the
+            # crew_fatigue system — AI ships have no crew_fatigue system.
+            lock_rate *= self._get_crew_fatigue_factor(ship, "tactical")
+
             self.lock_progress = min(1.0, self.lock_progress + lock_rate * dt)
 
             if self.lock_progress >= 1.0:
@@ -417,6 +422,10 @@ class TargetingSystem(BaseSystem):
         if hasattr(ship, 'get_effective_factor'):
             weapon_damage_factor = ship.get_effective_factor("weapons")
 
+        # Crew fatigue penalty on firing solution confidence.
+        # Only affects player ships — AI ships have no crew_fatigue system.
+        fatigue_factor = self._get_crew_fatigue_factor(ship, "tactical")
+
         for weapon_id, weapon in truth_weapons.items():
             if hasattr(weapon, 'calculate_solution'):
                 solution = weapon.calculate_solution(
@@ -431,6 +440,13 @@ class TargetingSystem(BaseSystem):
                     weapon_damage_factor=weapon_damage_factor,
                     target_accel=target_accel,
                 )
+                # Apply crew fatigue as a post-multiplier on confidence.
+                # Fatigued crew compute less precise firing solutions.
+                if fatigue_factor < 1.0:
+                    solution.confidence *= fatigue_factor
+                    solution.confidence_factors["crew_fatigue"] = round(
+                        fatigue_factor, 3
+                    )
                 self.firing_solutions[weapon_id] = {
                     "valid": solution.valid,
                     "ready": solution.ready_to_fire,
@@ -457,6 +473,24 @@ class TargetingSystem(BaseSystem):
             "cpa_distance": rel_motion.get("closest_approach_distance"),
             "target_subsystem": self.target_subsystem,
         }
+
+    def _get_crew_fatigue_factor(self, ship, station: str) -> float:
+        """Get crew fatigue performance factor for a station.
+
+        Returns 1.0 (no penalty) when the ship has no crew_fatigue system
+        (e.g. AI ships), so this is safe to call unconditionally.
+
+        Args:
+            ship: Ship object
+            station: Station name (e.g. "tactical", "helm")
+
+        Returns:
+            Performance multiplier (0.0 to 1.0)
+        """
+        crew_fatigue = ship.systems.get("crew_fatigue")
+        if crew_fatigue is None:
+            return 1.0
+        return crew_fatigue.get_station_performance(station)
 
     def _get_target_accel(self) -> Optional[Dict[str, float]]:
         """Estimate target acceleration from velocity changes.

--- a/server/main.py
+++ b/server/main.py
@@ -367,6 +367,9 @@ class UnifiedServer:
                 result["station"] = "captain"
                 logger.info(f"Auto-assigned {client_id} to {player_ship_id} as captain")
 
+                # Enable crew fatigue effects for the player ship
+                self._set_human_crew_flag(player_ship_id, True)
+
             # Register AI crew for all ships in the scenario
             if result.get("ok") and self.ai_crew_manager:
                 for sid in self.runner.simulator.ships:
@@ -430,7 +433,8 @@ class UnifiedServer:
         result = self.dispatcher.dispatch(client_id, ship_id or "", cmd, args)
 
         # Notify AI crew manager when stations are claimed/released
-        if self.ai_crew_manager and result.success:
+        # and update crew fatigue human-crew flag
+        if result.success:
             if cmd == "claim_station":
                 station_name = args.get("station", "")
                 from server.stations.station_types import StationType
@@ -438,13 +442,45 @@ class UnifiedServer:
                     st = StationType(station_name.lower())
                     sess = self.station_manager.get_session(client_id)
                     if sess and sess.ship_id:
-                        self.ai_crew_manager.deactivate_station(sess.ship_id, st)
+                        if self.ai_crew_manager:
+                            self.ai_crew_manager.deactivate_station(sess.ship_id, st)
+                        # Enable crew fatigue gameplay effects for this ship
+                        self._set_human_crew_flag(sess.ship_id, True)
                 except ValueError:
                     pass
             elif cmd == "release_station" and _pre_release_station and _pre_release_ship:
-                self.ai_crew_manager.activate_station(_pre_release_ship, _pre_release_station)
+                if self.ai_crew_manager:
+                    self.ai_crew_manager.activate_station(_pre_release_ship, _pre_release_station)
+                # Disable crew fatigue effects if no humans remain on ship
+                remaining = self.station_manager.get_clients_on_ship(_pre_release_ship)
+                has_humans = any(
+                    s.station is not None for s in remaining
+                    if s.client_id != client_id
+                )
+                if not has_humans:
+                    self._set_human_crew_flag(_pre_release_ship, False)
 
         return result.to_dict()
+
+    def _set_human_crew_flag(self, ship_id: str, has_human: bool) -> None:
+        """Set the has_human_crew flag on a ship's crew_fatigue system.
+
+        This controls whether crew fatigue gameplay penalties apply.
+        Only ships with human players at stations are affected.
+
+        Args:
+            ship_id: Ship to update
+            has_human: Whether any human has a station claimed
+        """
+        ship = self.runner.simulator.ships.get(ship_id)
+        if ship is None:
+            return
+        crew_fatigue = ship.systems.get("crew_fatigue")
+        if crew_fatigue is not None:
+            crew_fatigue.has_human_crew = has_human
+            logger.debug(
+                f"Ship {ship_id} crew_fatigue.has_human_crew = {has_human}"
+            )
 
     def _handle_resume_session(self, client_id: str, req: dict) -> dict:
         """

--- a/server/stations/station_dispatch.py
+++ b/server/stations/station_dispatch.py
@@ -3,6 +3,11 @@ Station-aware command dispatcher with permission enforcement.
 
 Wraps existing command handlers with station permission checks to ensure
 commands are only executed if the client has the appropriate station claim.
+
+Crew fatigue integration:
+- When a ship's crew_fatigue system reports blackout, ALL human commands
+  are rejected (autopilot and AI commands are unaffected since they bypass
+  this dispatcher entirely).
 """
 
 from typing import Dict, Any, Callable, Optional, Tuple, Mapping, Union
@@ -45,10 +50,22 @@ class StationAwareDispatcher:
     Wraps existing command handlers with permission checks.
     """
 
+    # Commands that are exempt from blackout blocking.
+    # These are status queries or safety-critical commands that should
+    # always work even when crew is incapacitated.
+    BLACKOUT_EXEMPT_COMMANDS = frozenset({
+        "crew_fatigue_status", "crew_status", "crew_rest", "cancel_rest",
+        "get_state", "get_events", "get_combat_log", "get_mission",
+        "get_mission_hints", "get_tick_metrics",
+    })
+
     def __init__(self, station_manager: StationManager):
         self.station_manager = station_manager
         self.handlers: Dict[str, CommandHandler] = {}
         self.command_metadata: Dict[str, Dict[str, Any]] = {}
+        # Optional callback to resolve ship objects by ID.
+        # Set by register_legacy_commands so we can check crew fatigue.
+        self._ship_resolver: Optional[Callable[[str], Any]] = None
 
     def register_command(
         self,
@@ -123,10 +140,25 @@ class StationAwareDispatcher:
                     message=f"Permission denied: {reason}",
                 )
 
-        # 3. Update client activity
+        # 3. Check crew fatigue blackout (human commands only)
+        #    AI ships never route through this dispatcher, so this only
+        #    affects human players at station seats.
+        if command not in self.BLACKOUT_EXEMPT_COMMANDS:
+            blocked, reason = self._check_crew_blackout(ship_id)
+            if blocked:
+                logger.info(
+                    f"Command blocked by crew blackout: {command} "
+                    f"from {client_id} on {ship_id}"
+                )
+                return CommandResult(
+                    success=False,
+                    message=reason,
+                )
+
+        # 4. Update client activity
         self.station_manager.update_activity(client_id)
 
-        # 4. Execute the command
+        # 5. Execute the command
         try:
             handler = self.handlers[command]
             result = handler(client_id, ship_id, args)
@@ -138,6 +170,36 @@ class StationAwareDispatcher:
                 success=False,
                 message=f"Command execution failed: {str(e)}",
             )
+
+    def _check_crew_blackout(self, ship_id: str) -> Tuple[bool, str]:
+        """Check if the ship's crew is blacked out, blocking commands.
+
+        Only blocks when a ship_resolver is configured and the ship has
+        a crew_fatigue system reporting blackout.
+
+        Args:
+            ship_id: Ship to check
+
+        Returns:
+            Tuple of (is_blocked, reason_message)
+        """
+        if not self._ship_resolver or not ship_id:
+            return False, ""
+        ship = self._ship_resolver(ship_id)
+        if ship is None:
+            return False, ""
+        crew_fatigue = getattr(ship, "systems", {}).get("crew_fatigue")
+        if crew_fatigue is None:
+            return False, ""
+        crew_state = getattr(crew_fatigue, "crew", None)
+        if crew_state and crew_state.is_blacked_out:
+            g = round(crew_state.current_g, 1)
+            recovery = round(crew_state.blackout_recovery, 1)
+            return True, (
+                f"CREW BLACKOUT — manual operations suspended "
+                f"({g}g, recovery in {recovery}s)"
+            )
+        return False, ""
 
     def get_available_commands(self, client_id: str) -> Dict[str, Any]:
         """
@@ -279,6 +341,9 @@ def register_legacy_commands(dispatcher: StationAwareDispatcher, runner):
     from .station_types import get_station_for_command
 
     ship_map_provider = lambda: runner.simulator.ships
+
+    # Wire ship resolver for crew fatigue blackout checks
+    dispatcher._ship_resolver = lambda sid: runner.simulator.ships.get(sid)
 
     # Register all system commands from the legacy system
     registered_commands = set()


### PR DESCRIPTION
## Summary
- **Blackout gate**: `station_dispatch.py` blocks all human station commands when `crew.is_blacked_out` (7g+ sustained 30s). Clear error: "CREW BLACKOUT — manual operations suspended". AI ships completely unaffected.
- **Targeting degradation**: Lock acquisition rate and firing solution confidence multiplied by `crew_fatigue.get_performance_factor()`. Only on ships with `has_human_crew=True`.
- **Helm sluggishness**: RCS torque scaled by crew fatigue helm performance, making rotation physically sluggish under high G.
- **Human crew flag**: `has_human_crew` set True on station claim, False when all humans leave. AI ships always return performance=1.0.
- **GUI overlay**: Amber warning vignette at <85% performance, full blackout screen with pulsing "CREW BLACKOUT" title, g-load readout, and recovery progress bar.

## Key design constraint
Only human players at station seats are affected. AI ships and AI-managed stations are NEVER impacted — their commands bypass station dispatch entirely, and `has_human_crew=False` ensures `get_performance_factor()` returns 1.0.

## Test plan
- [x] 1255 tests pass
- [x] Server starts clean
- [ ] Load combat scenario, sustain 7g+ for 30s — verify blackout overlay appears
- [ ] During blackout: verify commands are rejected with clear error message
- [ ] During blackout: verify autopilot continues functioning
- [ ] At 5g: verify targeting lock takes longer than at 1g
- [ ] At 5g: verify ship rotation is sluggish (RCS degraded)
- [ ] AI enemies: verify they fight at full effectiveness regardless of G

🤖 Generated with [Claude Code](https://claude.com/claude-code)