### PR TITLE
Fix: Handle throttled requests gracefully in target locking

### DIFF
--- a/gui/components/sensor-contacts.js
+++ b/gui/components/sensor-contacts.js
@@ -636,9 +636,14 @@ class SensorContacts extends HTMLElement {
         const result = await wsClient.sendShipCommand("lock_target", {
           contact_id: contactId
         });
+        if (result && result.reason === "throttled") return;
+
         if (result && result.ok === false) {
-          console.error("Lock target failed:", result.message || result.error);
-          this._showMessage(`Lock failed: ${result.message || result.error}`, "error");
+          console.error("Lock target failed:", result.message || result.error || "Unknown error");
+          this._showMessage(`Lock failed: ${result.message || result.error || "Unknown error"}`, "error");
+        } else if (result && result.error) {
+          console.error("Lock target error:", result.error);
+          this._showMessage(`Lock failed: ${result.error}`, "error");
         } else {
           this._showMessage(`Target locked: ${contactId}`, "info");
         }

--- a/gui/components/threat-board.js
+++ b/gui/components/threat-board.js
@@ -407,9 +407,14 @@ class ThreatBoard extends HTMLElement {
       const result = await wsClient.sendShipCommand("lock_target", {
         contact_id: contactId,
       });
+      if (result && result.reason === "throttled") return;
+
       if (result && result.ok === false) {
-        console.error("Lock target failed:", result.message || result.error);
-        this._showMessage(`Lock failed: ${result.message || result.error}`, "error");
+        console.error("Lock target failed:", result.message || result.error || "Unknown error");
+        this._showMessage(`Lock failed: ${result.message || result.error || "Unknown error"}`, "error");
+      } else if (result && result.error) {
+        console.error("Lock target error:", result.error);
+        this._showMessage(`Lock failed: ${result.error}`, "error");
       } else {
         this._showMessage(`Target locked: ${contactId}`, "info");
       }


### PR DESCRIPTION
Fixes an issue where tapping the 'Lock Target' button multiple times (common on mobile) caused a throttled response without a message/error to be logged to the UI as 'Lock failed: undefined'. Also hardens UI to capture and display raw backend exception strings.