### PR TITLE
feat(svelte): Prompts 3-8 — all station views + mission system

### DIFF
--- a/gui-svelte/src/components/comms/CommsChoicePanel.svelte
+++ b/gui-svelte/src/components/comms/CommsChoicePanel.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    formatChoiceCountdown,
+    normalizeCommsChoices,
+    recommendChoice,
+    type CommsChoice,
+  } from "./commsData.js";
+
+  let choices: CommsChoice[] = [];
+  let feedback = "";
+  let nowSeconds = Date.now() / 1000;
+  let pollHandle: number | null = null;
+  let timerHandle: number | null = null;
+
+  $: cpuAssistTier = $tier === "cpu-assist";
+
+  onMount(() => {
+    void refresh();
+    pollHandle = window.setInterval(() => void refresh(), 2000);
+    timerHandle = window.setInterval(() => {
+      nowSeconds = Date.now() / 1000;
+    }, 250);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+      if (timerHandle != null) window.clearInterval(timerHandle);
+    };
+  });
+
+  async function refresh() {
+    try {
+      const response = await wsClient.sendShipCommand("get_comms_choices", {});
+      choices = normalizeCommsChoices(response);
+    } catch {
+      choices = [];
+    }
+  }
+
+  async function respond(choice: CommsChoice, optionId: string) {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("comms_respond", {
+        choice_id: choice.choiceId,
+        option_id: optionId,
+      });
+      feedback = "Response transmitted";
+      await refresh();
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Response failed";
+    }
+  }
+</script>
+
+<Panel title="Incoming Traffic" domain="comms" priority="primary" className="comms-choice-panel">
+  <div class="shell">
+    {#if choices.length === 0}
+      <div class="empty">No active comms choices.</div>
+    {:else}
+      {#each choices as choice}
+        {@const countdown = formatChoiceCountdown(choice, nowSeconds)}
+        {@const recommended = recommendChoice(choice)}
+        <section class="choice-card">
+          <div class="choice-head">
+            <strong>{choice.contactId.toUpperCase()}</strong>
+            {#if choice.timeout != null}
+              <span>{Math.ceil(countdown.remaining)}s</span>
+            {:else}
+              <span>OPEN</span>
+            {/if}
+          </div>
+
+          <div class="prompt">{choice.prompt}</div>
+
+          {#if choice.timeout != null}
+            <div class="track">
+              <div class="fill" style={`width:${(countdown.progress * 100).toFixed(1)}%;`}></div>
+            </div>
+          {/if}
+
+          <div class="options">
+            {#each choice.options as option}
+              <button
+                type="button"
+                class:recommended={cpuAssistTier && recommended?.optionId === option.optionId}
+                on:click={() => respond(choice, option.optionId)}
+              >
+                <strong>{option.label}</strong>
+                {#if option.description}
+                  <span>{option.description}</span>
+                {/if}
+                {#if cpuAssistTier && recommended?.optionId === option.optionId}
+                  <em>Recommended</em>
+                {/if}
+              </button>
+            {/each}
+          </div>
+        </section>
+      {/each}
+    {/if}
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .choice-card,
+  .feedback,
+  .empty {
+    display: grid;
+    gap: 10px;
+    padding: 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .choice-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  .prompt,
+  .feedback,
+  .empty,
+  .options span,
+  .options em {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .track {
+    height: 8px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(0, 255, 136, 0.85), rgba(255, 68, 68, 0.85));
+    transform-origin: left center;
+  }
+
+  .options {
+    display: grid;
+    gap: 8px;
+  }
+
+  .options button {
+    display: grid;
+    gap: 6px;
+    text-align: left;
+    width: 100%;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text-primary);
+    font-family: inherit;
+  }
+
+  .options button.recommended {
+    border-color: rgba(var(--tier-accent-rgb), 0.45);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  .options em {
+    color: var(--status-info);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-style: normal;
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+</style>

--- a/gui-svelte/src/components/comms/CommsControlPanel.svelte
+++ b/gui-svelte/src/components/comms/CommsControlPanel.svelte
@@ -1,0 +1,367 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { selectedCommsTargetId } from "../../lib/stores/commsUi.js";
+  import {
+    emconLevelFromShip,
+    getAutoCommsState,
+    getCommsContacts,
+    getCommsProposals,
+    getCommsShip,
+    getCommsState,
+    getRecentCommsMessages,
+    humanMessageTimestamp,
+    toStringValue,
+  } from "./commsData.js";
+
+  let broadcastText = "";
+  let iffCode = "";
+  let spoofed = false;
+  let emconLevel = 0;
+  let feedback = "";
+
+  $: ship = getCommsShip($gameState);
+  $: comms = getCommsState(ship);
+  $: autoComms = getAutoCommsState(ship);
+  $: contacts = getCommsContacts(ship);
+  $: proposals = getCommsProposals(ship);
+  $: recentMessages = getRecentCommsMessages(ship);
+  $: cpuAssistTier = $tier === "cpu-assist";
+  $: if (!$selectedCommsTargetId && contacts.length) selectedCommsTargetId.set(contacts[0].id);
+  $: if (!iffCode) iffCode = toStringValue(comms.transponder_code, "CIVILIAN");
+  $: spoofed = Boolean(comms.is_spoofed);
+  $: emconLevel = emconLevel || emconLevelFromShip(ship);
+
+  async function setTransponder(enabled?: boolean) {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("set_transponder", {
+        enabled: enabled ?? Boolean(comms.transponder_enabled),
+        code: iffCode,
+        spoofed,
+      });
+      feedback = "Transponder updated";
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Transponder update failed";
+    }
+  }
+
+  async function hail() {
+    if (!$selectedCommsTargetId) return;
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("hail_contact", { target: $selectedCommsTargetId });
+      feedback = `Hailing ${$selectedCommsTargetId}`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Hail failed";
+    }
+  }
+
+  async function broadcast() {
+    if (!broadcastText.trim()) return;
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("broadcast_message", { message: broadcastText.trim() });
+      feedback = "Broadcast sent";
+      broadcastText = "";
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Broadcast failed";
+    }
+  }
+
+  async function toggleDistress() {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("set_distress", { enabled: !Boolean(comms.distress_active) });
+      feedback = Boolean(comms.distress_active) ? "Distress beacon cancelled" : "Distress beacon activated";
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Distress command failed";
+    }
+  }
+
+  async function applyEmcon() {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("set_emcon", { enabled: emconLevel > 0 });
+      feedback = emconLevel > 0 ? `EMCON L${emconLevel}` : "EMCON released";
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "EMCON update failed";
+    }
+  }
+
+  async function toggleAutoComms(enabled: boolean) {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand(enabled ? "enable_auto_comms" : "disable_auto_comms", {});
+      feedback = enabled ? "Auto-comms enabled" : "Auto-comms disabled";
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Auto-comms command failed";
+    }
+  }
+
+  async function reviewProposal(proposalId: string, approve: boolean) {
+    try {
+      await wsClient.sendShipCommand(approve ? "approve_comms" : "deny_comms", { proposal_id: proposalId });
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Proposal review failed";
+    }
+  }
+</script>
+
+<Panel title="Comms Control" domain="comms" priority={cpuAssistTier ? "primary" : "secondary"} className="comms-control-panel">
+  <div class="shell">
+    <section class="status-card">
+      <div class="head">
+        <span>Status</span>
+        <strong>{toStringValue(comms.status, "offline").toUpperCase()}</strong>
+      </div>
+      <div class="meta">
+        <span>Power {Number(comms.radio_power ?? 0).toFixed(0)} W</span>
+        <span>Range {Number(comms.radio_range ?? 0).toLocaleString()}</span>
+      </div>
+    </section>
+
+    {#if cpuAssistTier}
+      <section class="proposal-panel">
+        <div class="head">
+          <span>Auto-Comms</span>
+          <strong>{Boolean(autoComms.enabled) ? "ENABLED" : "DISABLED"}</strong>
+        </div>
+        <div class="toggle-row">
+          <button class:active={Boolean(autoComms.enabled)} type="button" on:click={() => toggleAutoComms(true)}>ENABLE</button>
+          <button class:active={!Boolean(autoComms.enabled)} type="button" on:click={() => toggleAutoComms(false)}>DISABLE</button>
+        </div>
+        <div class="policy">Policy {toStringValue(autoComms.policy, "open_comms").replaceAll("_", " ").toUpperCase()}</div>
+        {#if proposals.length === 0}
+          <div class="empty">No pending comms approvals.</div>
+        {:else}
+          {#each proposals as proposal}
+            <div class="proposal-card">
+              <div class="proposal-head">
+                <strong>{proposal.action.replaceAll("_", " ").toUpperCase()}</strong>
+                <span>{Math.round(proposal.confidence * 100)}%</span>
+              </div>
+              <div class="proposal-body">{proposal.reason}</div>
+              <div class="proposal-actions">
+                <button type="button" on:click={() => reviewProposal(proposal.proposalId, true)}>APPROVE</button>
+                <button class="secondary" type="button" on:click={() => reviewProposal(proposal.proposalId, false)}>DENY</button>
+              </div>
+            </div>
+          {/each}
+        {/if}
+      </section>
+    {/if}
+
+    <section class="transponder-card">
+      <div class="head">
+        <span>Transponder</span>
+        <strong>{Boolean(comms.transponder_active) ? "ACTIVE" : "QUIET"}</strong>
+      </div>
+      <div class="toggle-row">
+        <button class:active={Boolean(comms.transponder_enabled)} type="button" on:click={() => setTransponder(true)}>ON</button>
+        <button class:active={!Boolean(comms.transponder_enabled)} type="button" on:click={() => setTransponder(false)}>OFF</button>
+      </div>
+      <label class="field">
+        <span>IFF / Spoof Code</span>
+        <input bind:value={iffCode} maxlength="24" placeholder="CIVILIAN" />
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" bind:checked={spoofed} />
+        <span>Broadcast spoofed identity</span>
+      </label>
+      <button type="button" on:click={() => setTransponder()}>APPLY IDENTITY</button>
+    </section>
+
+    <section class="radio-card">
+      <div class="head">
+        <span>Radio Hail</span>
+        <strong>{$selectedCommsTargetId || "NO TARGET"}</strong>
+      </div>
+      <label class="field">
+        <span>Contact</span>
+        <select bind:value={$selectedCommsTargetId}>
+          <option value="">Select contact</option>
+          {#each contacts as contact}
+            <option value={contact.id}>{contact.id} · {contact.classification}</option>
+          {/each}
+        </select>
+      </label>
+      <button type="button" disabled={!$selectedCommsTargetId} on:click={hail}>HAIL CONTACT</button>
+    </section>
+
+    <section class="broadcast-card">
+      <div class="head">
+        <span>Broadcast</span>
+        <strong>{broadcastText.length}/280</strong>
+      </div>
+      <textarea bind:value={broadcastText} rows="4" maxlength="280" placeholder="All stations, stand by for broadcast..."></textarea>
+      <button type="button" disabled={!broadcastText.trim()} on:click={broadcast}>SEND BROADCAST</button>
+    </section>
+
+    <section class="emission-card">
+      <div class="head">
+        <span>Emission Control</span>
+        <strong>{emconLevel > 0 ? `L${emconLevel}` : "OPEN"}</strong>
+      </div>
+      <label class="field">
+        <span>EMCON Level</span>
+        <select bind:value={emconLevel} on:change={applyEmcon}>
+          {#each [0, 1, 2, 3, 4, 5] as level}
+            <option value={level}>{level === 0 ? "0 · OPEN" : `${level} · LOW EMISSION`}</option>
+          {/each}
+        </select>
+      </label>
+      <button class:alert={Boolean(comms.distress_active)} type="button" on:click={toggleDistress}>
+        {Boolean(comms.distress_active) ? "CANCEL DISTRESS" : "ACTIVATE DISTRESS"}
+      </button>
+    </section>
+
+    <section class="log-card">
+      <div class="head">
+        <span>Recent Traffic</span>
+        <strong>{recentMessages.length}</strong>
+      </div>
+      {#if recentMessages.length === 0}
+        <div class="empty">No recent radio traffic.</div>
+      {:else}
+        <div class="log-list">
+          {#each recentMessages.slice().reverse() as message}
+            <div class="log-row">
+              <span>{humanMessageTimestamp(Number(message.time ?? message.timestamp ?? 0))}</span>
+              <strong>{toStringValue(message.from, "SYS")}</strong>
+              <span>{toStringValue(message.message, "--")}</span>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </section>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .status-card,
+  .proposal-panel,
+  .transponder-card,
+  .radio-card,
+  .broadcast-card,
+  .emission-card,
+  .log-card,
+  .feedback {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .head,
+  .meta,
+  .proposal-head,
+  .proposal-actions,
+  .toggle-row,
+  .log-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  .field {
+    display: grid;
+    gap: 6px;
+  }
+
+  .field span,
+  .meta,
+  .policy,
+  .proposal-body,
+  .log-row,
+  .empty,
+  .feedback,
+  .checkbox span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .checkbox {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  input,
+  select,
+  textarea,
+  button {
+    width: 100%;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  .toggle-row button {
+    flex: 1;
+  }
+
+  button.active {
+    border-color: rgba(0, 255, 136, 0.4);
+    background: rgba(0, 255, 136, 0.08);
+  }
+
+  button.secondary {
+    color: var(--text-secondary);
+  }
+
+  button.alert {
+    border-color: rgba(255, 68, 68, 0.4);
+    background: rgba(255, 68, 68, 0.12);
+  }
+
+  .log-list {
+    display: grid;
+    gap: 6px;
+    max-height: 180px;
+    overflow: auto;
+  }
+
+  .log-row {
+    display: grid;
+    grid-template-columns: 56px 56px 1fr;
+    align-items: start;
+    gap: 8px;
+    text-transform: none;
+    letter-spacing: normal;
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+</style>

--- a/gui-svelte/src/components/comms/StationChat.svelte
+++ b/gui-svelte/src/components/comms/StationChat.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { humanMessageTimestamp, normalizeStationMessages, type StationMessageRow } from "./commsData.js";
+
+  const STATION_OPTIONS = ["all", "helm", "tactical", "ops", "engineering", "science", "comms", "captain", "fleet_commander"];
+  const STATION_COLORS: Record<string, string> = {
+    all: "var(--status-info)",
+    helm: "#50a6ff",
+    tactical: "#ff6666",
+    ops: "#6be0a8",
+    engineering: "#ffb26a",
+    science: "#69d7ff",
+    comms: "#d29dff",
+    captain: "#ffd66b",
+    fleet_commander: "#ff8ece",
+  };
+
+  let messages: StationMessageRow[] = [];
+  let draft = "";
+  let target = "all";
+  let latestId = 0;
+  let pollHandle: number | null = null;
+
+  onMount(() => {
+    void refresh();
+    pollHandle = window.setInterval(() => void refresh(), 1000);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  async function refresh() {
+    try {
+      const response = await wsClient.send("get_station_messages", { since_id: latestId });
+      const incoming = normalizeStationMessages(response);
+      if (!incoming.length) return;
+      messages = [...messages, ...incoming].slice(-120);
+      latestId = messages[messages.length - 1]?.id ?? latestId;
+    } catch {
+      // best effort
+    }
+  }
+
+  async function sendMessage() {
+    if (!draft.trim()) return;
+    try {
+      await wsClient.send("station_message", { to: target, text: draft.trim() });
+      draft = "";
+      await refresh();
+    } catch {
+      // best effort
+    }
+  }
+</script>
+
+<Panel title="Station Chat" domain="comms" priority="secondary" className="station-chat-panel">
+  <div class="shell">
+    <div class="messages">
+      {#if messages.length === 0}
+        <div class="empty">No station messages yet.</div>
+      {:else}
+        {#each messages as message}
+          <div class="message-row">
+            <span class="time">{humanMessageTimestamp(message.timestamp)}</span>
+            <span class="badge" style={`--badge-color:${STATION_COLORS[message.fromStation] ?? "#888899"};`}>
+              {message.fromStation.toUpperCase()}
+            </span>
+            <div class="text">
+              {#if message.to !== "all"}
+                <strong>{message.to.toUpperCase()}</strong>
+              {/if}
+              {message.text}
+            </div>
+          </div>
+        {/each}
+      {/if}
+    </div>
+
+    <div class="composer">
+      <select bind:value={target}>
+        {#each STATION_OPTIONS as option}
+          <option value={option}>{option.toUpperCase()}</option>
+        {/each}
+      </select>
+      <input
+        bind:value={draft}
+        maxlength="500"
+        placeholder="Coordinate with your crew"
+        on:keydown={(event) => {
+          if (event.key === "Enter" && !event.shiftKey) {
+            event.preventDefault();
+            void sendMessage();
+          }
+        }}
+      />
+      <button type="button" disabled={!draft.trim()} on:click={sendMessage}>SEND</button>
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+    min-height: 0;
+  }
+
+  .messages {
+    display: grid;
+    gap: 6px;
+    max-height: 320px;
+    overflow: auto;
+  }
+
+  .message-row {
+    display: grid;
+    grid-template-columns: 54px 118px 1fr;
+    gap: 8px;
+    align-items: start;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .time,
+  .empty,
+  .text,
+  .composer select,
+  .composer input,
+  .composer button {
+    font-size: var(--font-size-xs);
+  }
+
+  .time,
+  .empty,
+  .text {
+    color: var(--text-secondary);
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 24px;
+    padding: 0 8px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--badge-color) 50%, transparent);
+    color: var(--badge-color);
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.08em;
+  }
+
+  .text strong {
+    margin-right: 6px;
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+  }
+
+  .composer {
+    display: grid;
+    grid-template-columns: 110px 1fr 90px;
+    gap: 8px;
+  }
+
+  .composer select,
+  .composer input,
+  .composer button {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+  }
+
+  @media (max-width: 640px) {
+    .message-row {
+      grid-template-columns: 1fr;
+    }
+
+    .composer {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/gui-svelte/src/components/comms/commsData.ts
+++ b/gui-svelte/src/components/comms/commsData.ts
@@ -1,0 +1,177 @@
+import type { JsonMap } from "../helm/helmData.js";
+import {
+  asRecord,
+  clamp,
+  extractShipState,
+  formatDistance,
+  formatDuration,
+  toNumber,
+  toStringValue,
+} from "../helm/helmData.js";
+import { getTacticalContacts, type TacticalContact } from "../tactical/tacticalData.js";
+
+export interface CommsProposal {
+  proposalId: string;
+  action: string;
+  target: string;
+  reason: string;
+  confidence: number;
+  params: JsonMap;
+}
+
+export interface ChoiceOption {
+  optionId: string;
+  label: string;
+  description: string;
+}
+
+export interface CommsChoice {
+  choiceId: string;
+  contactId: string;
+  prompt: string;
+  timeout: number | null;
+  presentedAt: number | null;
+  defaultOption: string;
+  options: ChoiceOption[];
+}
+
+export interface StationMessageRow {
+  id: number;
+  fromStation: string;
+  fromPlayer: string;
+  to: string;
+  text: string;
+  timestamp: number;
+}
+
+export function getCommsShip(gameState: JsonMap | null | undefined): JsonMap {
+  return extractShipState(gameState);
+}
+
+export function getCommsState(ship: JsonMap): JsonMap {
+  return asRecord(ship.comms) ?? {};
+}
+
+export function getAutoCommsState(ship: JsonMap): JsonMap {
+  return asRecord(ship.auto_comms) ?? {};
+}
+
+export function getCommsContacts(ship: JsonMap): TacticalContact[] {
+  return getTacticalContacts(ship);
+}
+
+export function getRecentCommsMessages(ship: JsonMap): JsonMap[] {
+  const comms = getCommsState(ship);
+  const source = Array.isArray(comms.recent_messages) ? comms.recent_messages : [];
+  return source.map((item) => asRecord(item)).filter((item): item is JsonMap => Boolean(item));
+}
+
+export function getCommsProposals(ship: JsonMap): CommsProposal[] {
+  const autoComms = getAutoCommsState(ship);
+  const source = Array.isArray(autoComms.proposals) ? (autoComms.proposals as unknown[]) : [];
+  return source
+    .map((item) => asRecord(item))
+    .filter((item): item is JsonMap => Boolean(item))
+    .map((item) => ({
+      proposalId: toStringValue(item.proposal_id),
+      action: toStringValue(item.action, "proposal"),
+      target: toStringValue(item.target, "contact"),
+      reason: toStringValue(item.reason, "Awaiting approval"),
+      confidence: clamp(toNumber(item.confidence, 0), 0, 1),
+      params: asRecord(item.params) ?? {},
+    }));
+}
+
+export function normalizeCommsChoices(value: unknown): CommsChoice[] {
+  const record = asRecord(value) ?? {};
+  const source = Array.isArray(record.choices) ? (record.choices as unknown[]) : [];
+  return source
+    .map((item) => asRecord(item))
+    .filter((item): item is JsonMap => Boolean(item))
+    .map((item) => ({
+      choiceId: toStringValue(item.choice_id),
+      contactId: toStringValue(item.contact_id, "unknown"),
+      prompt: toStringValue(item.prompt, "Incoming message"),
+      timeout: Number.isFinite(toNumber(item.timeout, Number.NaN)) ? toNumber(item.timeout, Number.NaN) : null,
+      presentedAt: Number.isFinite(toNumber(item.presented_at, Number.NaN)) ? toNumber(item.presented_at, Number.NaN) : null,
+      defaultOption: toStringValue(item.default_option),
+      options: (Array.isArray(item.options) ? item.options : [])
+        .map((option) => asRecord(option))
+        .filter((option): option is JsonMap => Boolean(option))
+        .map((option) => ({
+          optionId: toStringValue(option.option_id),
+          label: toStringValue(option.label, "Option"),
+          description: toStringValue(option.description),
+        })),
+    }));
+}
+
+export function normalizeStationMessages(value: unknown): StationMessageRow[] {
+  const record = asRecord(value) ?? {};
+  const source = Array.isArray(record.messages) ? (record.messages as unknown[]) : [];
+  return source
+    .map((item) => asRecord(item))
+    .filter((item): item is JsonMap => Boolean(item))
+    .map((item) => ({
+      id: toNumber(item.id, 0),
+      fromStation: toStringValue(item.from_station, "unknown"),
+      fromPlayer: toStringValue(item.from_player, ""),
+      to: toStringValue(item.to, "all"),
+      text: toStringValue(item.text),
+      timestamp: toNumber(item.timestamp, 0),
+    }));
+}
+
+export function recommendChoice(choice: CommsChoice): ChoiceOption | null {
+  if (!choice.options.length) return null;
+  if (choice.defaultOption) {
+    const defaultMatch = choice.options.find((option) => option.optionId === choice.defaultOption);
+    if (defaultMatch) return defaultMatch;
+  }
+
+  const positive = choice.options.find((option) => {
+    const text = `${option.label} ${option.description}`.toLowerCase();
+    return ["identify", "accept", "reply", "acknowledge", "stand down", "assist"].some((token) => text.includes(token));
+  });
+
+  return positive ?? choice.options[0] ?? null;
+}
+
+export function commsModeClass(ship: JsonMap): "active" | "silent" | "emcon" | "distress" | "offline" {
+  const comms = getCommsState(ship);
+  const status = toStringValue(comms.status, "offline").toLowerCase();
+  if (status.includes("distress")) return "distress";
+  if (status.includes("emcon")) return "emcon";
+  if (status.includes("silent")) return "silent";
+  if (status.includes("active")) return "active";
+  return "offline";
+}
+
+export function emconLevelFromShip(ship: JsonMap): number {
+  const ecm = asRecord(ship.ecm) ?? {};
+  return Boolean(ecm.emcon_active) ? 5 : 0;
+}
+
+export function formatChoiceCountdown(choice: CommsChoice, nowSeconds: number): { remaining: number; progress: number } {
+  if (choice.timeout == null || choice.presentedAt == null) {
+    return { remaining: 0, progress: 1 };
+  }
+  const elapsed = Math.max(0, nowSeconds - choice.presentedAt);
+  const remaining = Math.max(0, choice.timeout - elapsed);
+  const progress = choice.timeout > 0 ? clamp(remaining / choice.timeout, 0, 1) : 0;
+  return { remaining, progress };
+}
+
+export function humanMessageTimestamp(timestamp: number): string {
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return "--:--";
+  return new Date(timestamp * 1000).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function formatSignalDistance(distance: number): string {
+  return formatDistance(distance);
+}
+
+export { asRecord, formatDistance, formatDuration, toNumber, toStringValue };

--- a/gui-svelte/src/components/engineering/EngineeringControlPanel.svelte
+++ b/gui-svelte/src/components/engineering/EngineeringControlPanel.svelte
@@ -1,0 +1,399 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    formatDriveLimit,
+    formatFuelBurnRate,
+    formatFuelTime,
+    formatSpeed,
+    getEngineeringProposals,
+    getEngineeringShip,
+    getEngineeringState,
+    getReactorSummary,
+    getThermalState,
+    toNumber,
+    toStringValue,
+  } from "./engineeringData.js";
+
+  const RADIATOR_PANELS = ["P1", "P2", "P3", "S1", "S2", "S3"];
+
+  let reactorDraft = 0;
+  let driveDraft = 100;
+  let reactorTimer: number | null = null;
+  let driveTimer: number | null = null;
+  let editMode = "";
+  let feedback = "";
+  let showVentConfirm = false;
+  let pending = false;
+
+  $: ship = getEngineeringShip($gameState);
+  $: engineering = getEngineeringState(ship);
+  $: thermal = getThermalState(ship);
+  $: summary = getReactorSummary(ship);
+  $: proposals = getEngineeringProposals(ship);
+  $: cpuAssistTier = $tier === "cpu-assist";
+  $: arcadeTier = $tier === "arcade";
+  $: radiatorsDeployed = Boolean(engineering.radiators_deployed);
+  $: radiatorPriority = toStringValue(engineering.radiator_priority, "balanced");
+  $: ventAvailable = Boolean(engineering.emergency_vent_available ?? true);
+  $: ventActive = Boolean(engineering.emergency_vent_active);
+  $: if (editMode !== "reactor") reactorDraft = Math.round(summary.output * 100);
+  $: if (editMode !== "drive") driveDraft = Math.round(summary.driveLimit * 100);
+
+  function scheduleCommand(kind: "reactor" | "drive", value: number) {
+    editMode = kind;
+    if (kind === "reactor") {
+      reactorDraft = value;
+      if (reactorTimer != null) window.clearTimeout(reactorTimer);
+      reactorTimer = window.setTimeout(async () => {
+        await sendCommand("set_reactor_output", { output: value });
+        editMode = "";
+      }, 60);
+      return;
+    }
+
+    driveDraft = value;
+    if (driveTimer != null) window.clearTimeout(driveTimer);
+    driveTimer = window.setTimeout(async () => {
+      await sendCommand("throttle_drive", { limit: value });
+      editMode = "";
+    }, 60);
+  }
+
+  async function sendCommand(command: string, params: Record<string, unknown>) {
+    pending = true;
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand(command, params);
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : `${command} failed`;
+    } finally {
+      pending = false;
+    }
+  }
+
+  async function setRadiators(deployed: boolean) {
+    await sendCommand("manage_radiators", { deployed });
+  }
+
+  async function setRadiatorPriority(priority: string) {
+    await sendCommand("manage_radiators", { priority });
+  }
+
+  async function approveProposal(proposalId: string) {
+    await sendCommand("approve_engineering", { proposal_id: proposalId });
+  }
+
+  async function denyProposal(proposalId: string) {
+    await sendCommand("deny_engineering", { proposal_id: proposalId });
+  }
+
+  async function triggerEmergencyVent() {
+    showVentConfirm = false;
+    await sendCommand("emergency_vent", { confirm: true });
+  }
+</script>
+
+<Panel title="Engineering Control" domain="power" priority={cpuAssistTier ? "primary" : "secondary"} className="engineering-control-panel">
+  <div class="shell">
+    {#if cpuAssistTier}
+      <section class="proposal-list">
+        <div class="assist-note">
+          <strong>{toStringValue(engineering.status, "AUTO-ENGINEERING").toUpperCase()}</strong>
+          <span>{proposals.length} pending proposal{proposals.length === 1 ? "" : "s"}</span>
+        </div>
+
+        {#if proposals.length === 0}
+          <div class="empty-card">
+            <strong>Stable</strong>
+            <span>Auto-ops is holding reactor, radiators, and drive governor inside limits.</span>
+          </div>
+        {:else}
+          {#each proposals as proposal}
+            <div class="proposal-card">
+              <div class="proposal-head">
+                <strong>{proposal.action.replaceAll("_", " ").toUpperCase()}</strong>
+                <span>{Math.round(proposal.confidence * 100)}%</span>
+              </div>
+              <div class="proposal-target">{proposal.target.toUpperCase()}</div>
+              <div class="proposal-reason">{proposal.reason}</div>
+              <div class="proposal-actions">
+                <button type="button" on:click={() => approveProposal(proposal.proposalId)}>APPROVE</button>
+                <button class="secondary" type="button" on:click={() => denyProposal(proposal.proposalId)}>DENY</button>
+              </div>
+            </div>
+          {/each}
+        {/if}
+      </section>
+    {:else}
+      <section class="control-card">
+        <div class="row-head">
+          <span>Reactor Output</span>
+          <strong>{reactorDraft}%</strong>
+        </div>
+        <input type="range" min="0" max="100" step="1" value={reactorDraft} on:input={(event) => scheduleCommand("reactor", Number((event.currentTarget as HTMLInputElement).value))} />
+      </section>
+
+      <section class="control-card">
+        <div class="row-head">
+          <span>Drive Limit</span>
+          <strong>{driveDraft}%</strong>
+        </div>
+        <input type="range" min="0" max="100" step="1" value={driveDraft} on:input={(event) => scheduleCommand("drive", Number((event.currentTarget as HTMLInputElement).value))} />
+      </section>
+
+      <section class="fuel-card">
+        <div class="row-head">
+          <span>Fuel Monitor</span>
+          <strong>{summary.fuelPercent.toFixed(0)}%</strong>
+        </div>
+        <div class="track">
+          <div class="fill fuel" style={`width:${summary.fuelPercent.toFixed(0)}%;`}></div>
+        </div>
+        <div class="detail-grid">
+          <div><span>Burn</span><strong>{formatFuelBurnRate(summary.burnRate)}</strong></div>
+          <div><span>Delta-V</span><strong>{formatSpeed(summary.deltaV)}</strong></div>
+          <div><span>Limit</span><strong>{formatDriveLimit(summary.driveLimit)}</strong></div>
+          <div><span>Remaining</span><strong>{formatFuelTime(summary.timeRemaining)}</strong></div>
+        </div>
+      </section>
+
+      <section class="radiator-card">
+        <div class="row-head">
+          <span>Radiator Panels</span>
+          <strong>{radiatorsDeployed ? "DEPLOYED" : "RETRACTED"}</strong>
+        </div>
+        <div class="panel-grid">
+          {#each RADIATOR_PANELS as panelId}
+            <button
+              type="button"
+              class:active={radiatorsDeployed}
+              on:click={() => setRadiators(!radiatorsDeployed)}
+            >
+              {panelId}
+            </button>
+          {/each}
+        </div>
+        <div class="priority-row">
+          {#each ["balanced", "cooling", "stealth"] as priority}
+            <button class:selected={radiatorPriority === priority} type="button" on:click={() => setRadiatorPriority(priority)}>
+              {priority.replaceAll("_", " ").toUpperCase()}
+            </button>
+          {/each}
+        </div>
+      </section>
+
+      <section class="vent-card">
+        <div class="row-head">
+          <span>Emergency Vent</span>
+          <strong class:warning={toNumber(thermal.temperature_percent) >= 70} class:critical={toNumber(thermal.temperature_percent) >= 90}>
+            {ventActive ? "ACTIVE" : ventAvailable ? "ARMED" : "SPENT"}
+          </strong>
+        </div>
+        <button
+          type="button"
+          class="vent-button"
+          disabled={!ventAvailable || ventActive || pending}
+          on:click={() => showVentConfirm = true}
+        >
+          {ventActive ? "VENTING..." : arcadeTier ? "VENT NOW" : "EMERGENCY VENT"}
+        </button>
+      </section>
+    {/if}
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+
+  {#if showVentConfirm}
+    <div class="modal-backdrop">
+      <div class="modal">
+        <strong>Confirm Coolant Vent</strong>
+        <p>This is irreversible and will permanently dump coolant reserves.</p>
+        <div class="modal-actions">
+          <button type="button" on:click={triggerEmergencyVent}>CONFIRM VENT</button>
+          <button class="secondary" type="button" on:click={() => showVentConfirm = false}>CANCEL</button>
+        </div>
+      </div>
+    </div>
+  {/if}
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .control-card,
+  .fuel-card,
+  .radiator-card,
+  .vent-card,
+  .proposal-card,
+  .assist-note,
+  .empty-card {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent);
+  }
+
+  .proposal-list {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .row-head,
+  .proposal-head,
+  .detail-grid {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .detail-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .detail-grid span,
+  .row-head span,
+  .proposal-target,
+  .proposal-reason,
+  .assist-note span,
+  .empty-card span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .warning {
+    color: var(--status-warning);
+  }
+
+  .critical {
+    color: var(--status-critical);
+  }
+
+  input[type="range"] {
+    width: 100%;
+  }
+
+  .track {
+    height: 10px;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+    overflow: hidden;
+  }
+
+  .fill {
+    height: 100%;
+  }
+
+  .fill.fuel {
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.35), var(--tier-accent));
+  }
+
+  .panel-grid,
+  .priority-row,
+  .proposal-actions {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-xs);
+  }
+
+  .panel-grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  button {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  button.active,
+  button.selected {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  button.secondary {
+    color: var(--text-secondary);
+  }
+
+  .vent-button {
+    background: rgba(255, 68, 68, 0.12);
+    border-color: rgba(255, 68, 68, 0.45);
+    color: var(--status-critical);
+  }
+
+  .proposal-target {
+    color: var(--tier-accent);
+  }
+
+  .feedback {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-xs);
+    color: var(--status-warning);
+    border: 1px solid rgba(255, 170, 0, 0.25);
+    background: rgba(255, 170, 0, 0.08);
+  }
+
+  .modal-backdrop {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: rgba(4, 5, 10, 0.76);
+  }
+
+  .modal {
+    display: grid;
+    gap: var(--space-sm);
+    width: min(340px, calc(100% - 24px));
+    padding: 14px;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 68, 68, 0.35);
+    background: var(--bg-panel);
+  }
+
+  .modal p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 0.82rem;
+  }
+
+  .modal-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-sm);
+  }
+
+  @media (max-width: 760px) {
+    .panel-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+</style>

--- a/gui-svelte/src/components/engineering/PowerAllocationPanel.svelte
+++ b/gui-svelte/src/components/engineering/PowerAllocationPanel.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    POWER_CATEGORY_ORDER,
+    POWER_CATEGORY_TO_BUS,
+    asRecord,
+    formatKw,
+    getDrawProfileBuses,
+    getEngineeringShip,
+    getPowerCategoryWeights,
+    translateCategoryWeightsToBusAllocation,
+    toNumber,
+    type PowerCategory,
+  } from "./engineeringData.js";
+
+  let profile: Record<string, unknown> | null = null;
+  let pollHandle: number | null = null;
+  let dragging: PowerCategory | null = null;
+  let dirty = false;
+  let feedback = "";
+  let weights: Record<PowerCategory, number> = {
+    propulsion: 0.25,
+    weapons: 0.15,
+    sensors: 0.15,
+    comms: 0.05,
+    life_support: 0.05,
+  };
+
+  $: ship = getEngineeringShip($gameState);
+  $: sourceWeights = getPowerCategoryWeights(ship);
+  $: buses = getDrawProfileBuses(asRecord(profile));
+  $: cpuAssistTier = $tier === "cpu-assist";
+  $: if (!dirty && dragging == null) weights = { ...sourceWeights };
+
+  onMount(() => {
+    void refresh();
+    pollHandle = window.setInterval(() => void refresh(), 3000);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  async function refresh() {
+    if (cpuAssistTier || document.hidden) return;
+    try {
+      const response = await wsClient.sendShipCommand("get_draw_profile", {});
+      const record = asRecord(response);
+      profile = (asRecord(record?.data) ?? record) as Record<string, unknown>;
+    } catch {
+      // best effort
+    }
+  }
+
+  function setDraft(category: PowerCategory, value: number) {
+    dirty = true;
+    weights = {
+      ...weights,
+      [category]: Math.max(0, Math.min(1, value / 100)),
+    };
+  }
+
+  async function commit(category: PowerCategory) {
+    dragging = null;
+    dirty = true;
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("set_power_allocation", {
+        allocation: translateCategoryWeightsToBusAllocation(weights),
+      });
+      feedback = `${category.replaceAll("_", " ")} allocation transmitted`;
+      dirty = false;
+      void refresh();
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Allocation update failed";
+    }
+  }
+
+  function busInfo(category: PowerCategory) {
+    return asRecord(buses[POWER_CATEGORY_TO_BUS[category]]) ?? {};
+  }
+</script>
+
+<Panel title="Power Allocation" domain="power" priority={$tier === "manual" || $tier === "raw" ? "primary" : "secondary"} className="power-allocation-panel">
+  <div class="shell">
+    {#if cpuAssistTier}
+      <div class="assist-note">Auto-ops manages live power allocation in CPU-ASSIST mode.</div>
+      {#each POWER_CATEGORY_ORDER as category}
+        <div class="readonly-card">
+          <div class="head">
+            <strong>{category.replaceAll("_", " ").toUpperCase()}</strong>
+            <span>{Math.round((sourceWeights[category] ?? 0) * 100)}%</span>
+          </div>
+          <div class="track">
+            <div class="fill" style={`width:${Math.round((sourceWeights[category] ?? 0) * 100)}%;`}></div>
+          </div>
+        </div>
+      {/each}
+    {:else}
+      {#each POWER_CATEGORY_ORDER as category}
+        {@const info = busInfo(category)}
+        <div class="alloc-card">
+          <div class="head">
+            <strong>{category.replaceAll("_", " ").toUpperCase()}</strong>
+            <span>{POWER_CATEGORY_TO_BUS[category].toUpperCase()}</span>
+          </div>
+          <div class="slider-row">
+            <input
+              type="range"
+              min="0"
+              max="100"
+              step="1"
+              value={Math.round((weights[category] ?? 0) * 100)}
+              on:mousedown={() => dragging = category}
+              on:touchstart={() => dragging = category}
+              on:input={(event) => setDraft(category, Number((event.currentTarget as HTMLInputElement).value))}
+              on:change={() => commit(category)}
+            />
+            <strong>{Math.round((weights[category] ?? 0) * 100)}%</strong>
+          </div>
+          <div class="bus-meta">
+            <span>Supply {formatKw(toNumber(info.available_kw))}</span>
+            <span>Demand {formatKw(toNumber(info.requested_kw))}</span>
+          </div>
+        </div>
+      {/each}
+      {#if feedback}
+        <div class="feedback">{feedback}</div>
+      {/if}
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .alloc-card,
+  .readonly-card,
+  .assist-note,
+  .feedback {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .head,
+  .bus-meta,
+  .slider-row {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .head span,
+  .bus-meta,
+  .assist-note,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  input[type="range"] {
+    flex: 1;
+  }
+
+  .track {
+    height: 10px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.35), var(--tier-accent));
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+</style>

--- a/gui-svelte/src/components/engineering/PowerDrawDisplay.svelte
+++ b/gui-svelte/src/components/engineering/PowerDrawDisplay.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { asRecord, formatKw, getDrawProfileBuses, toNumber } from "./engineeringData.js";
+
+  let root: HTMLDivElement;
+  let profile: Record<string, unknown> | null = null;
+  let intervalHandle: number | null = null;
+  let observer: IntersectionObserver | null = null;
+  let isVisible = true;
+
+  $: cpuAssistTier = $tier === "cpu-assist";
+  $: buses = Object.entries(getDrawProfileBuses(asRecord(profile)));
+  $: maxAxis = Math.max(
+    1,
+    ...buses.flatMap(([, bus]) => [toNumber(bus.available_kw), toNumber(bus.requested_kw)]),
+  );
+
+  onMount(() => {
+    if (typeof IntersectionObserver !== "undefined") {
+      observer = new IntersectionObserver((entries) => {
+        isVisible = entries.some((entry) => entry.isIntersecting);
+        if (isVisible) void refresh();
+      });
+      if (root) observer.observe(root);
+    }
+
+    void refresh();
+    intervalHandle = window.setInterval(() => void refresh(), 3000);
+
+    return () => {
+      observer?.disconnect();
+      if (intervalHandle != null) window.clearInterval(intervalHandle);
+    };
+  });
+
+  async function refresh() {
+    if (cpuAssistTier || !isVisible || document.hidden) return;
+    try {
+      const response = await wsClient.sendShipCommand("get_draw_profile", {});
+      const record = asRecord(response);
+      profile = (asRecord(record?.data) ?? record) as Record<string, unknown>;
+    } catch {
+      // best effort
+    }
+  }
+
+  function widthFor(value: number): string {
+    return `${Math.max(0, Math.min(100, (value / maxAxis) * 100)).toFixed(1)}%`;
+  }
+</script>
+
+<Panel title="Power Draw" domain="power" priority={$tier === "raw" ? "primary" : "secondary"} className="power-draw-panel">
+  <div bind:this={root} class="shell">
+    {#if cpuAssistTier}
+      <div class="assist">Auto-ops is managing power.</div>
+    {:else if buses.length === 0}
+      <div class="empty">No draw profile available.</div>
+    {:else}
+      {#each buses as [busName, bus]}
+        {@const supply = toNumber(bus.available_kw)}
+        {@const demand = toNumber(bus.requested_kw)}
+        {@const deficit = demand > supply}
+        <div class="bus-card" class:deficit={deficit}>
+          <div class="head">
+            <strong>{busName.toUpperCase()}</strong>
+            <span class:deficit>{formatKw(supply)} / {formatKw(demand)}</span>
+          </div>
+          <div class="overlay-track">
+            <div class="demand-outline" style={`width:${widthFor(demand)};`}></div>
+            <div class="supply-fill" style={`width:${widthFor(supply)};`}></div>
+          </div>
+          <div class="meta">
+            <span>Supply {formatKw(supply)}</span>
+            <span>Demand {formatKw(demand)}</span>
+          </div>
+        </div>
+      {/each}
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .bus-card,
+  .assist,
+  .empty {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .bus-card.deficit {
+    border-color: rgba(255, 68, 68, 0.35);
+    animation: deficit-pulse 0.8s ease-in-out infinite alternate;
+  }
+
+  .head,
+  .meta {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .head span,
+  .meta,
+  .assist,
+  .empty {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .head span.deficit {
+    color: var(--status-critical);
+  }
+
+  .overlay-track {
+    position: relative;
+    height: 14px;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+    overflow: hidden;
+  }
+
+  .demand-outline,
+  .supply-fill {
+    position: absolute;
+    inset-block: 2px;
+    left: 2px;
+    border-radius: 999px;
+  }
+
+  .demand-outline {
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .supply-fill {
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.3), var(--tier-accent));
+  }
+
+  @keyframes deficit-pulse {
+    from {
+      box-shadow: 0 0 0 rgba(255, 68, 68, 0);
+    }
+    to {
+      box-shadow: 0 0 12px rgba(255, 68, 68, 0.18);
+    }
+  }
+</style>

--- a/gui-svelte/src/components/engineering/SubsystemStatus.svelte
+++ b/gui-svelte/src/components/engineering/SubsystemStatus.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { getEngineeringShip, getSubsystemRows } from "./engineeringData.js";
+
+  $: ship = getEngineeringShip($gameState);
+  $: rows = getSubsystemRows(ship);
+  $: showExact = $tier === "raw" || $tier === "manual";
+
+  function healthClass(percent: number): string {
+    if (percent < 35) return "critical";
+    if (percent < 60) return "warning";
+    return "nominal";
+  }
+</script>
+
+<Panel title="Subsystem Status" domain="power" priority={$tier === "raw" ? "primary" : "secondary"} className="subsystem-status-panel">
+  <div class="stack">
+    {#each rows as row}
+      <div class="system-card">
+        <div class="head">
+          <strong>{row.label}</strong>
+          <span class={healthClass(row.healthPercent)}>{row.status.toUpperCase()}</span>
+        </div>
+        <div class="track">
+          <div class="fill {healthClass(row.healthPercent)}" style={`width:${row.healthPercent.toFixed(0)}%;`}></div>
+        </div>
+        <div class="meta">
+          {#if showExact}
+            <span>Health {row.healthPercent.toFixed(1)}%</span>
+            <span>Damage {row.damagePercent.toFixed(1)}%</span>
+          {:else}
+            <span>{healthClass(row.healthPercent).toUpperCase()}</span>
+            <span>{row.repairStatus.toUpperCase()}</span>
+          {/if}
+        </div>
+        {#if showExact}
+          <div class="detail">
+            <span>Heat {row.heatPercent.toFixed(0)}%</span>
+            <span>Repair {row.repairStatus.toUpperCase()}</span>
+          </div>
+        {/if}
+      </div>
+    {/each}
+  </div>
+</Panel>
+
+<style>
+  .stack {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .system-card {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .head,
+  .meta,
+  .detail {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .meta,
+  .detail,
+  .head span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .track {
+    height: 10px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .fill {
+    height: 100%;
+  }
+
+  .nominal,
+  .fill.nominal {
+    color: var(--status-nominal);
+    background: rgba(0, 255, 136, 0.82);
+  }
+
+  .warning,
+  .fill.warning {
+    color: var(--status-warning);
+    background: rgba(255, 170, 0, 0.88);
+  }
+
+  .critical,
+  .fill.critical {
+    color: var(--status-critical);
+    background: rgba(255, 68, 68, 0.9);
+  }
+</style>

--- a/gui-svelte/src/components/engineering/SystemToggles.svelte
+++ b/gui-svelte/src/components/engineering/SystemToggles.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { getEngineeringShip, getSystemToggleState } from "./engineeringData.js";
+
+  let pendingSystem = "";
+  let feedback = "";
+
+  $: ship = getEngineeringShip($gameState);
+  $: rows = getSystemToggleState(ship);
+  $: cpuAssistTier = $tier === "cpu-assist";
+
+  async function toggleSystem(systemId: string, enabled: boolean) {
+    pendingSystem = systemId;
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("toggle_system", {
+        system: systemId,
+        state: enabled ? 0 : 1,
+      });
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Toggle failed";
+    } finally {
+      pendingSystem = "";
+    }
+  }
+</script>
+
+<Panel title="System Toggles" domain="power" priority="secondary" className="system-toggles-panel">
+  <div class="shell">
+    {#each rows as row}
+      <div class="toggle-row">
+        <div class="meta">
+          <strong>{row.label}</strong>
+          <span>{row.status.toUpperCase()}</span>
+        </div>
+        {#if cpuAssistTier}
+          <div class:active={row.enabled} class="indicator">{row.enabled ? "ON" : "OFF"}</div>
+        {:else}
+          <button
+            type="button"
+            class:active={row.enabled}
+            disabled={pendingSystem === row.id}
+            on:click={() => toggleSystem(row.id, row.enabled)}
+          >
+            {row.enabled ? "POWER DOWN" : "POWER UP"}
+          </button>
+        {/if}
+      </div>
+    {/each}
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .toggle-row {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .meta {
+    display: grid;
+    gap: 4px;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .meta span,
+  .indicator,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .indicator,
+  button {
+    min-width: 100px;
+    text-align: center;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.03);
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .indicator.active,
+  button.active {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  .feedback {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 170, 0, 0.28);
+    background: rgba(255, 170, 0, 0.08);
+    color: var(--status-warning);
+  }
+</style>

--- a/gui-svelte/src/components/engineering/ThermalDisplay.svelte
+++ b/gui-svelte/src/components/engineering/ThermalDisplay.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import {
+    formatThermalStatus,
+    getEngineeringShip,
+    getEngineeringState,
+    getThermalBars,
+    getThermalState,
+    toNumber,
+    toStringValue,
+  } from "./engineeringData.js";
+
+  $: ship = getEngineeringShip($gameState);
+  $: thermal = getThermalState(ship);
+  $: engineering = getEngineeringState(ship);
+  $: bars = getThermalBars(ship);
+  $: hullTemperature = toNumber(thermal.hull_temperature);
+  $: maxTemperature = toNumber(thermal.max_temperature, 1);
+  $: warningTemperature = toNumber(thermal.warning_temperature);
+  $: netHeat = toNumber(thermal.net_heat_rate);
+  $: radiatorFactor = toNumber(thermal.radiator_factor, 1);
+  $: radiatorPriority = toStringValue(engineering.radiator_priority, "balanced").toUpperCase();
+  $: radiatorsDeployed = Boolean(engineering.radiators_deployed ?? (radiatorFactor > 1.05));
+  $: arcadeTier = $tier === "arcade";
+
+  function temperatureValue(id: string, current: number): string {
+    if (id === "radiators") return `${current.toFixed(1)} area`;
+    if (!Number.isFinite(current)) return "--";
+    return `${current.toFixed(current >= 1000 ? 0 : 1)} K`;
+  }
+</script>
+
+<Panel title="Thermal Display" domain="power" priority={$tier === "manual" || $tier === "raw" ? "primary" : "secondary"} className="thermal-display-panel">
+  <div class="stack">
+    <section class="summary">
+      <div>
+        <span class="label">Hull Temp</span>
+        <strong>{hullTemperature.toFixed(1)} K</strong>
+      </div>
+      <div>
+        <span class="label">Thermal State</span>
+        <strong class:warn={hullTemperature >= warningTemperature} class:critical={hullTemperature >= maxTemperature * 0.9}>{formatThermalStatus(thermal)}</strong>
+      </div>
+      <div>
+        <span class="label">Net Heat</span>
+        <strong class:cool={netHeat <= 0}>{netHeat >= 0 ? "+" : ""}{netHeat.toFixed(1)} kW</strong>
+      </div>
+    </section>
+
+    <section class="radiator-card">
+      <div class="radiator-head">
+        <div>
+          <div class="label">Radiators</div>
+          <strong>{radiatorsDeployed ? "DEPLOYED" : "RETRACTED"}</strong>
+        </div>
+        <div class="radiator-meta">
+          <span>{radiatorPriority}</span>
+          <span>x{radiatorFactor.toFixed(2)} cooling</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="bar-list">
+      {#each bars as bar}
+        <div class="bar-card">
+          <div class="bar-head">
+            <span>{bar.label}</span>
+            <strong class={bar.status}>{bar.percent.toFixed(0)}%</strong>
+          </div>
+          <div class="track">
+            <div class="fill {bar.status}" style={`width:${bar.percent.toFixed(0)}%;`}></div>
+          </div>
+          {#if !arcadeTier}
+            <div class="detail-row">
+              <span>{temperatureValue(bar.id, bar.current)}</span>
+              <span>{bar.status.toUpperCase()}</span>
+            </div>
+          {/if}
+        </div>
+      {/each}
+    </section>
+  </div>
+</Panel>
+
+<style>
+  .stack {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .summary,
+  .radiator-head,
+  .bar-head,
+  .detail-row {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .summary,
+  .radiator-card,
+  .bar-card {
+    padding: 10px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent);
+  }
+
+  .summary {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .bar-list {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .label,
+  .detail-row,
+  .radiator-meta {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .warn {
+    color: var(--status-warning);
+  }
+
+  .critical {
+    color: var(--status-critical);
+  }
+
+  .cool {
+    color: var(--status-nominal);
+  }
+
+  .track {
+    height: 10px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+    margin-top: 8px;
+  }
+
+  .fill {
+    height: 100%;
+  }
+
+  .fill.green,
+  strong.green {
+    background: rgba(0, 255, 136, 0.85);
+    color: var(--status-nominal);
+  }
+
+  .fill.yellow,
+  strong.yellow {
+    background: rgba(255, 210, 77, 0.88);
+    color: #ffd24d;
+  }
+
+  .fill.orange,
+  strong.orange {
+    background: rgba(255, 151, 71, 0.9);
+    color: #ff9747;
+  }
+
+  .fill.red,
+  strong.red {
+    background: rgba(255, 68, 68, 0.92);
+    color: var(--status-critical);
+  }
+
+  @media (max-width: 720px) {
+    .summary {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/gui-svelte/src/components/engineering/engineeringData.ts
+++ b/gui-svelte/src/components/engineering/engineeringData.ts
@@ -1,0 +1,259 @@
+import type { JsonMap } from "../helm/helmData.js";
+import {
+  asRecord,
+  clamp,
+  extractShipState,
+  formatDuration,
+  formatSpeed,
+  getSystem,
+  toNumber,
+  toStringValue,
+} from "../helm/helmData.js";
+
+export interface EngineeringProposal {
+  proposalId: string;
+  action: string;
+  target: string;
+  reason: string;
+  confidence: number;
+  params: JsonMap;
+}
+
+export interface SystemHealthRow {
+  id: string;
+  label: string;
+  healthPercent: number;
+  heatPercent: number;
+  damagePercent: number;
+  status: string;
+  repairStatus: string;
+  combinedFactor: number;
+}
+
+export const ENGINEERING_SYSTEM_LABELS: Record<string, string> = {
+  propulsion: "Drive",
+  reactor: "Reactor",
+  weapons: "Weapons",
+  sensors: "Sensors",
+  comms: "Comms",
+  radiators: "Radiators",
+  life_support: "Life Support",
+};
+
+export const POWER_CATEGORY_ORDER = [
+  "weapons",
+  "sensors",
+  "comms",
+  "life_support",
+  "propulsion",
+] as const;
+
+export type PowerCategory = typeof POWER_CATEGORY_ORDER[number];
+
+export const POWER_CATEGORY_TO_BUS: Record<PowerCategory, "primary" | "secondary" | "tertiary"> = {
+  propulsion: "primary",
+  weapons: "primary",
+  sensors: "primary",
+  comms: "secondary",
+  life_support: "tertiary",
+};
+
+export function getEngineeringShip(gameState: JsonMap | null | undefined): JsonMap {
+  return extractShipState(gameState);
+}
+
+export function getEngineeringState(ship: JsonMap): JsonMap {
+  return asRecord(ship.engineering) ?? getSystem(ship, "engineering");
+}
+
+export function getThermalState(ship: JsonMap): JsonMap {
+  return asRecord(ship.thermal) ?? getSystem(ship, "thermal");
+}
+
+export function getOpsState(ship: JsonMap): JsonMap {
+  return asRecord(ship.ops) ?? getSystem(ship, "ops");
+}
+
+export function getAutoEngineeringState(ship: JsonMap): JsonMap {
+  return asRecord(ship.auto_engineering) ?? getSystem(ship, "auto_engineering");
+}
+
+export function getFuelState(ship: JsonMap): JsonMap {
+  return asRecord(ship.fuel) ?? {};
+}
+
+export function getDrawProfileBuses(profile: JsonMap | null): Record<string, JsonMap> {
+  return (asRecord(profile?.buses) as Record<string, JsonMap> | null) ?? {};
+}
+
+export function getReactorSummary(ship: JsonMap): { output: number; driveLimit: number; fuelPercent: number; timeRemaining: number | null; burnRate: number; deltaV: number } {
+  const engineering = getEngineeringState(ship);
+  const fuel = getFuelState(ship);
+  return {
+    output: clamp(toNumber(engineering.reactor_output, 1), 0, 1),
+    driveLimit: clamp(toNumber(engineering.drive_limit, 1), 0, 1),
+    fuelPercent: clamp(toNumber(fuel.percent), 0, 100),
+    timeRemaining: Number.isFinite(toNumber(fuel.time_remaining, Number.NaN)) ? toNumber(fuel.time_remaining, Number.NaN) : null,
+    burnRate: toNumber(fuel.burn_rate, toNumber(engineering.fuel_burn_rate)),
+    deltaV: toNumber(ship.delta_v_remaining),
+  };
+}
+
+export function getPowerCategoryWeights(ship: JsonMap): Record<PowerCategory, number> {
+  const ops = getOpsState(ship);
+  const source = asRecord(ops.power_allocation) ?? {};
+  const defaults: Record<PowerCategory, number> = {
+    propulsion: 0.25,
+    weapons: 0.15,
+    sensors: 0.15,
+    comms: 0.05,
+    life_support: 0.05,
+  };
+
+  return {
+    propulsion: toNumber(source.propulsion, defaults.propulsion),
+    weapons: toNumber(source.weapons, defaults.weapons),
+    sensors: toNumber(source.sensors, defaults.sensors),
+    comms: toNumber(source.comms, defaults.comms),
+    life_support: toNumber(source.life_support, defaults.life_support),
+  };
+}
+
+export function translateCategoryWeightsToBusAllocation(weights: Record<PowerCategory, number>): Record<"primary" | "secondary" | "tertiary", number> {
+  const buses = {
+    primary: 0,
+    secondary: 0,
+    tertiary: 0,
+  };
+
+  for (const category of POWER_CATEGORY_ORDER) {
+    buses[POWER_CATEGORY_TO_BUS[category]] += Math.max(0, weights[category]);
+  }
+
+  const total = buses.primary + buses.secondary + buses.tertiary;
+  if (total <= 0) {
+    return { primary: 0.5, secondary: 0.3, tertiary: 0.2 };
+  }
+
+  return {
+    primary: buses.primary / total,
+    secondary: buses.secondary / total,
+    tertiary: buses.tertiary / total,
+  };
+}
+
+export function getSubsystemRows(ship: JsonMap): SystemHealthRow[] {
+  const report = asRecord(ship.subsystem_health) ?? {};
+  const subsystems = asRecord(report.subsystems) ?? {};
+  const ops = getOpsState(ship);
+  const repairTeams = Array.isArray(ops.repair_teams) ? ops.repair_teams : [];
+
+  const getRepairStatus = (subsystemId: string): string => {
+    const assigned = repairTeams
+      .map((team) => asRecord(team))
+      .find((team) => toStringValue(team?.assigned_subsystem) === subsystemId);
+    if (!assigned) return "idle";
+    return toStringValue(assigned.status, "assigned");
+  };
+
+  return Object.entries(ENGINEERING_SYSTEM_LABELS).map(([id, label]) => {
+    const row = asRecord(subsystems[id]) ?? {};
+    const healthPercent = clamp(toNumber(row.health_percent, 100), 0, 100);
+    const heatPercent = clamp(toNumber(row.heat_percent, 0), 0, 100);
+    return {
+      id,
+      label,
+      healthPercent,
+      heatPercent,
+      damagePercent: 100 - healthPercent,
+      status: toStringValue(row.status, "online"),
+      repairStatus: getRepairStatus(id),
+      combinedFactor: clamp(toNumber(row.combined_factor, 1), 0, 1),
+    };
+  });
+}
+
+export function getSystemToggleState(ship: JsonMap): Array<{ id: string; label: string; enabled: boolean; status: string }> {
+  const statuses = asRecord(ship.systems) ?? {};
+  const topLevel = ship;
+  const ids = ["propulsion", "reactor", "weapons", "sensors", "comms", "radiators", "life_support"];
+  return ids.map((id) => {
+    const statusValue = toStringValue(statuses[id], toStringValue(asRecord(topLevel[id])?.status, "online"));
+    const enabled = !["offline", "failed", "destroyed", "disabled", "unavailable"].includes(statusValue.toLowerCase());
+    return {
+      id,
+      label: ENGINEERING_SYSTEM_LABELS[id] ?? id,
+      enabled,
+      status: statusValue,
+    };
+  });
+}
+
+export function getThermalBars(ship: JsonMap): Array<{ id: string; label: string; percent: number; current: number; status: string }> {
+  const thermal = getThermalState(ship);
+  const subsystems = asRecord(asRecord(ship.subsystem_health)?.subsystems) ?? {};
+  const weaponHeat = toNumber(asRecord(subsystems.weapons)?.heat_percent, 0);
+  const radiatorHeat = toNumber(asRecord(subsystems.radiators)?.heat_percent, 0);
+  const reactorHeat = Math.max(
+    toNumber(asRecord(subsystems.reactor)?.heat_percent, 0),
+    clamp((toNumber(thermal.reactor_heat) / 100_000) * 100, 0, 100),
+  );
+  const driveHeat = Math.max(
+    toNumber(asRecord(subsystems.propulsion)?.heat_percent, 0),
+    clamp((toNumber(thermal.drive_heat) / 100_000) * 100, 0, 100),
+  );
+
+  return [
+    { id: "reactor", label: "Reactor", percent: reactorHeat, current: toNumber(thermal.reactor_heat), status: thermalStatusFromPercent(reactorHeat) },
+    { id: "drives", label: "Drives", percent: driveHeat, current: toNumber(thermal.drive_heat), status: thermalStatusFromPercent(driveHeat) },
+    { id: "weapons", label: "Weapons", percent: weaponHeat, current: weaponHeat, status: thermalStatusFromPercent(weaponHeat) },
+    { id: "radiators", label: "Radiators", percent: radiatorHeat, current: toNumber(thermal.radiator_effective_area), status: thermalStatusFromPercent(radiatorHeat) },
+  ];
+}
+
+export function getEngineeringProposals(ship: JsonMap): EngineeringProposal[] {
+  const autoEngineering = getAutoEngineeringState(ship);
+  const source = Array.isArray(autoEngineering.proposals) ? autoEngineering.proposals : [];
+  return source
+    .map((item) => asRecord(item))
+    .filter((item): item is JsonMap => Boolean(item))
+    .map((item) => ({
+      proposalId: toStringValue(item.proposal_id),
+      action: toStringValue(item.action, "proposal"),
+      target: toStringValue(item.target, "ship"),
+      reason: toStringValue(item.reason, "Awaiting approval"),
+      confidence: clamp(toNumber(item.confidence, 0), 0, 1),
+      params: asRecord(item.params) ?? {},
+    }));
+}
+
+export function thermalStatusFromPercent(percent: number): "green" | "yellow" | "orange" | "red" {
+  if (percent >= 85) return "red";
+  if (percent >= 65) return "orange";
+  if (percent >= 40) return "yellow";
+  return "green";
+}
+
+export function formatKw(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "--";
+  return `${value.toFixed(value >= 100 ? 0 : 1)} kW`;
+}
+
+export function formatThermalStatus(thermal: JsonMap): string {
+  return toStringValue(thermal.status, "nominal").toUpperCase();
+}
+
+export function formatFuelTime(seconds: number | null): string {
+  return seconds == null ? "--" : formatDuration(seconds);
+}
+
+export function formatDriveLimit(limit: number): string {
+  return `${Math.round(limit * 100)}%`;
+}
+
+export function formatFuelBurnRate(value: number): string {
+  if (!Number.isFinite(value)) return "--";
+  return `${value.toFixed(value >= 10 ? 1 : 2)} kg/s`;
+}
+
+export { asRecord, clamp, extractShipState, formatDuration, formatSpeed, toNumber, toStringValue };

--- a/gui-svelte/src/components/fleet/FleetFireControl.svelte
+++ b/gui-svelte/src/components/fleet/FleetFireControl.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { getTacticalContacts } from "../tactical/tacticalData.js";
+  import { getFleetShip } from "./fleetData.js";
+
+  let selectedTarget = "";
+  let fireMode: "salvo" | "sustained" | "cease" = "salvo";
+  let feedback = "";
+
+  $: ship = getFleetShip($gameState);
+  $: contacts = getTacticalContacts(ship);
+  $: if (!selectedTarget && contacts.length) selectedTarget = contacts[0].id;
+
+  async function designate() {
+    if (!selectedTarget) return;
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("fleet_target", { contact: selectedTarget });
+      feedback = `Fleet target set to ${selectedTarget}`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Target designation failed";
+    }
+  }
+
+  async function fire() {
+    feedback = "";
+    try {
+      if (fireMode === "cease") {
+        await wsClient.sendShipCommand("fleet_cease_fire", {});
+        feedback = "Fleet cease-fire issued";
+      } else {
+        await wsClient.sendShipCommand("fleet_fire", { volley: fireMode === "salvo" });
+        feedback = fireMode === "salvo" ? "Fleet salvo launched" : "Fleet sustained fire ordered";
+      }
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Fire control command failed";
+    }
+  }
+</script>
+
+<Panel title="Fleet Fire Control" domain="weapons" priority="secondary" className="fleet-fire-control-panel">
+  <div class="shell">
+    <label class="field">
+      <span>Target</span>
+      <select bind:value={selectedTarget}>
+        <option value="">Select contact</option>
+        {#each contacts as contact}
+          <option value={contact.id}>{contact.id} · {contact.classification}</option>
+        {/each}
+      </select>
+    </label>
+
+    <div class="button-row">
+      <button type="button" disabled={!selectedTarget} on:click={designate}>DESIGNATE</button>
+    </div>
+
+    <label class="field">
+      <span>Fire Mode</span>
+      <select bind:value={fireMode}>
+        <option value="salvo">SALVO</option>
+        <option value="sustained">SUSTAINED</option>
+        <option value="cease">CEASE</option>
+      </select>
+    </label>
+
+    <button class:danger={fireMode !== "cease"} type="button" on:click={fire}>
+      {fireMode === "cease" ? "CEASE FIRE" : "EXECUTE FIRE ORDER"}
+    </button>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .field,
+  .feedback {
+    display: grid;
+    gap: 6px;
+  }
+
+  .field span,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  select,
+  button {
+    width: 100%;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  button.danger {
+    border-color: rgba(255, 68, 68, 0.35);
+    background: rgba(255, 68, 68, 0.12);
+  }
+
+  .feedback {
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+    color: var(--status-info);
+  }
+</style>

--- a/gui-svelte/src/components/fleet/FleetOrders.svelte
+++ b/gui-svelte/src/components/fleet/FleetOrders.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { autoFleetProposals } from "./fleetData.js";
+
+  const SIMPLE_ORDERS = [
+    { label: "INTERCEPT", command: "intercept" },
+    { label: "HOLD", command: "hold" },
+    { label: "FLANK", command: "intercept" },
+    { label: "RETREAT", command: "evasive" },
+  ];
+
+  let maneuver = "hold";
+  let position = { x: 0, y: 0, z: 0 };
+  let velocity = { x: 0, y: 0, z: 0 };
+  let proposals: ReturnType<typeof autoFleetProposals> = [];
+  let feedback = "";
+  let pollHandle: number | null = null;
+
+  $: rawTier = $tier === "raw";
+  $: arcadeTier = $tier === "arcade";
+  $: cpuAssistTier = $tier === "cpu-assist";
+
+  onMount(() => {
+    if (cpuAssistTier) {
+      void refreshProposals();
+      pollHandle = window.setInterval(() => void refreshProposals(), 3000);
+    }
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  async function refreshProposals() {
+    try {
+      const response = await wsClient.sendShipCommand("auto_fleet_status", {});
+      proposals = autoFleetProposals(response);
+    } catch {
+      proposals = [];
+    }
+  }
+
+  async function sendOrder(command = maneuver) {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("fleet_maneuver", {
+        maneuver: command,
+        position,
+        velocity,
+      });
+      feedback = `${command.toUpperCase()} ordered`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Fleet maneuver failed";
+    }
+  }
+
+  async function reviewProposal(proposalId: string, approve: boolean) {
+    try {
+      await wsClient.sendShipCommand(approve ? "approve_fleet" : "deny_fleet", { proposal_id: proposalId });
+      await refreshProposals();
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Proposal review failed";
+    }
+  }
+</script>
+
+<Panel title="Fleet Orders" domain="weapons" priority={cpuAssistTier ? "primary" : "secondary"} className="fleet-orders-panel">
+  <div class="shell">
+    {#if cpuAssistTier}
+      {#if proposals.length === 0}
+        <div class="empty">No pending fleet proposals.</div>
+      {:else}
+        {#each proposals as proposal}
+          <section class="proposal-card">
+            <div class="head">
+              <strong>{proposal.action.replaceAll("_", " ").toUpperCase()}</strong>
+              <span>{Math.round(proposal.confidence * 100)}%</span>
+            </div>
+            <div class="reason">{proposal.reason}</div>
+            <div class="button-row">
+              <button type="button" on:click={() => reviewProposal(proposal.proposalId, true)}>APPROVE</button>
+              <button class="secondary" type="button" on:click={() => reviewProposal(proposal.proposalId, false)}>DENY</button>
+            </div>
+          </section>
+        {/each}
+      {/if}
+    {:else if arcadeTier}
+      <div class="simple-grid">
+        {#each SIMPLE_ORDERS as order}
+          <button type="button" on:click={() => sendOrder(order.command)}>{order.label}</button>
+        {/each}
+      </div>
+    {:else}
+      <label class="field">
+        <span>Maneuver</span>
+        <select bind:value={maneuver}>
+          <option value="intercept">INTERCEPT</option>
+          <option value="match_velocity">MATCH VELOCITY</option>
+          <option value="hold">HOLD</option>
+          <option value="evasive">EVASIVE</option>
+        </select>
+      </label>
+
+      {#if rawTier}
+        <div class="coord-grid">
+          <label class="field"><span>X</span><input type="number" bind:value={position.x} /></label>
+          <label class="field"><span>Y</span><input type="number" bind:value={position.y} /></label>
+          <label class="field"><span>Z</span><input type="number" bind:value={position.z} /></label>
+          <label class="field"><span>VX</span><input type="number" bind:value={velocity.x} /></label>
+          <label class="field"><span>VY</span><input type="number" bind:value={velocity.y} /></label>
+          <label class="field"><span>VZ</span><input type="number" bind:value={velocity.z} /></label>
+        </div>
+      {/if}
+
+      <button type="button" on:click={() => sendOrder()}>EXECUTE MANEUVER</button>
+    {/if}
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .field,
+  .proposal-card,
+  .feedback,
+  .empty {
+    display: grid;
+    gap: 8px;
+  }
+
+  .proposal-card,
+  .feedback,
+  .empty {
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .simple-grid,
+  .coord-grid {
+    display: grid;
+    gap: 8px;
+  }
+
+  .simple-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .coord-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .head,
+  .button-row {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .field span,
+  .reason,
+  .feedback,
+  .empty {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  strong,
+  input,
+  select,
+  button {
+    font-family: var(--font-mono);
+  }
+
+  strong {
+    color: var(--text-primary);
+  }
+
+  input,
+  select,
+  button {
+    width: 100%;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-size: 0.72rem;
+  }
+
+  .button-row button {
+    flex: 1;
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+
+  @media (max-width: 640px) {
+    .simple-grid,
+    .coord-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/gui-svelte/src/components/fleet/FleetRoster.svelte
+++ b/gui-svelte/src/components/fleet/FleetRoster.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { fleetIdFromRecord, fleetShipsFromStatus, statusClass, type FleetShipRow } from "./fleetData.js";
+
+  let fleetRecord: Record<string, unknown> = {};
+  let ships: FleetShipRow[] = [];
+  let newFleetName = "";
+  let shipToAdd = "";
+  let feedback = "";
+  let pollHandle: number | null = null;
+
+  $: fleetId = fleetIdFromRecord(fleetRecord);
+
+  onMount(() => {
+    void refresh();
+    pollHandle = window.setInterval(() => void refresh(), 4000);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  async function refresh() {
+    try {
+      const response = await wsClient.sendShipCommand("fleet_status", {});
+      fleetRecord = (response as Record<string, unknown>) ?? {};
+      ships = fleetShipsFromStatus(response);
+    } catch {
+      fleetRecord = {};
+      ships = [];
+    }
+  }
+
+  async function createFleet() {
+    if (!newFleetName.trim()) return;
+    feedback = "";
+    const fleet_id = globalThis.crypto?.randomUUID?.() ?? `fleet-${Date.now()}`;
+    try {
+      await wsClient.sendShipCommand("fleet_create", { fleet_id, name: newFleetName.trim() });
+      newFleetName = "";
+      feedback = "Fleet created";
+      await refresh();
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Fleet create failed";
+    }
+  }
+
+  async function addShip() {
+    if (!shipToAdd.trim() || !fleetId) return;
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("fleet_add_ship", {
+        fleet_id: fleetId,
+        target_ship: shipToAdd.trim(),
+      });
+      shipToAdd = "";
+      feedback = "Ship added to fleet";
+      await refresh();
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Add ship failed";
+    }
+  }
+</script>
+
+<Panel title="Fleet Roster" domain="weapons" priority="secondary" className="fleet-roster-panel">
+  <div class="shell">
+    {#if !fleetId}
+      <section class="entry-card">
+        <div class="head">
+          <span>No fleet assigned</span>
+          <strong>CREATE</strong>
+        </div>
+        <input bind:value={newFleetName} placeholder="Task force name" maxlength="40" />
+        <button type="button" disabled={!newFleetName.trim()} on:click={createFleet}>CREATE FLEET</button>
+      </section>
+    {:else}
+      <section class="entry-card">
+        <div class="head">
+          <span>Fleet</span>
+          <strong>{fleetId}</strong>
+        </div>
+        <div class="adder">
+          <input bind:value={shipToAdd} placeholder="Ship ID" />
+          <button type="button" disabled={!shipToAdd.trim()} on:click={addShip}>ADD SHIP</button>
+        </div>
+      </section>
+
+      {#if ships.length === 0}
+        <div class="empty">Fleet exists but no ship telemetry is currently available.</div>
+      {:else}
+        <div class="ship-list">
+          {#each ships as row}
+            <section class="ship-card {statusClass(row.status)}">
+              <div class="card-head">
+                <strong>{row.name}</strong>
+                {#if row.isFlagship}
+                  <span class="flag">FLAG</span>
+                {/if}
+              </div>
+              <div class="meta">
+                <span>{row.className.toUpperCase()}</span>
+                <span>{row.status.toUpperCase()}</span>
+              </div>
+              <div class="track"><div class="fill" style={`width:${row.hullPercent.toFixed(1)}%;`}></div></div>
+              <div class="meta">
+                <span>Hull</span>
+                <span>{Math.round(row.hullPercent)}%</span>
+              </div>
+            </section>
+          {/each}
+        </div>
+      {/if}
+    {/if}
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .entry-card,
+  .ship-card,
+  .feedback,
+  .empty {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .head,
+  .card-head,
+  .meta,
+  .adder {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .ship-list {
+    display: grid;
+    gap: 8px;
+  }
+
+  .head span,
+  .meta,
+  .feedback,
+  .empty {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  strong,
+  input,
+  button {
+    font-family: var(--font-mono);
+  }
+
+  strong {
+    color: var(--text-primary);
+  }
+
+  input,
+  button {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-size: 0.72rem;
+  }
+
+  .adder input {
+    flex: 1;
+  }
+
+  .track {
+    height: 8px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(0, 255, 136, 0.18), rgba(0, 255, 136, 0.85));
+  }
+
+  .ship-card.warning {
+    border-color: rgba(255, 184, 77, 0.35);
+  }
+
+  .ship-card.critical {
+    border-color: rgba(255, 68, 68, 0.35);
+  }
+
+  .flag {
+    padding: 2px 6px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 212, 107, 0.4);
+    color: #ffd46b;
+    font-size: 0.65rem;
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+</style>

--- a/gui-svelte/src/components/fleet/FleetTacticalDisplay.svelte
+++ b/gui-svelte/src/components/fleet/FleetTacticalDisplay.svelte
@@ -1,0 +1,295 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { getTacticalContacts } from "../tactical/tacticalData.js";
+  import {
+    fleetIdFromRecord,
+    fleetShipsFromStatus,
+    fleetSummaryFromTactical,
+    getFleetShip,
+    type FleetShipRow,
+  } from "./fleetData.js";
+
+  const SCALES = [5_000, 10_000, 50_000, 100_000, 500_000];
+
+  let canvas: HTMLCanvasElement | null = null;
+  let wrapper: HTMLDivElement | null = null;
+  let scale = SCALES[2];
+  let panX = 0;
+  let panY = 0;
+  let dragging = false;
+  let dragStartX = 0;
+  let dragStartY = 0;
+  let originPanX = 0;
+  let originPanY = 0;
+  let tacticalSummary: Record<string, unknown> = {};
+  let fleetRecord: Record<string, unknown> = {};
+  let ships: FleetShipRow[] = [];
+  let pollHandle: number | null = null;
+  let resizeObserver: ResizeObserver | null = null;
+
+  $: ship = getFleetShip($gameState);
+  $: localContacts = getTacticalContacts(ship);
+  $: fleetId = fleetIdFromRecord(fleetRecord);
+
+  onMount(() => {
+    void refresh();
+    pollHandle = window.setInterval(() => void refresh(), 3000);
+
+    if (wrapper) {
+      resizeObserver = new ResizeObserver(() => draw());
+      resizeObserver.observe(wrapper);
+    }
+
+    draw();
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+      resizeObserver?.disconnect();
+    };
+  });
+
+  $: draw();
+
+  async function refresh() {
+    if (document.hidden) return;
+    try {
+      const [tactical, status] = await Promise.all([
+        wsClient.sendShipCommand("fleet_tactical", {}),
+        wsClient.sendShipCommand("fleet_status", {}),
+      ]);
+      tacticalSummary = (tactical as Record<string, unknown>) ?? {};
+      fleetRecord = (status as Record<string, unknown>) ?? {};
+      ships = fleetShipsFromStatus(status);
+    } catch {
+      tacticalSummary = {};
+      ships = [];
+    }
+  }
+
+  function zoom(delta: number) {
+    const index = Math.max(0, Math.min(SCALES.length - 1, SCALES.indexOf(scale) + delta));
+    scale = SCALES[index];
+  }
+
+  function toScreen(x: number, z: number, width: number, height: number): [number, number] {
+    const ppm = Math.min(width, height) / 2 / scale;
+    return [width / 2 + (x - panX) * ppm, height / 2 - (z - panY) * ppm];
+  }
+
+  function draw() {
+    if (!canvas || !wrapper) return;
+    const rect = wrapper.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    const width = rect.width;
+    const height = rect.height;
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = "#0b1219";
+    ctx.fillRect(0, 0, width, height);
+
+    ctx.strokeStyle = "rgba(120,180,255,0.1)";
+    ctx.lineWidth = 1;
+    const gridStep = Math.max(32, Math.min(width, height) / 6);
+    for (let x = 0; x <= width; x += gridStep) {
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, height);
+      ctx.stroke();
+    }
+    for (let y = 0; y <= height; y += gridStep) {
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(width, y);
+      ctx.stroke();
+    }
+
+    if (ships.length > 1) {
+      ctx.strokeStyle = "rgba(80,166,255,0.28)";
+      ctx.setLineDash([6, 6]);
+      for (let index = 1; index < ships.length; index += 1) {
+        const a = ships[index - 1];
+        const b = ships[index];
+        const [ax, ay] = toScreen(a.position.x, a.position.z, width, height);
+        const [bx, by] = toScreen(b.position.x, b.position.z, width, height);
+        ctx.beginPath();
+        ctx.moveTo(ax, ay);
+        ctx.lineTo(bx, by);
+        ctx.stroke();
+      }
+      ctx.setLineDash([]);
+    }
+
+    ships.forEach((row) => {
+      const [sx, sy] = toScreen(row.position.x, row.position.z, width, height);
+      const size = row.isFlagship ? 9 : 7;
+      ctx.fillStyle = row.isFlagship ? "#ffd46b" : "#00ff88";
+      ctx.beginPath();
+      ctx.moveTo(sx, sy - size);
+      ctx.lineTo(sx - size * 0.75, sy + size * 0.7);
+      ctx.lineTo(sx + size * 0.75, sy + size * 0.7);
+      ctx.closePath();
+      ctx.fill();
+      ctx.fillStyle = "#d4e6ff";
+      ctx.font = "10px JetBrains Mono";
+      ctx.fillText(row.name, sx + size + 4, sy + 4);
+    });
+
+    localContacts.forEach((contact) => {
+      const [tx, ty] = toScreen(contact.position.x, contact.position.z, width, height);
+      ctx.fillStyle = contact.threatLevel === "red" ? "#ff4444" : contact.threatLevel === "orange" ? "#ff9f43" : "#5dd3ff";
+      ctx.beginPath();
+      ctx.moveTo(tx, ty - 6);
+      ctx.lineTo(tx + 6, ty);
+      ctx.lineTo(tx, ty + 6);
+      ctx.lineTo(tx - 6, ty);
+      ctx.closePath();
+      ctx.fill();
+      ctx.fillStyle = "#9fb8d9";
+      ctx.font = "10px JetBrains Mono";
+      ctx.fillText(contact.id, tx + 10, ty + 4);
+    });
+  }
+
+  function handlePointerDown(event: PointerEvent) {
+    dragging = true;
+    dragStartX = event.clientX;
+    dragStartY = event.clientY;
+    originPanX = panX;
+    originPanY = panY;
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    if (!dragging || !wrapper) return;
+    const rect = wrapper.getBoundingClientRect();
+    const ppm = Math.min(rect.width, rect.height) / 2 / scale;
+    panX = originPanX - (event.clientX - dragStartX) / ppm;
+    panY = originPanY + (event.clientY - dragStartY) / ppm;
+  }
+
+  function handlePointerUp() {
+    dragging = false;
+  }
+</script>
+
+<svelte:window on:pointermove={handlePointerMove} on:pointerup={handlePointerUp} />
+
+<Panel title="Fleet Tactical" domain="weapons" priority="primary" className="fleet-tactical-display">
+  <div class="shell">
+    <div class="toolbar">
+      <div class="summary">
+        <strong>{fleetId || "NO FLEET"}</strong>
+        <span>{ships.length} ships · {Number(fleetSummaryFromTactical(tacticalSummary).contacts_tracked ?? localContacts.length)} contacts</span>
+      </div>
+      <label>
+        <span>Scale</span>
+        <select bind:value={scale}>
+          {#each SCALES as option}
+            <option value={option}>{option >= 1000 ? `${option / 1000} km` : `${option} m`}</option>
+          {/each}
+        </select>
+      </label>
+    </div>
+
+    <div class="canvas-wrap" bind:this={wrapper}>
+      <canvas bind:this={canvas} on:pointerdown={handlePointerDown} on:wheel|preventDefault={(event) => zoom(event.deltaY > 0 ? 1 : -1)}></canvas>
+      <div class="legend">
+        <span class="friendly">▲ Friendly</span>
+        <span class="hostile">◆ Threat</span>
+      </div>
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+    min-height: 420px;
+  }
+
+  .toolbar,
+  .summary {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .summary span,
+  label span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  label {
+    display: grid;
+    gap: 4px;
+  }
+
+  select {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  .canvas-wrap {
+    position: relative;
+    min-height: 360px;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    border: 1px solid var(--border-subtle);
+    background: #0b1219;
+  }
+
+  canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+    touch-action: none;
+    cursor: grab;
+  }
+
+  .legend {
+    position: absolute;
+    left: 10px;
+    bottom: 10px;
+    display: flex;
+    gap: 12px;
+    padding: 6px 8px;
+    border-radius: 999px;
+    background: rgba(5, 8, 12, 0.75);
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .friendly {
+    color: #00ff88;
+  }
+
+  .hostile {
+    color: #ff6666;
+  }
+</style>

--- a/gui-svelte/src/components/fleet/FormationControl.svelte
+++ b/gui-svelte/src/components/fleet/FormationControl.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+
+  const FORMATIONS = [
+    { label: "LINE", command: "line" },
+    { label: "WEDGE", command: "wedge" },
+    { label: "DIAMOND", command: "diamond" },
+    { label: "COLUMN", command: "column" },
+    { label: "SPREAD", command: "wall" },
+    { label: "ESCORT", command: "diamond" },
+    { label: "SPHERE", command: "sphere" },
+  ];
+
+  let selectedFormation = FORMATIONS[0];
+  let spacing = 2000;
+  let echelonAngle = 30;
+  let manualOffset = { x: 0, y: 0, z: 0 };
+  let feedback = "";
+
+  $: rawTier = $tier === "raw";
+
+  async function applyFormation() {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("fleet_form", {
+        formation: selectedFormation.command,
+        spacing,
+        echelon_angle: echelonAngle,
+        offset: rawTier ? manualOffset : undefined,
+      });
+      feedback = `${selectedFormation.label} ordered`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Formation command failed";
+    }
+  }
+
+  async function breakFormation() {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("fleet_break_formation", {});
+      feedback = "Formation broken";
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Break command failed";
+    }
+  }
+</script>
+
+<Panel title="Formation Control" domain="weapons" priority="secondary" className="formation-control-panel">
+  <div class="shell">
+    <div class="preset-grid">
+      {#each FORMATIONS as formation}
+        <button class:active={selectedFormation.label === formation.label} type="button" on:click={() => selectedFormation = formation}>
+          {formation.label}
+        </button>
+      {/each}
+    </div>
+
+    <label class="field">
+      <span>Echelon Angle</span>
+      <input type="range" min="0" max="60" step="1" bind:value={echelonAngle} />
+      <strong>{Math.round(echelonAngle)}°</strong>
+    </label>
+
+    {#if rawTier}
+      <div class="offset-grid">
+        <label class="field"><span>Offset X</span><input type="number" bind:value={manualOffset.x} /></label>
+        <label class="field"><span>Offset Y</span><input type="number" bind:value={manualOffset.y} /></label>
+        <label class="field"><span>Offset Z</span><input type="number" bind:value={manualOffset.z} /></label>
+      </div>
+    {/if}
+
+    <div class="button-row">
+      <button type="button" on:click={applyFormation}>FORM FLEET</button>
+      <button class="secondary" type="button" on:click={breakFormation}>BREAK</button>
+    </div>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .preset-grid,
+  .offset-grid {
+    display: grid;
+    gap: 8px;
+  }
+
+  .preset-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .offset-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .field {
+    display: grid;
+    gap: 6px;
+  }
+
+  .button-row {
+    display: flex;
+    gap: var(--space-sm);
+  }
+
+  .field span,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  strong,
+  input,
+  button {
+    font-family: var(--font-mono);
+  }
+
+  strong {
+    color: var(--text-primary);
+  }
+
+  input,
+  button {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-size: 0.72rem;
+  }
+
+  button.active {
+    border-color: rgba(var(--tier-accent-rgb), 0.45);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  .button-row button {
+    flex: 1;
+  }
+
+  .feedback {
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+    color: var(--status-info);
+  }
+
+  @media (max-width: 640px) {
+    .preset-grid,
+    .offset-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/gui-svelte/src/components/fleet/SharedContacts.svelte
+++ b/gui-svelte/src/components/fleet/SharedContacts.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { localSharedContacts, formatDistance, getFleetShip } from "./fleetData.js";
+
+  let shared = new Set<string>();
+  let hostile = new Set<string>();
+  let feedback = "";
+
+  $: ship = getFleetShip($gameState);
+  $: contacts = localSharedContacts(ship);
+
+  async function share(contactId: string) {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("share_contact", {
+        contact: contactId,
+        hostile: hostile.has(contactId),
+      });
+      shared = new Set([...shared, contactId]);
+      feedback = `${contactId} shared with fleet`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Share failed";
+    }
+  }
+
+  function toggleHostile(contactId: string) {
+    const next = new Set(hostile);
+    if (next.has(contactId)) next.delete(contactId);
+    else next.add(contactId);
+    hostile = next;
+  }
+</script>
+
+<Panel title="Shared Contacts" domain="weapons" priority="secondary" className="shared-contacts-panel">
+  <div class="shell">
+    {#if contacts.length === 0}
+      <div class="empty">No contacts available for data-link sharing.</div>
+    {:else}
+      {#each contacts as contact}
+        <div class="contact-row">
+          <div class="info">
+            <strong>{contact.id}</strong>
+            <span>{contact.classification} · {contact.sourceShip} · {formatDistance(contact.distance)}</span>
+          </div>
+          <div class="actions">
+            <label class="hostile-toggle">
+              <input type="checkbox" checked={hostile.has(contact.id)} on:change={() => toggleHostile(contact.id)} />
+              <span>HOSTILE</span>
+            </label>
+            <button type="button" class:active={shared.has(contact.id)} on:click={() => share(contact.id)}>
+              {shared.has(contact.id) ? "RESHARE" : "SHARE"}
+            </button>
+          </div>
+        </div>
+      {/each}
+    {/if}
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .contact-row,
+  .feedback,
+  .empty {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .info,
+  .actions {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .info span,
+  .hostile-toggle span,
+  .feedback,
+  .empty {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .hostile-toggle {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  }
+
+  button {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  button.active {
+    border-color: rgba(var(--tier-accent-rgb), 0.4);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+</style>

--- a/gui-svelte/src/components/fleet/fleetData.ts
+++ b/gui-svelte/src/components/fleet/fleetData.ts
@@ -1,0 +1,147 @@
+import type { JsonMap, Vec3 } from "../helm/helmData.js";
+import {
+  asRecord,
+  clamp,
+  extractShipState,
+  formatDistance,
+  formatSpeed,
+  magnitude,
+  toNumber,
+  toStringValue,
+  toVec3,
+} from "../helm/helmData.js";
+import { getTacticalContacts, type TacticalContact } from "../tactical/tacticalData.js";
+
+export interface FleetShipRow {
+  id: string;
+  name: string;
+  className: string;
+  hullPercent: number;
+  status: string;
+  isFlagship: boolean;
+  position: Vec3;
+  velocity: Vec3;
+}
+
+export interface FleetProposal {
+  proposalId: string;
+  action: string;
+  target: string;
+  reason: string;
+  confidence: number;
+  params: JsonMap;
+}
+
+export interface SharedFleetContact {
+  id: string;
+  classification: string;
+  sourceShip: string;
+  threatLevel: string;
+  hostile: boolean;
+  distance: number;
+  bearing: number;
+}
+
+function seededPercent(seedText: string): number {
+  let hash = 0;
+  for (let i = 0; i < seedText.length; i += 1) hash = ((hash << 5) - hash + seedText.charCodeAt(i)) | 0;
+  return Math.abs(hash % 85) + 15;
+}
+
+export function getFleetShip(gameState: JsonMap | null | undefined): JsonMap {
+  return extractShipState(gameState);
+}
+
+export function getFleetCoordState(ship: JsonMap): JsonMap {
+  return asRecord(ship.fleet_coord) ?? {};
+}
+
+export function getFleetStatusRecord(response: unknown): JsonMap {
+  return asRecord(response) ?? {};
+}
+
+export function fleetIdFromRecord(record: JsonMap): string {
+  return toStringValue(record.fleet_id) || toStringValue(asRecord(record.fleet)?.fleet_id);
+}
+
+export function fleetShipsFromStatus(response: unknown): FleetShipRow[] {
+  const record = getFleetStatusRecord(response);
+  const source = Array.isArray(record.ships) ? (record.ships as unknown[]) : [];
+
+  return source
+    .map((item) => asRecord(item))
+    .filter((item): item is JsonMap => Boolean(item))
+    .map((item) => {
+      const id = toStringValue(item.ship_id, "unknown");
+      const position = toVec3(item.position);
+      const velocity = toVec3(item.velocity);
+      const systemsOnline = asRecord(item.systems_online) ?? {};
+      const statuses = Object.values(systemsOnline).map((value) => Boolean(value));
+      const onlineRatio = statuses.length ? statuses.filter(Boolean).length / statuses.length : 0.85;
+      const hullPercent = clamp(toNumber(item.hull_percent, onlineRatio * 100), 0, 100);
+
+      return {
+        id,
+        name: toStringValue(item.name, id),
+        className: toStringValue(item.class, "Escort"),
+        hullPercent,
+        status: toStringValue(item.status, hullPercent < 40 ? "damaged" : "nominal"),
+        isFlagship: Boolean(item.is_flagship),
+        position,
+        velocity,
+      };
+    });
+}
+
+export function fleetSummaryFromTactical(response: unknown): JsonMap {
+  return asRecord(response) ?? {};
+}
+
+export function autoFleetProposals(value: unknown): FleetProposal[] {
+  const record = asRecord(value) ?? {};
+  const source = Array.isArray(record.proposals) ? (record.proposals as unknown[]) : [];
+  return source
+    .map((item) => asRecord(item))
+    .filter((item): item is JsonMap => Boolean(item))
+    .map((item) => ({
+      proposalId: toStringValue(item.proposal_id),
+      action: toStringValue(item.action, "proposal"),
+      target: toStringValue(item.target, "fleet"),
+      reason: toStringValue(item.reason, "Awaiting approval"),
+      confidence: clamp(toNumber(item.confidence, 0), 0, 1),
+      params: asRecord(item.params) ?? {},
+    }));
+}
+
+export function localSharedContacts(ship: JsonMap): SharedFleetContact[] {
+  return getTacticalContacts(ship).map((contact) => ({
+    id: contact.id,
+    classification: contact.classification,
+    sourceShip: toStringValue(asRecord(contact as unknown as JsonMap)?.source_ship, "LOCAL"),
+    threatLevel: contact.threatLevel,
+    hostile: ["orange", "red"].includes(contact.threatLevel),
+    distance: contact.distance,
+    bearing: contact.bearing,
+  }));
+}
+
+export function formationLabel(form: string): string {
+  return form.replaceAll("_", " ").toUpperCase();
+}
+
+export function statusClass(status: string): "critical" | "warning" | "nominal" {
+  const lower = status.toLowerCase();
+  if (["damaged", "retreating", "broken", "offline"].some((token) => lower.includes(token))) return "critical";
+  if (["forming", "engaging", "holding"].some((token) => lower.includes(token))) return "warning";
+  return "nominal";
+}
+
+export function contactPosition(contact: TacticalContact): Vec3 {
+  return contact.position;
+}
+
+export function contactSpeed(contact: TacticalContact): number {
+  return magnitude(contact.velocity);
+}
+
+export { asRecord, formatDistance, formatSpeed, magnitude, toNumber, toStringValue, toVec3 };

--- a/gui-svelte/src/components/games/DamageControlGame.svelte
+++ b/gui-svelte/src/components/games/DamageControlGame.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { getOpsShip, getRepairTargets } from "../ops/opsData.js";
+
+  type CellType = "line" | "corner" | "tee" | "blocked";
+  interface Cell {
+    type: CellType;
+    rotation: number;
+  }
+
+  const SIZE = 4;
+  const START = { x: 0, y: 1 };
+  const END = { x: 3, y: 2 };
+
+  let grid: Cell[][] = [];
+  let solving = false;
+  let solvedTarget = "";
+  let feedback = "";
+
+  $: ship = getOpsShip($gameState);
+  $: targets = getRepairTargets(ship);
+  $: activeTarget = targets[0]?.id ?? "";
+  $: if (!grid.length || solvedTarget !== activeTarget) resetPuzzle(activeTarget);
+
+  function openings(cell: Cell): boolean[] {
+    if (cell.type === "blocked") return [false, false, false, false];
+    const variants: Record<CellType, boolean[][]> = {
+      line: [
+        [true, false, true, false],
+        [false, true, false, true],
+        [true, false, true, false],
+        [false, true, false, true],
+      ],
+      corner: [
+        [true, true, false, false],
+        [false, true, true, false],
+        [false, false, true, true],
+        [true, false, false, true],
+      ],
+      tee: [
+        [true, true, false, true],
+        [true, true, true, false],
+        [false, true, true, true],
+        [true, false, true, true],
+      ],
+      blocked: [[false, false, false, false]],
+    };
+    return variants[cell.type][cell.rotation % variants[cell.type].length];
+  }
+
+  function resetPuzzle(targetId: string) {
+    solvedTarget = targetId;
+    feedback = "";
+    solving = false;
+    const seed: Cell[][] = [
+      [{ type: "line", rotation: 1 }, { type: "corner", rotation: 1 }, { type: "line", rotation: 1 }, { type: "corner", rotation: 2 }],
+      [{ type: "line", rotation: 1 }, { type: "blocked", rotation: 0 }, { type: "tee", rotation: 2 }, { type: "line", rotation: 0 }],
+      [{ type: "corner", rotation: 0 }, { type: "line", rotation: 1 }, { type: "corner", rotation: 3 }, { type: "line", rotation: 0 }],
+      [{ type: "blocked", rotation: 0 }, { type: "corner", rotation: 0 }, { type: "line", rotation: 1 }, { type: "corner", rotation: 3 }],
+    ];
+    grid = seed.map((row) => row.map((cell) => ({ ...cell, rotation: cell.type === "blocked" ? 0 : Math.floor(Math.random() * 4) })));
+  }
+
+  function rotateCell(x: number, y: number) {
+    const cell = grid[y][x];
+    if (cell.type === "blocked") return;
+    grid = grid.map((row, rowIndex) =>
+      row.map((entry, colIndex) =>
+        rowIndex === y && colIndex === x
+          ? { ...entry, rotation: (entry.rotation + 1) % 4 }
+          : entry,
+      ),
+    );
+    if (isSolved()) {
+      solving = true;
+      void dispatchRepair();
+    }
+  }
+
+  function isSolved(): boolean {
+    const queue = [[START.x, START.y]];
+    const visited = new Set<string>();
+    const dirs = [
+      [0, -1, 2],
+      [1, 0, 3],
+      [0, 1, 0],
+      [-1, 0, 1],
+    ];
+
+    while (queue.length) {
+      const [x, y] = queue.shift()!;
+      const key = `${x},${y}`;
+      if (visited.has(key)) continue;
+      visited.add(key);
+      if (x === END.x && y === END.y) return true;
+
+      const cell = grid[y]?.[x];
+      if (!cell) continue;
+      const open = openings(cell);
+      dirs.forEach(([dx, dy, opposite], index) => {
+        if (!open[index]) return;
+        const nx = x + dx;
+        const ny = y + dy;
+        const next = grid[ny]?.[nx];
+        if (!next) return;
+        if (!openings(next)[opposite]) return;
+        queue.push([nx, ny]);
+      });
+    }
+    return false;
+  }
+
+  async function dispatchRepair() {
+    if (!activeTarget) return;
+    try {
+      await wsClient.sendShipCommand("dispatch_repair", { subsystem: activeTarget });
+      feedback = `Repair dispatched to ${activeTarget}`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Dispatch failed";
+    } finally {
+      solving = false;
+    }
+  }
+
+  function symbol(cell: Cell): string {
+    if (cell.type === "blocked") return "■";
+    if (cell.type === "line") return cell.rotation % 2 === 0 ? "│" : "─";
+    if (cell.type === "corner") return ["└", "┌", "┐", "┘"][cell.rotation % 4];
+    return ["┴", "├", "┬", "┤"][cell.rotation % 4];
+  }
+</script>
+
+<Panel title="Damage Control" domain="power" priority="primary" className="damage-control-game">
+  <div class="shell">
+    <div class="header">
+      <span>Route power from reactor to damaged system</span>
+      <strong>{activeTarget ? activeTarget.toUpperCase() : "NO TARGET"}</strong>
+    </div>
+    <div class="grid">
+      {#each grid as row, y}
+        {#each row as cell, x}
+          <button
+            type="button"
+            class="cell"
+            class:blocked={cell.type === "blocked"}
+            class:start={x === START.x && y === START.y}
+            class:end={x === END.x && y === END.y}
+            on:click={() => rotateCell(x, y)}
+          >
+            {symbol(cell)}
+          </button>
+        {/each}
+      {/each}
+    </div>
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .header,
+  .feedback {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  .cell {
+    aspect-ratio: 1;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 1.4rem;
+  }
+
+  .cell.start {
+    border-color: rgba(0, 255, 136, 0.45);
+  }
+
+  .cell.end {
+    border-color: rgba(68, 136, 255, 0.45);
+  }
+
+  .cell.blocked {
+    opacity: 0.35;
+  }
+
+  span,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+</style>

--- a/gui-svelte/src/components/games/EcmFrequencyGame.svelte
+++ b/gui-svelte/src/components/games/EcmFrequencyGame.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  let slider = 40;
+  let target = 62;
+  let delta = 22;
+  let timer: number | null = null;
+
+  function drift() {
+    target = 50 + Math.sin(Date.now() / 900) * 26;
+    delta = Math.abs(slider - target);
+    timer = window.setTimeout(drift, 60);
+  }
+
+  onMount(() => {
+    drift();
+    return () => {
+      if (timer != null) window.clearTimeout(timer);
+    };
+  });
+</script>
+
+<div class="card">
+  <input type="range" min="0" max="100" bind:value={slider} />
+  <div class="readout">Filter delta {Math.round(delta)}</div>
+  <div class="track">
+    <div class="target" style={`left:${target}%`}></div>
+    <div class="user" style={`left:${slider}%`}></div>
+  </div>
+</div>
+
+<style>
+  .card { display: grid; gap: 10px; padding: var(--space-sm); border-radius: var(--radius-sm); border: 1px solid var(--border-subtle); }
+  .track { position: relative; height: 18px; border-radius: 999px; background: var(--bg-input); }
+  .target, .user { position: absolute; top: -2px; width: 4px; height: 22px; transform: translateX(-50%); }
+  .target { background: #ff4444; }
+  .user { background: #00aaff; }
+  .readout { font-size: var(--font-size-xs); color: var(--text-secondary); }
+</style>

--- a/gui-svelte/src/components/games/FleetFormationGame.svelte
+++ b/gui-svelte/src/components/games/FleetFormationGame.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+
+  const FORMATIONS = {
+    wedge: [
+      { x: 180, y: 60 },
+      { x: 120, y: 130 },
+      { x: 240, y: 130 },
+      { x: 180, y: 200 },
+    ],
+    line: [
+      { x: 80, y: 140 },
+      { x: 150, y: 140 },
+      { x: 220, y: 140 },
+      { x: 290, y: 140 },
+    ],
+    diamond: [
+      { x: 180, y: 60 },
+      { x: 110, y: 140 },
+      { x: 250, y: 140 },
+      { x: 180, y: 220 },
+    ],
+  } as const;
+
+  type FormationKey = keyof typeof FORMATIONS;
+
+  interface ShipToken {
+    id: string;
+    x: number;
+    y: number;
+    slot: number;
+  }
+
+  let board: HTMLDivElement | null = null;
+  let formation: FormationKey = "wedge";
+  let ships: ShipToken[] = [];
+  let draggingId = "";
+  let offsetX = 0;
+  let offsetY = 0;
+  let solvedSent = false;
+
+  onMount(() => {
+    resetBoard();
+  });
+
+  function resetBoard() {
+    ships = [
+      { id: "A", x: 24, y: 28, slot: -1 },
+      { id: "B", x: 24, y: 82, slot: -1 },
+      { id: "C", x: 24, y: 136, slot: -1 },
+      { id: "D", x: 24, y: 190, slot: -1 },
+    ];
+    solvedSent = false;
+  }
+
+  function pointerDown(event: PointerEvent, shipId: string) {
+    const token = ships.find((ship) => ship.id === shipId);
+    if (!token || !board) return;
+    const rect = board.getBoundingClientRect();
+    draggingId = shipId;
+    offsetX = event.clientX - rect.left - token.x;
+    offsetY = event.clientY - rect.top - token.y;
+  }
+
+  function pointerMove(event: PointerEvent) {
+    if (!draggingId || !board) return;
+    const rect = board.getBoundingClientRect();
+    ships = ships.map((ship) => ship.id === draggingId
+      ? { ...ship, x: event.clientX - rect.left - offsetX, y: event.clientY - rect.top - offsetY, slot: -1 }
+      : ship);
+  }
+
+  function pointerUp() {
+    if (!draggingId) return;
+    const slots = FORMATIONS[formation];
+    ships = ships.map((ship) => {
+      if (ship.id !== draggingId) return ship;
+      let bestSlot = -1;
+      let bestDistance = Number.POSITIVE_INFINITY;
+      slots.forEach((slot, index) => {
+        const distance = Math.hypot(ship.x - slot.x, ship.y - slot.y);
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          bestSlot = index;
+        }
+      });
+      if (bestSlot >= 0 && bestDistance < 50) {
+        return { ...ship, x: slots[bestSlot].x, y: slots[bestSlot].y, slot: bestSlot };
+      }
+      return ship;
+    });
+    draggingId = "";
+    checkSolved();
+  }
+
+  async function checkSolved() {
+    const solved = ships.every((ship) => ship.slot >= 0) && new Set(ships.map((ship) => ship.slot)).size === ships.length;
+    if (!solved || solvedSent) return;
+    solvedSent = true;
+    await wsClient.sendShipCommand("fleet_form", { formation });
+  }
+</script>
+
+<svelte:window on:pointermove={pointerMove} on:pointerup={pointerUp} />
+
+<Panel title="Formation Puzzle" domain="weapons" priority="secondary" className="fleet-formation-game">
+  <div class="shell">
+    <div class="toolbar">
+      <select bind:value={formation} on:change={resetBoard}>
+        <option value="wedge">WEDGE</option>
+        <option value="line">LINE</option>
+        <option value="diamond">DIAMOND</option>
+      </select>
+      <button type="button" on:click={resetBoard}>RESET</button>
+    </div>
+
+    <div class="board" bind:this={board}>
+      {#each FORMATIONS[formation] as slot}
+        <div class="slot" style={`left:${slot.x}px; top:${slot.y}px;`}></div>
+      {/each}
+      {#each ships as ship}
+        <button
+          class="ship-token"
+          type="button"
+          style={`left:${ship.x}px; top:${ship.y}px;`}
+          on:pointerdown={(event) => pointerDown(event, ship.id)}
+        >
+          {ship.id}
+        </button>
+      {/each}
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: 10px;
+    padding: var(--space-sm);
+  }
+
+  .toolbar {
+    display: flex;
+    gap: 8px;
+  }
+
+  select,
+  button {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  .board {
+    position: relative;
+    height: 280px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background:
+      linear-gradient(transparent 23px, rgba(255,255,255,0.04) 24px),
+      linear-gradient(90deg, transparent 23px, rgba(255,255,255,0.04) 24px),
+      #0b1219;
+    background-size: 24px 24px;
+    overflow: hidden;
+  }
+
+  .slot,
+  .ship-token {
+    position: absolute;
+    width: 34px;
+    height: 34px;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+  }
+
+  .slot {
+    border: 2px dashed rgba(0, 170, 255, 0.45);
+    background: rgba(0, 170, 255, 0.06);
+  }
+
+  .ship-token {
+    border: 1px solid rgba(255, 212, 107, 0.45);
+    background: rgba(255, 212, 107, 0.14);
+    color: #ffd46b;
+    font-weight: 700;
+    cursor: grab;
+  }
+</style>

--- a/gui-svelte/src/components/games/HailFrequencyGame.svelte
+++ b/gui-svelte/src/components/games/HailFrequencyGame.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { selectedCommsTargetId } from "../../lib/stores/commsUi.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { getCommsContacts, getCommsShip } from "../comms/commsData.js";
+
+  let dial = 500;
+  let targetFrequency = 500;
+  let signalStrength = 0;
+  let locked = false;
+  let sentForTarget = "";
+  let lockHold = 0;
+  let timer: number | null = null;
+
+  $: ship = getCommsShip($gameState);
+  $: contacts = getCommsContacts(ship);
+  $: activeTarget = contacts.find((contact) => contact.id === $selectedCommsTargetId) ?? contacts[0] ?? null;
+  $: if (activeTarget && !$selectedCommsTargetId) selectedCommsTargetId.set(activeTarget.id);
+  $: if (activeTarget) {
+    const seed = Array.from(activeTarget.id).reduce((sum, char) => sum + char.charCodeAt(0), 0);
+    targetFrequency = 80 + (seed % 840);
+  }
+
+  onMount(() => {
+    timer = window.setInterval(() => {
+      const delta = Math.abs(dial - targetFrequency);
+      signalStrength = Math.max(0, 1 - delta / 140);
+      locked = delta <= 3;
+      if (locked) lockHold += 0.1;
+      else lockHold = 0;
+
+      if (activeTarget && lockHold >= 1.5 && sentForTarget !== activeTarget.id) {
+        sentForTarget = activeTarget.id;
+        void wsClient.sendShipCommand("hail_contact", { target: activeTarget.id, frequency: Math.round(dial) });
+      }
+    }, 100);
+
+    return () => {
+      if (timer != null) window.clearInterval(timer);
+    };
+  });
+
+  $: if (activeTarget && sentForTarget && sentForTarget !== activeTarget.id) {
+    sentForTarget = "";
+    lockHold = 0;
+  }
+</script>
+
+<Panel title="Hail Frequency" domain="comms" priority="secondary" className="hail-frequency-game">
+  <div class="shell">
+    <div class="meta">
+      <strong>{activeTarget ? activeTarget.id : "NO TARGET"}</strong>
+      <span>{locked ? "LOCKED" : signalStrength > 0.5 ? "SIGNAL DETECTED" : "SCANNING"}</span>
+    </div>
+
+    <input type="range" min="0" max="999" step="1" bind:value={dial} />
+
+    <div class="track">
+      <div class="noise"></div>
+      <div class="signal" style={`width:${(signalStrength * 100).toFixed(1)}%;`}></div>
+      <div class="dial" style={`left:${(dial / 999) * 100}%;`}></div>
+    </div>
+
+    <div class="readout">
+      <span>{Math.round(dial)} MHz</span>
+      <span>{Math.round(signalStrength * 100)}% clarity</span>
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: 10px;
+    padding: var(--space-sm);
+  }
+
+  .meta,
+  .readout {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .meta span,
+  .readout {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .track {
+    position: relative;
+    height: 48px;
+    overflow: hidden;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.01));
+  }
+
+  .noise {
+    position: absolute;
+    inset: 0;
+    background:
+      repeating-linear-gradient(90deg, rgba(255,255,255,0.03) 0 2px, transparent 2px 6px),
+      linear-gradient(90deg, rgba(0,0,0,0.2), transparent 40%, rgba(0,0,0,0.25));
+  }
+
+  .signal {
+    position: absolute;
+    inset: 0 auto 0 0;
+    background: linear-gradient(90deg, rgba(0, 255, 136, 0.18), rgba(0, 255, 136, 0.55));
+  }
+
+  .dial {
+    position: absolute;
+    top: -4px;
+    bottom: -4px;
+    width: 4px;
+    transform: translateX(-50%);
+    background: var(--status-info);
+    box-shadow: 0 0 10px rgba(0, 170, 255, 0.45);
+  }
+</style>

--- a/gui-svelte/src/components/games/HelmBalanceGame.svelte
+++ b/gui-svelte/src/components/games/HelmBalanceGame.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { extractShipState, getOrientation, magnitude, toVec3 } from "../helm/helmData.js";
+
+  let canvas: HTMLCanvasElement | null = null;
+  let drift = 0;
+  let rotation = 0;
+
+  $: ship = extractShipState($gameState);
+  $: drift = Math.min(1, Math.abs(getOrientation(ship).yaw) / 180);
+  $: rotation = Math.min(1, magnitude(toVec3(ship.angular_velocity)) / 40);
+
+  onMount(() => {
+    if (!canvas) return undefined;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return undefined;
+
+    let raf = 0;
+
+    const draw = (time: number) => {
+      if (!canvas) return;
+      const width = canvas.width;
+      const height = canvas.height;
+      const centerX = width / 2;
+      const centerY = height / 2;
+      const zoneWidth = 76;
+      const zoneHeight = 34;
+      const ballX = centerX + Math.sin(time / 500) * 10 + (drift - 0.5) * 80;
+      const ballY = centerY + Math.cos(time / 650) * 8 + (rotation - 0.5) * 58;
+
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = "#0d1622";
+      ctx.fillRect(0, 0, width, height);
+
+      ctx.strokeStyle = "rgba(68, 136, 255, 0.35)";
+      ctx.lineWidth = 1;
+      ctx.strokeRect(centerX - zoneWidth / 2, centerY - zoneHeight / 2, zoneWidth, zoneHeight);
+
+      ctx.strokeStyle = "rgba(255,255,255,0.08)";
+      ctx.beginPath();
+      ctx.moveTo(centerX, 10);
+      ctx.lineTo(centerX, height - 10);
+      ctx.moveTo(10, centerY);
+      ctx.lineTo(width - 10, centerY);
+      ctx.stroke();
+
+      const inZone = Math.abs(ballX - centerX) < zoneWidth / 2 && Math.abs(ballY - centerY) < zoneHeight / 2;
+      ctx.fillStyle = inZone ? "#00ff88" : "#ffaa00";
+      ctx.beginPath();
+      ctx.arc(ballX, ballY, 10, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.fillStyle = "rgba(255,255,255,0.75)";
+      ctx.font = "11px JetBrains Mono";
+      ctx.fillText("trim zone", centerX - 24, centerY - zoneHeight / 2 - 8);
+
+      raf = requestAnimationFrame(draw);
+    };
+
+    raf = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(raf);
+  });
+</script>
+
+<Panel title="Balance Game" domain="helm" priority="secondary" className="helm-balance-game">
+  <div class="game-shell">
+    <canvas bind:this={canvas} width="220" height="140"></canvas>
+    <div class="caption">Arcade stability cue. Keep the ball centered while the ship settles.</div>
+  </div>
+</Panel>
+
+<style>
+  .game-shell {
+    display: grid;
+    gap: 10px;
+    padding: var(--space-sm);
+  }
+
+  canvas {
+    width: 100%;
+    height: auto;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: #0d1622;
+  }
+
+  .caption {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+</style>

--- a/gui-svelte/src/components/games/MassEstimationGame.svelte
+++ b/gui-svelte/src/components/games/MassEstimationGame.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { selectedScienceContactId } from "../../lib/stores/scienceUi.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    findScienceContact,
+    formatWatts,
+    getScienceContacts,
+    getScienceShip,
+    pseudoAcceleration,
+    pseudoTargetMass,
+  } from "../science/scienceData.js";
+
+  let estimate = 80_000;
+  let sentForTarget = "";
+
+  $: ship = getScienceShip($gameState);
+  $: contacts = getScienceContacts(ship);
+  $: if (!$selectedScienceContactId && contacts.length) selectedScienceContactId.set(contacts[0].id);
+  $: contact = findScienceContact(ship, $selectedScienceContactId);
+  $: targetMass = pseudoTargetMass(contact);
+  $: acceleration = pseudoAcceleration(contact);
+  $: thrust = targetMass * acceleration;
+  $: errorRatio = targetMass > 0 ? Math.abs(estimate - targetMass) / targetMass : 1;
+  $: if (contact && errorRatio <= 0.08 && sentForTarget !== contact.id) {
+    sentForTarget = contact.id;
+    void wsClient.sendShipCommand("estimate_mass", { contact_id: contact.id });
+  }
+</script>
+
+<Panel title="Mass Estimate" domain="sensor" priority="secondary" className="mass-estimation-game">
+  <div class="shell">
+    <div class="equation">F = m · a</div>
+    <div class="meta">
+      <span>Thrust {formatWatts(thrust)}</span>
+      <span>Accel {acceleration.toFixed(1)} m/s²</span>
+    </div>
+    <input type="range" min="1000" max="500000" step="1000" bind:value={estimate} />
+    <div class="readout">
+      <strong>{Math.round(estimate).toLocaleString()} kg</strong>
+      <span>{Math.round((1 - Math.min(errorRatio, 1)) * 100)}% fit</span>
+    </div>
+    <div class="track"><div class="fill" style={`width:${((1 - Math.min(errorRatio, 1)) * 100).toFixed(1)}%;`}></div></div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: 10px;
+    padding: var(--space-sm);
+  }
+
+  .equation,
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .equation {
+    font-size: 1rem;
+    text-align: center;
+  }
+
+  .meta,
+  .readout {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  .meta,
+  .readout span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .track {
+    height: 8px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(255, 120, 80, 0.8), rgba(0, 255, 136, 0.8));
+  }
+</style>

--- a/gui-svelte/src/components/games/MunitionConfigGame.svelte
+++ b/gui-svelte/src/components/games/MunitionConfigGame.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { selectedLauncherType } from "../../lib/stores/tacticalUi.js";
+
+  let profile = "direct";
+</script>
+
+<div class="card">
+  <div class="toggle">
+    <button class:selected={$selectedLauncherType === "torpedo"} on:click={() => selectedLauncherType.set("torpedo")}>TORPEDO</button>
+    <button class:selected={$selectedLauncherType === "missile"} on:click={() => selectedLauncherType.set("missile")}>MISSILE</button>
+  </div>
+  <label>
+    <span>Flight profile</span>
+    <select bind:value={profile}>
+      <option value="direct">direct</option>
+      <option value="evasive">evasive</option>
+      <option value="terminal_pop">terminal_pop</option>
+      <option value="bracket">bracket</option>
+    </select>
+  </label>
+</div>
+
+<style>
+  .card, label { display: grid; gap: 10px; padding: var(--space-sm); border-radius: var(--radius-sm); border: 1px solid var(--border-subtle); }
+  .toggle { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+  .toggle button.selected { border-color: rgba(var(--tier-accent-rgb), 0.5); background: rgba(var(--tier-accent-rgb), 0.12); }
+  span { font-size: var(--font-size-xs); color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.05em; }
+</style>

--- a/gui-svelte/src/components/games/MunitionProgrammingPanel.svelte
+++ b/gui-svelte/src/components/games/MunitionProgrammingPanel.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { selectedLauncherType } from "../../lib/stores/tacticalUi.js";
+
+  let guidanceMode = "guided";
+  let warheadType = "fragmentation";
+  let flightProfile = "direct";
+  let pnGain = "3";
+  let fuseDistance = "35";
+  let terminalRange = "4000";
+  let boostDuration = "6";
+  let datalink = true;
+
+  async function program() {
+    await wsClient.sendShipCommand("program_munition", {
+      munition_type: $selectedLauncherType,
+      guidance_mode: guidanceMode,
+      warhead_type: warheadType,
+      flight_profile: flightProfile,
+      pn_gain: Number(pnGain),
+      fuse_distance: Number(fuseDistance),
+      terminal_range: Number(terminalRange),
+      boost_duration: Number(boostDuration),
+      datalink,
+    });
+  }
+</script>
+
+<Panel title="Munition Programming" domain="weapons" priority="secondary" className="munition-programming-panel">
+  <div class="shell">
+    <div class="grid">
+      <label><span>Guidance</span><input bind:value={guidanceMode} /></label>
+      <label><span>Warhead</span><input bind:value={warheadType} /></label>
+      <label><span>Profile</span><input bind:value={flightProfile} /></label>
+      <label><span>PN gain</span><input bind:value={pnGain} /></label>
+      <label><span>Fuse distance</span><input bind:value={fuseDistance} /></label>
+      <label><span>Terminal range</span><input bind:value={terminalRange} /></label>
+      <label><span>Boost duration</span><input bind:value={boostDuration} /></label>
+    </div>
+    <label class="toggle"><input type="checkbox" bind:checked={datalink} /> Datalink</label>
+    <button on:click={program}>PROGRAM MUNITION</button>
+  </div>
+</Panel>
+
+<style>
+  .shell,
+  .grid,
+  label {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    padding: 0;
+  }
+
+  span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0;
+  }
+</style>

--- a/gui-svelte/src/components/games/PdcThreatGame.svelte
+++ b/gui-svelte/src/components/games/PdcThreatGame.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { extractShipState, getThreatList } from "../tactical/tacticalData.js";
+
+  $: ship = extractShipState($gameState);
+  $: threats = getThreatList(ship).slice(0, 6);
+  let score = 0;
+
+  function hit(id: string) {
+    score += id.length;
+  }
+</script>
+
+<div class="radial-card">
+  <div class="radial">
+    {#each threats as threat, index}
+      <button
+        class="pip {threat.threatLevel}"
+        style={`left:${50 + Math.sin(index * 1.1) * 34}%; top:${50 - Math.cos(index * 1.1) * 34}%;`}
+        aria-label={`Intercept ${threat.id}`}
+        on:click={() => hit(threat.id)}
+      ></button>
+    {/each}
+  </div>
+  <div class="caption">Threat intercept score {score}</div>
+</div>
+
+<style>
+  .radial-card { display: grid; gap: 8px; padding: var(--space-sm); border-radius: var(--radius-sm); border: 1px solid var(--border-subtle); }
+  .radial { position: relative; aspect-ratio: 1; border-radius: 50%; border: 1px solid rgba(255,255,255,0.08); background: radial-gradient(circle, rgba(255,255,255,0.04), transparent 70%); }
+  .pip { position: absolute; transform: translate(-50%, -50%); width: 14px; height: 14px; border-radius: 50%; min-height: 0; padding: 0; }
+  .pip.green { background: #00ff88; }
+  .pip.yellow { background: #ffd84d; }
+  .pip.orange { background: #ff9d47; }
+  .pip.red { background: #ff4444; }
+  .caption { font-size: var(--font-size-xs); color: var(--text-secondary); }
+</style>

--- a/gui-svelte/src/components/games/RadiatorDeployGame.svelte
+++ b/gui-svelte/src/components/games/RadiatorDeployGame.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { getEngineeringShip, getEngineeringState, getThermalState, toNumber, toStringValue } from "../engineering/engineeringData.js";
+
+  const PANELS = ["PORT-1", "PORT-2", "DORSAL", "VENTRAL", "STBD-1", "STBD-2"];
+
+  let pending = false;
+
+  $: ship = getEngineeringShip($gameState);
+  $: engineering = getEngineeringState(ship);
+  $: thermal = getThermalState(ship);
+  $: deployed = Boolean(engineering.radiators_deployed);
+  $: priority = toStringValue(engineering.radiator_priority, "balanced");
+  $: thermalLoad = Math.max(0, Math.min(100, toNumber(thermal.temperature_percent)));
+  $: coolingScore = deployed ? Math.min(100, 45 + thermalLoad * 0.55) : Math.max(10, thermalLoad * 0.2);
+  $: radarSignature = deployed ? 78 : 28;
+
+  async function togglePanels() {
+    pending = true;
+    try {
+      await wsClient.sendShipCommand("manage_radiators", { deployed: !deployed });
+    } finally {
+      pending = false;
+    }
+  }
+
+  async function setPriority(value: string) {
+    pending = true;
+    try {
+      await wsClient.sendShipCommand("manage_radiators", { priority: value });
+    } finally {
+      pending = false;
+    }
+  }
+</script>
+
+<Panel title="Radiator Deploy" domain="power" priority="primary" className="radiator-deploy-game">
+  <div class="shell">
+    <div class="panel-grid">
+      {#each PANELS as panel}
+        <button type="button" class:active={deployed} disabled={pending} on:click={togglePanels}>
+          <span>{panel}</span>
+          <strong>{deployed ? "DEPLOYED" : "STOWED"}</strong>
+        </button>
+      {/each}
+    </div>
+
+    <div class="priority-row">
+      {#each ["balanced", "cooling", "stealth"] as mode}
+        <button class:selected={priority === mode} type="button" on:click={() => setPriority(mode)}>
+          {mode.toUpperCase()}
+        </button>
+      {/each}
+    </div>
+
+    <div class="tradeoff-card">
+      <div class="metric">
+        <span>Cooling</span>
+        <div class="track"><div class="fill cooling" style={`width:${coolingScore.toFixed(0)}%;`}></div></div>
+      </div>
+      <div class="metric">
+        <span>Radar Signature</span>
+        <div class="track"><div class="fill signature" style={`width:${radarSignature.toFixed(0)}%;`}></div></div>
+      </div>
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .panel-grid,
+  .priority-row {
+    display: grid;
+    gap: var(--space-xs);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .panel-grid button,
+  .priority-row button {
+    display: grid;
+    gap: 4px;
+    padding: 10px 8px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+  }
+
+  .panel-grid button.active,
+  .priority-row button.selected {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  .panel-grid span,
+  .metric span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .tradeoff-card {
+    display: grid;
+    gap: var(--space-sm);
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .metric {
+    display: grid;
+    gap: 6px;
+  }
+
+  .track {
+    height: 10px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .fill {
+    height: 100%;
+  }
+
+  .fill.cooling {
+    background: rgba(0, 255, 136, 0.8);
+  }
+
+  .fill.signature {
+    background: rgba(255, 122, 71, 0.88);
+  }
+</style>

--- a/gui-svelte/src/components/games/ReactorBalanceGame.svelte
+++ b/gui-svelte/src/components/games/ReactorBalanceGame.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { getEngineeringShip } from "../engineering/engineeringData.js";
+  import { getEngineeringState, getThermalState, toNumber } from "../engineering/engineeringData.js";
+
+  let canvas: HTMLCanvasElement;
+  let ctx: CanvasRenderingContext2D | null = null;
+  let frame = 0;
+  let outputDraft = 50;
+  let sweetSpot = 0.55;
+  let timer: number | null = null;
+  let rafId: number | null = null;
+
+  $: ship = getEngineeringShip($gameState);
+  $: engineering = getEngineeringState(ship);
+  $: thermal = getThermalState(ship);
+  $: powerLevel = toNumber(engineering.reactor_percent, toNumber(engineering.reactor_output) * 100);
+  $: heatLevel = Math.max(toNumber(thermal.temperature_percent), toNumber(thermal.hull_temperature) / Math.max(1, toNumber(thermal.max_temperature)) * 100);
+  $: outputDraft = Math.round(powerLevel);
+
+  onMount(() => {
+    ctx = canvas.getContext("2d");
+    const loop = () => {
+      frame += 1;
+      sweetSpot = 0.5 + Math.sin(frame / 90) * 0.18;
+      draw();
+      rafId = requestAnimationFrame(loop);
+    };
+    rafId = requestAnimationFrame(loop);
+    return () => {
+      if (rafId != null) cancelAnimationFrame(rafId);
+      if (timer != null) window.clearTimeout(timer);
+    };
+  });
+
+  function scheduleOutput(value: number) {
+    outputDraft = value;
+    if (timer != null) window.clearTimeout(timer);
+    timer = window.setTimeout(() => {
+      void wsClient.sendShipCommand("set_reactor_output", { output: value });
+    }, 50);
+  }
+
+  function drawMeter(x: number, label: string, value: number, hue: string) {
+    if (!ctx) return;
+    const top = 26;
+    const height = 150;
+    const width = 72;
+    const sweetY = top + height * (1 - sweetSpot);
+
+    ctx.fillStyle = "rgba(12, 18, 28, 0.92)";
+    ctx.fillRect(x, top, width, height);
+    ctx.strokeStyle = "rgba(150, 170, 210, 0.18)";
+    ctx.strokeRect(x, top, width, height);
+
+    ctx.fillStyle = "rgba(68, 136, 255, 0.12)";
+    ctx.fillRect(x + 2, sweetY - 16, width - 4, 32);
+
+    const markerY = top + height * (1 - Math.max(0, Math.min(100, value)) / 100);
+    ctx.fillStyle = hue;
+    ctx.fillRect(x + 6, markerY - 6, width - 12, 12);
+
+    ctx.fillStyle = "#d8e4ff";
+    ctx.font = "12px var(--font-mono)";
+    ctx.fillText(label, x, 198);
+    ctx.fillText(`${Math.round(value)}%`, x, 214);
+  }
+
+  function draw() {
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "#060912";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.fillStyle = "#8da4d8";
+    ctx.font = "12px var(--font-mono)";
+    ctx.fillText("KEEP BOTH METERS INSIDE THE DRIFTING SWEET SPOT", 18, 18);
+
+    drawMeter(28, "POWER", powerLevel, "#4da3ff");
+    drawMeter(132, "HEAT", heatLevel, "#ff8047");
+
+    const balance = Math.max(0, 100 - Math.abs(powerLevel - heatLevel) - Math.abs(powerLevel - sweetSpot * 100));
+    ctx.fillStyle = "#aeb9d4";
+    ctx.fillText(`BALANCE ${Math.round(balance)}%`, 252, 48);
+    ctx.strokeStyle = "rgba(114, 145, 204, 0.25)";
+    ctx.strokeRect(248, 60, 120, 18);
+    ctx.fillStyle = "rgba(68, 136, 255, 0.7)";
+    ctx.fillRect(250, 62, Math.max(0, Math.min(116, balance * 1.16)), 14);
+
+    ctx.fillStyle = "#8da4d8";
+    ctx.fillText(`SWEET SPOT ${Math.round(sweetSpot * 100)}%`, 252, 96);
+    ctx.fillText(`OUTPUT ${outputDraft}%`, 252, 124);
+    ctx.fillText(`THERMAL ${Math.round(heatLevel)}%`, 252, 152);
+  }
+</script>
+
+<Panel title="Reactor Balance" domain="power" priority="primary" className="reactor-balance-game">
+  <div class="shell">
+    <canvas bind:this={canvas} width="390" height="226"></canvas>
+    <div class="slider-row">
+      <span>Output</span>
+      <input type="range" min="0" max="100" step="1" value={outputDraft} on:input={(event) => scheduleOutput(Number((event.currentTarget as HTMLInputElement).value))} />
+      <strong>{outputDraft}%</strong>
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  canvas {
+    width: 100%;
+    height: auto;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: #060912;
+  }
+
+  .slider-row {
+    display: flex;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .slider-row span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .slider-row input {
+    flex: 1;
+  }
+
+  .slider-row strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+</style>

--- a/gui-svelte/src/components/games/SensorSweepGame.svelte
+++ b/gui-svelte/src/components/games/SensorSweepGame.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { extractShipState, getTacticalContacts } from "../tactical/tacticalData.js";
+
+  let canvas: HTMLCanvasElement | null = null;
+
+  $: ship = extractShipState($gameState);
+  $: contacts = getTacticalContacts(ship).slice(0, 6);
+
+  onMount(() => {
+    if (!canvas) return undefined;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return undefined;
+    let raf = 0;
+
+    const draw = (time: number) => {
+      if (!canvas) return;
+      const w = canvas.width;
+      const h = canvas.height;
+      const cx = w / 2;
+      const cy = h / 2;
+      const sweep = (time / 1000) % (Math.PI * 2);
+
+      ctx.clearRect(0, 0, w, h);
+      ctx.fillStyle = "#071018";
+      ctx.fillRect(0, 0, w, h);
+      ctx.strokeStyle = "rgba(0,255,180,0.18)";
+      [34, 64, 96].forEach((r) => {
+        ctx.beginPath();
+        ctx.arc(cx, cy, r, 0, Math.PI * 2);
+        ctx.stroke();
+      });
+
+      ctx.beginPath();
+      ctx.moveTo(cx, cy);
+      ctx.lineTo(cx + Math.sin(sweep) * 96, cy - Math.cos(sweep) * 96);
+      ctx.strokeStyle = "rgba(0,255,180,0.55)";
+      ctx.stroke();
+
+      contacts.forEach((contact, index) => {
+        const angle = ((contact.bearing + 180) * Math.PI) / 180;
+        const radius = 30 + index * 14;
+        const x = cx + Math.sin(angle) * radius;
+        const y = cy - Math.cos(angle) * radius;
+        const lit = Math.abs(angle - sweep) < 0.45;
+        ctx.fillStyle = lit ? "#00ff88" : "rgba(0,255,136,0.22)";
+        ctx.beginPath();
+        ctx.arc(x, y, lit ? 4 : 3, 0, Math.PI * 2);
+        ctx.fill();
+      });
+
+      raf = requestAnimationFrame(draw);
+    };
+
+    raf = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(raf);
+  });
+</script>
+
+<Panel title="Sensor Sweep" domain="sensor" priority="secondary" className="sensor-sweep-game">
+  <div class="shell">
+    <canvas bind:this={canvas} width="220" height="220"></canvas>
+    <div class="caption">Arcade ping cue. Read the sweep and react to the strongest returns.</div>
+  </div>
+</Panel>
+
+<style>
+  .shell { display: grid; gap: 8px; padding: var(--space-sm); }
+  canvas { width: 100%; height: auto; border-radius: var(--radius-sm); border: 1px solid var(--border-subtle); background: #071018; }
+  .caption { font-size: var(--font-size-xs); color: var(--text-secondary); }
+</style>

--- a/gui-svelte/src/components/games/SpectralAnalysisGame.svelte
+++ b/gui-svelte/src/components/games/SpectralAnalysisGame.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { selectedScienceContactId } from "../../lib/stores/scienceUi.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    findScienceContact,
+    getScienceContacts,
+    getScienceShip,
+    spectralBandsForContact,
+  } from "../science/scienceData.js";
+
+  let sliders = [50, 50, 50];
+  let solvedTarget = "";
+
+  $: ship = getScienceShip($gameState);
+  $: contacts = getScienceContacts(ship);
+  $: if (!$selectedScienceContactId && contacts.length) selectedScienceContactId.set(contacts[0].id);
+  $: contact = findScienceContact(ship, $selectedScienceContactId);
+  $: target = spectralBandsForContact(contact).slice(0, 3).map((band) => band.value);
+  $: match = target.length
+    ? Math.max(
+        0,
+        100 - (Math.abs(sliders[0] - target[0]) + Math.abs(sliders[1] - target[1]) + Math.abs(sliders[2] - target[2])) / 3,
+      )
+    : 0;
+  $: if (contact && match >= 92 && solvedTarget !== contact.id) {
+    solvedTarget = contact.id;
+    void wsClient.sendShipCommand("analyze_contact", { contact_id: contact.id });
+  }
+</script>
+
+<Panel title="Spectral Match" domain="sensor" priority="secondary" className="spectral-analysis-game">
+  <div class="shell">
+    <div class="head">
+      <strong>{contact ? contact.id : "PRACTICE"}</strong>
+      <span>{Math.round(match)}% match</span>
+    </div>
+
+    {#each ["IR", "EM", "RCS"] as label, index}
+      <label class="row">
+        <span>{label}</span>
+        <input type="range" min="0" max="100" bind:value={sliders[index]} />
+        <strong>{Math.round(sliders[index])}</strong>
+      </label>
+    {/each}
+
+    <div class="track"><div class="fill" style={`width:${match.toFixed(1)}%;`}></div></div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: 10px;
+    padding: var(--space-sm);
+  }
+
+  .head,
+  .row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  .row input {
+    flex: 1;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .track {
+    height: 8px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(255, 165, 0, 0.8), rgba(0, 255, 136, 0.8));
+  }
+</style>

--- a/gui-svelte/src/components/games/TargetingLockGame.svelte
+++ b/gui-svelte/src/components/games/TargetingLockGame.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  let cursor = 0;
+  let score = 0;
+  let zone = 42;
+  let direction = 1;
+  let ticker: number | null = null;
+
+  function tick() {
+    cursor += direction * 1.8;
+    if (cursor >= 100 || cursor <= 0) direction *= -1;
+    zone = 45 + Math.sin(Date.now() / 700) * 18;
+    ticker = window.setTimeout(tick, 24);
+  }
+
+  function capture() {
+    const delta = Math.abs(cursor - zone);
+    score = Math.max(0, 100 - delta * 4);
+  }
+
+  onMount(() => {
+    tick();
+    return () => {
+      if (ticker != null) window.clearTimeout(ticker);
+    };
+  });
+</script>
+
+<div class="game-card">
+  <div class="bar">
+    <div class="zone" style={`left:${zone - 8}%`}></div>
+    <div class="cursor" style={`left:${cursor}%`}></div>
+  </div>
+  <button on:click={capture}>LOCK</button>
+  <div class="score">Lock score {Math.round(score)}%</div>
+</div>
+
+<style>
+  .game-card { display: grid; gap: 10px; padding: var(--space-sm); border-radius: var(--radius-sm); border: 1px solid var(--border-subtle); }
+  .bar { position: relative; height: 22px; border-radius: 999px; background: var(--bg-input); overflow: hidden; }
+  .zone { position: absolute; top: 0; width: 16%; height: 100%; background: rgba(0,255,136,0.22); }
+  .cursor { position: absolute; top: 0; width: 4px; height: 100%; background: #00aaff; }
+  .score { font-size: var(--font-size-xs); color: var(--text-secondary); }
+</style>

--- a/gui-svelte/src/components/games/WeaponsChargeGame.svelte
+++ b/gui-svelte/src/components/games/WeaponsChargeGame.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  let phase = 0;
+  let timer: number | null = null;
+  let success = 0;
+
+  function loop() {
+    phase = (phase + 2.5) % 100;
+    timer = window.setTimeout(loop, 40);
+  }
+
+  function pulse() {
+    success = 100 - Math.abs(phase - 76) * 3;
+  }
+
+  onMount(() => {
+    loop();
+    return () => {
+      if (timer != null) window.clearTimeout(timer);
+    };
+  });
+</script>
+
+<div class="card">
+  <div class="track">
+    <div class="sweet"></div>
+    <div class="needle" style={`left:${phase}%`}></div>
+  </div>
+  <button on:click={pulse}>DISCHARGE</button>
+  <div class="caption">Charge timing {Math.max(0, Math.round(success))}%</div>
+</div>
+
+<style>
+  .card { display: grid; gap: 10px; padding: var(--space-sm); border-radius: var(--radius-sm); border: 1px solid var(--border-subtle); }
+  .track { position: relative; height: 18px; border-radius: 999px; background: var(--bg-input); }
+  .sweet { position: absolute; left: 70%; width: 12%; height: 100%; background: rgba(0,255,136,0.22); }
+  .needle { position: absolute; top: -2px; width: 4px; height: 22px; background: #ffcc44; }
+  .caption { font-size: var(--font-size-xs); color: var(--text-secondary); }
+</style>

--- a/gui-svelte/src/components/helm/AutopilotStatus.svelte
+++ b/gui-svelte/src/components/helm/AutopilotStatus.svelte
@@ -1,0 +1,266 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    asRecord,
+    extractShipState,
+    formatDistance,
+    formatDuration,
+    getAutopilotSnapshot,
+    getCourse,
+    getWaypoint,
+    toNumber,
+  } from "./helmData.js";
+
+  let busy = false;
+  let feedback = "";
+
+  $: ship = extractShipState($gameState);
+  $: autopilot = getAutopilotSnapshot(ship);
+  $: course = getCourse(ship);
+  $: waypoint = getWaypoint(ship);
+  $: courseDestination = waypoint ?? null;
+  $: canResume = Boolean(autopilot.program || courseDestination);
+  $: statusText = autopilot.status || (autopilot.active ? "Autopilot active" : "Standing by");
+  $: progressWidth = `${autopilot.progress.toFixed(0)}%`;
+
+  async function toggleAutopilot() {
+    busy = true;
+    feedback = "";
+
+    try {
+      if (autopilot.active) {
+        await wsClient.sendShipCommand("autopilot", {
+          enable: false,
+          program: "off",
+        });
+        feedback = "Autopilot disengaged";
+      } else if (autopilot.program) {
+        await wsClient.sendShipCommand("autopilot", {
+          enable: true,
+          program: autopilot.program,
+          target: autopilot.targetId || undefined,
+        });
+        feedback = `Autopilot engaged: ${autopilot.program}`;
+      } else if (courseDestination) {
+        await wsClient.sendShipCommand("set_course", {
+          x: courseDestination.x,
+          y: courseDestination.y,
+          z: courseDestination.z,
+          stop: true,
+        });
+        feedback = "Course resumed";
+      }
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Autopilot command failed";
+    } finally {
+      busy = false;
+    }
+  }
+
+  function phaseLabel(): string {
+    if (!autopilot.phase) return "IDLE";
+    return autopilot.phase.replaceAll("_", " ").toUpperCase();
+  }
+
+  function displayDistance(): string {
+    return formatDistance(autopilot.distance);
+  }
+
+  function displayEta(): string {
+    return formatDuration(autopilot.eta);
+  }
+
+  function phaseVariant(): string {
+    const phase = autopilot.phase.toLowerCase();
+    if (phase.includes("burn") || phase.includes("accel")) return "burn";
+    if (phase.includes("coast")) return "coast";
+    if (phase.includes("brake") || phase.includes("decel")) return "brake";
+    if (phase.includes("hold") || phase.includes("stationkeep")) return "hold";
+    return "idle";
+  }
+
+  $: autopilotState = asRecord(ship.autopilot_state) ?? asRecord(getCourse(ship));
+  $: rawEta = autopilot.eta ?? toNumber(autopilotState?.time_to_arrival, 0);
+</script>
+
+<Panel title="Autopilot Status" domain="helm" priority={autopilot.active ? "primary" : "secondary"} className="autopilot-status-panel">
+  <div class="status-grid">
+    <div class="header-row">
+      <div>
+        <div class="program">{autopilot.program ? autopilot.program.replaceAll("_", " ").toUpperCase() : "NO PROGRAM"}</div>
+        <div class="status-text">{statusText}</div>
+      </div>
+      <div class="phase {phaseVariant()}">{phaseLabel()}</div>
+    </div>
+
+    <div class="progress-track" aria-label="Autopilot progress">
+      <div class="progress-fill {phaseVariant()}" style={`width: ${progressWidth};`}></div>
+    </div>
+    <div class="progress-caption">{autopilot.progress.toFixed(0)}%</div>
+
+    <div class="metrics">
+      <div class="metric">
+        <span>Distance</span>
+        <strong>{displayDistance()}</strong>
+      </div>
+      <div class="metric">
+        <span>ETA</span>
+        <strong>{rawEta > 0 ? displayEta() : "--"}</strong>
+      </div>
+      <div class="metric">
+        <span>Target</span>
+        <strong>{autopilot.targetId || "--"}</strong>
+      </div>
+    </div>
+
+    <button class:disengage={autopilot.active} disabled={busy || (!autopilot.active && !canResume)} on:click={toggleAutopilot}>
+      {#if autopilot.active}
+        DISENGAGE
+      {:else if autopilot.program}
+        ENGAGE
+      {:else if courseDestination}
+        RESUME COURSE
+      {:else}
+        NO COURSE
+      {/if}
+    </button>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .status-grid {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .header-row {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  .program {
+    font-family: var(--font-mono);
+    font-size: 0.92rem;
+    color: var(--text-primary);
+    letter-spacing: 0.06em;
+  }
+
+  .status-text,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  .phase {
+    padding: 5px 10px;
+    border-radius: 999px;
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    border: 1px solid var(--border-default);
+  }
+
+  .phase.burn {
+    color: var(--status-warning);
+    border-color: rgba(255, 170, 0, 0.4);
+  }
+
+  .phase.coast {
+    color: var(--status-info);
+    border-color: rgba(0, 170, 255, 0.4);
+  }
+
+  .phase.brake {
+    color: var(--status-critical);
+    border-color: rgba(255, 68, 68, 0.4);
+  }
+
+  .phase.hold {
+    color: var(--status-nominal);
+    border-color: rgba(0, 255, 136, 0.4);
+  }
+
+  .progress-track {
+    height: 10px;
+    background: var(--bg-input);
+    border-radius: 999px;
+    overflow: hidden;
+    border: 1px solid var(--border-subtle);
+  }
+
+  .progress-fill {
+    height: 100%;
+    transition: width var(--transition-base);
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.35), var(--tier-accent));
+  }
+
+  .progress-fill.burn {
+    background: linear-gradient(90deg, rgba(255, 170, 0, 0.25), var(--status-warning));
+  }
+
+  .progress-fill.coast {
+    background: linear-gradient(90deg, rgba(0, 170, 255, 0.25), var(--status-info));
+  }
+
+  .progress-fill.brake {
+    background: linear-gradient(90deg, rgba(255, 68, 68, 0.25), var(--status-critical));
+  }
+
+  .progress-fill.hold {
+    background: linear-gradient(90deg, rgba(0, 255, 136, 0.25), var(--status-nominal));
+  }
+
+  .progress-caption {
+    margin-top: -4px;
+    text-align: right;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--text-dim);
+  }
+
+  .metrics {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .metric {
+    display: grid;
+    gap: 2px;
+    padding: 8px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.015);
+  }
+
+  .metric span {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-dim);
+  }
+
+  .metric strong {
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+  }
+
+  button.disengage {
+    border-color: rgba(255, 68, 68, 0.4);
+    color: var(--status-critical);
+  }
+
+  button.disengage:hover:not(:disabled) {
+    background: rgba(255, 68, 68, 0.08);
+  }
+</style>

--- a/gui-svelte/src/components/helm/DockingPanel.svelte
+++ b/gui-svelte/src/components/helm/DockingPanel.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { selectedHelmTargetId } from "../../lib/stores/helmUi.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    clamp,
+    extractShipState,
+    findContact,
+    formatDistance,
+    formatSpeed,
+    getContacts,
+    getDockingSnapshot,
+    getOrientation,
+    headingToTarget,
+    normalizeAngle,
+    toStringValue,
+  } from "./helmData.js";
+
+  let feedback = "";
+
+  $: ship = extractShipState($gameState);
+  $: contacts = getContacts(ship);
+  $: docking = getDockingSnapshot(ship);
+  $: currentTargetId = docking.targetId || $selectedHelmTargetId || toStringValue(ship.target_id);
+  $: stateLabel = docking.status === "docked" ? "docked" : docking.status === "idle" ? "free" : "approaching";
+  $: contact = currentTargetId ? findContact(ship, currentTargetId) : null;
+  $: guidanceHeading = contact ? headingToTarget(ship, contact.position) : null;
+  $: shipHeading = getOrientation(ship);
+  $: alignment = guidanceHeading
+    ? clamp(100 - ((Math.abs(normalizeAngle(guidanceHeading.yaw - shipHeading.yaw)) + Math.abs(guidanceHeading.pitch - shipHeading.pitch)) / 180) * 100, 0, 100)
+    : stateLabel === "docked" ? 100 : 0;
+
+  function onTargetChange(event: Event) {
+    selectedHelmTargetId.set((event.currentTarget as HTMLSelectElement).value);
+  }
+
+  async function requestDocking() {
+    if (!currentTargetId) {
+      feedback = "Select a contact first";
+      return;
+    }
+    await wsClient.sendShipCommand("request_docking", { target_id: currentTargetId });
+    feedback = `Docking requested with ${currentTargetId}`;
+  }
+
+  async function cancelDocking() {
+    await wsClient.sendShipCommand("cancel_docking", {});
+    feedback = "Docking cancelled";
+  }
+
+  async function undock() {
+    await wsClient.sendShipCommand("undock", {});
+    feedback = "Undocked";
+  }
+</script>
+
+<Panel title="Docking" domain="helm" priority={stateLabel === "docked" ? "primary" : "secondary"} className="docking-panel">
+  <div class="shell">
+    <div class="status-row">
+      <div class="state {stateLabel}">{stateLabel.toUpperCase()}</div>
+      <div class="target">{currentTargetId || "No target"}</div>
+    </div>
+
+    <label>
+      Docking target
+      <select value={currentTargetId} on:change={onTargetChange} disabled={stateLabel === "docked"}>
+        <option value="">Select a contact</option>
+        {#each contacts as entry}
+          <option value={entry.id}>{entry.id} · {entry.name}</option>
+        {/each}
+      </select>
+    </label>
+
+    <div class="guidance-grid">
+      <div><span>Range</span><strong>{formatDistance(docking.range)}</strong></div>
+      <div><span>Alignment</span><strong>{alignment.toFixed(0)}%</strong></div>
+      <div><span>Rel velocity</span><strong>{formatSpeed(docking.relativeVelocity)}</strong></div>
+    </div>
+
+    {#if docking.serviceReport}
+      <div class="service">
+        <div class="eyebrow">Station service</div>
+        <div class="guidance-grid">
+          <div><span>Hull</span><strong>+{docking.serviceReport.hull_repaired ?? 0}</strong></div>
+          <div><span>Fuel</span><strong>+{docking.serviceReport.fuel_added ?? 0}</strong></div>
+          <div><span>Weapons</span><strong>+{docking.serviceReport.weapons_resupplied ?? 0}</strong></div>
+        </div>
+      </div>
+    {/if}
+
+    <div class="actions">
+      <button on:click={requestDocking} disabled={stateLabel === "docked" || !currentTargetId}>REQUEST DOCK</button>
+      <button on:click={cancelDocking} disabled={stateLabel === "free" || stateLabel === "docked"}>CANCEL</button>
+      <button class="danger" on:click={undock} disabled={stateLabel !== "docked"}>UNDOCK</button>
+    </div>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .status-row,
+  .guidance-grid,
+  .actions {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .status-row,
+  .guidance-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .state,
+  .target,
+  .guidance-grid div,
+  .service {
+    padding: 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .state.free {
+    color: var(--text-secondary);
+  }
+
+  .state.approaching {
+    color: var(--status-warning);
+  }
+
+  .state.docked {
+    color: var(--status-nominal);
+  }
+
+  .guidance-grid span,
+  .feedback,
+  .eyebrow,
+  label {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .guidance-grid strong,
+  .target {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .actions {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .danger {
+    border-color: rgba(255, 68, 68, 0.4);
+    color: var(--status-critical);
+  }
+</style>

--- a/gui-svelte/src/components/helm/FlightComputerPanel.svelte
+++ b/gui-svelte/src/components/helm/FlightComputerPanel.svelte
@@ -1,0 +1,457 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { selectedHelmTargetId } from "../../lib/stores/helmUi.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    asRecord,
+    extractShipState,
+    formatDistance,
+    formatDuration,
+    getAutopilotSnapshot,
+    getContacts,
+    toNumber,
+    toStringValue,
+  } from "./helmData.js";
+
+  type ProfileName = "aggressive" | "balanced" | "conservative";
+  type CommandName = "rendezvous" | "intercept" | "match" | "hold";
+
+  interface SolutionCard {
+    profile: ProfileName;
+    totalTime: number;
+    fuelCost: number;
+    accuracy: number;
+    riskLevel: string;
+    description: string;
+    maxThrust: number;
+    estimatedFlipTime: number;
+  }
+
+  let profile: ProfileName = "balanced";
+  let xInput = "";
+  let yInput = "";
+  let zInput = "";
+  let vxInput = "";
+  let vyInput = "";
+  let vzInput = "";
+  let navSolutions: SolutionCard[] = [];
+  let busy = false;
+  let navBusy = false;
+  let feedback = "";
+  let pollHandle: number | null = null;
+
+  $: ship = extractShipState($gameState);
+  $: contacts = getContacts(ship);
+  $: shipTargetId = toStringValue(ship.target_id);
+  $: activeTargetId = $selectedHelmTargetId || shipTargetId;
+  $: autopilot = getAutopilotSnapshot(ship);
+  $: arcadeTier = $tier === "arcade";
+  $: cpuAssistTier = $tier === "cpu-assist";
+  $: rawTier = $tier === "raw";
+  $: hasCoords = [xInput, yInput, zInput].every((value) => value.trim() !== "");
+  $: canSolve = Boolean(activeTargetId || hasCoords);
+  $: recommended = pickRecommended(navSolutions);
+
+  onMount(() => {
+    void refreshSolutions();
+    pollHandle = window.setInterval(() => {
+      if (canSolve && (rawTier || cpuAssistTier)) void refreshSolutions();
+    }, 5000);
+
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  function toSolutionCards(source: unknown): SolutionCard[] {
+    const solutions = asRecord(asRecord(source)?.solutions);
+    if (!solutions) return [];
+
+    return (Object.entries(solutions) as [string, unknown][])
+      .map(([name, value]) => {
+        const row = asRecord(value);
+        if (!row) return null;
+        return {
+          profile: (name as ProfileName),
+          totalTime: toNumber(row.total_time),
+          fuelCost: toNumber(row.fuel_cost),
+          accuracy: toNumber(row.accuracy),
+          riskLevel: toStringValue(row.risk_level, "medium"),
+          description: toStringValue(row.description),
+          maxThrust: toNumber(row.max_thrust),
+          estimatedFlipTime: toNumber(row.estimated_flip_time),
+        };
+      })
+      .filter((row): row is SolutionCard => Boolean(row));
+  }
+
+  function pickRecommended(solutions: SolutionCard[]): SolutionCard | null {
+    if (solutions.length === 0) return null;
+    const penalties: Record<string, number> = { low: 0.08, medium: 0.2, high: 0.38 };
+    const sorted = [...solutions].sort((a, b) => {
+      const scoreA = a.fuelCost + a.totalTime / 10_000 + (penalties[a.riskLevel] ?? 0.2);
+      const scoreB = b.fuelCost + b.totalTime / 10_000 + (penalties[b.riskLevel] ?? 0.2);
+      return scoreA - scoreB;
+    });
+    return sorted[0];
+  }
+
+  async function refreshSolutions() {
+    if (!canSolve) {
+      navSolutions = [];
+      return;
+    }
+
+    navBusy = true;
+    try {
+      const params = activeTargetId
+        ? { target_id: activeTargetId }
+        : { x: Number(xInput), y: Number(yInput), z: Number(zInput) };
+      const response = await wsClient.sendShipCommand("get_nav_solutions", params);
+      navSolutions = toSolutionCards(response);
+    } catch {
+      navSolutions = [];
+    } finally {
+      navBusy = false;
+    }
+  }
+
+  async function engageCommand(program: CommandName) {
+    busy = true;
+    feedback = "";
+
+    try {
+      if (program === "hold") {
+        await wsClient.sendShipCommand("autopilot", { enable: true, program: "hold" });
+        feedback = "Hold position engaged";
+      } else {
+        if (!activeTargetId) {
+          feedback = "Select a target first";
+          return;
+        }
+
+        await wsClient.sendShipCommand("autopilot", {
+          enable: true,
+          program,
+          target: activeTargetId,
+          profile,
+        });
+        feedback = `${program.toUpperCase()} engaged`;
+      }
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Flight computer command failed";
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function setCourse() {
+    if (!hasCoords) {
+      feedback = "Enter X/Y/Z coordinates";
+      return;
+    }
+
+    busy = true;
+    feedback = "";
+
+    try {
+      await wsClient.sendShipCommand("set_course", {
+        x: Number(xInput),
+        y: Number(yInput),
+        z: Number(zInput),
+        stop: true,
+        profile,
+      });
+      feedback = "Course uploaded";
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Course upload failed";
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function approveRecommended() {
+    if (activeTargetId) {
+      await engageCommand("rendezvous");
+      return;
+    }
+
+    await setCourse();
+  }
+
+  function onTargetChange(event: Event) {
+    const target = event.currentTarget as HTMLSelectElement;
+    selectedHelmTargetId.set(target.value);
+    void refreshSolutions();
+  }
+
+  function onCoordinateBlur() {
+    void refreshSolutions();
+  }
+</script>
+
+<Panel title="Flight Computer" domain="helm" priority={arcadeTier || cpuAssistTier ? "primary" : "secondary"} className="flight-computer-panel">
+  <div class="content">
+    {#if !arcadeTier}
+      <div class="selector-row">
+        <label>
+          Target
+          <select on:change={onTargetChange} value={activeTargetId}>
+            <option value="">Custom coordinates</option>
+            {#each contacts as contact}
+              <option value={contact.id}>{contact.id} · {contact.name}</option>
+            {/each}
+          </select>
+        </label>
+
+        <div class="profile-selector">
+          {#each ["aggressive", "balanced", "conservative"] as candidate}
+            <button class:selected={profile === candidate} type="button" on:click={() => { profile = candidate as ProfileName; void refreshSolutions(); }}>
+              {candidate}
+            </button>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    {#if rawTier}
+      <div class="coordinate-grid">
+        <label><span>X</span><input bind:value={xInput} on:blur={onCoordinateBlur} placeholder="0" /></label>
+        <label><span>Y</span><input bind:value={yInput} on:blur={onCoordinateBlur} placeholder="0" /></label>
+        <label><span>Z</span><input bind:value={zInput} on:blur={onCoordinateBlur} placeholder="0" /></label>
+      </div>
+      <div class="velocity-grid">
+        <label><span>Vx target</span><input bind:value={vxInput} placeholder="optional" /></label>
+        <label><span>Vy target</span><input bind:value={vyInput} placeholder="optional" /></label>
+        <label><span>Vz target</span><input bind:value={vzInput} placeholder="optional" /></label>
+      </div>
+    {/if}
+
+    {#if arcadeTier}
+      <div class="command-grid arcade">
+        <button disabled={busy || !activeTargetId} on:click={() => engageCommand("rendezvous")}>RENDEZVOUS</button>
+        <button disabled={busy || !activeTargetId} on:click={() => engageCommand("intercept")}>INTERCEPT</button>
+        <button disabled={busy || !activeTargetId} on:click={() => engageCommand("match")}>MATCH VELOCITY</button>
+        <button disabled={busy} on:click={() => engageCommand("hold")}>HOLD POSITION</button>
+      </div>
+    {:else if cpuAssistTier}
+      <div class="assist-shell">
+        <div class="assist-header">
+          <div>
+            <div class="eyebrow">Recommended Solution</div>
+            <div class="assist-title">{recommended ? recommended.profile.toUpperCase() : "No solution loaded"}</div>
+          </div>
+          <button disabled={busy || (!recommended && !canSolve)} on:click={approveRecommended}>
+            APPROVE
+          </button>
+        </div>
+
+        {#if recommended}
+          <div class="assist-card">
+            <div class="assist-stat"><span>ETA</span><strong>{formatDuration(recommended.totalTime)}</strong></div>
+            <div class="assist-stat"><span>Fuel</span><strong>{(recommended.fuelCost * 100).toFixed(1)}%</strong></div>
+            <div class="assist-stat"><span>Risk</span><strong>{recommended.riskLevel.toUpperCase()}</strong></div>
+            <div class="assist-stat"><span>Range</span><strong>{formatDistance(autopilot.distance)}</strong></div>
+          </div>
+          <div class="assist-notes">{recommended.description}</div>
+        {/if}
+      </div>
+    {:else}
+      <div class="command-grid">
+        <button disabled={busy || !activeTargetId} on:click={() => engageCommand("rendezvous")}>Rendezvous</button>
+        <button disabled={busy || !activeTargetId} on:click={() => engageCommand("intercept")}>Intercept</button>
+        <button disabled={busy || !activeTargetId} on:click={() => engageCommand("match")}>Match Velocity</button>
+        <button disabled={busy} on:click={() => engageCommand("hold")}>Hold Position</button>
+        <button class="wide" disabled={busy || !hasCoords} on:click={setCourse}>Set Course</button>
+        <button class="wide secondary" disabled={navBusy || !canSolve} on:click={refreshSolutions}>Refresh Solutions</button>
+      </div>
+    {/if}
+
+    {#if rawTier}
+      <div class="solutions-shell">
+        <div class="eyebrow">Nav Solutions</div>
+        {#if navBusy}
+          <div class="empty">Calculating profiles…</div>
+        {:else if navSolutions.length === 0}
+          <div class="empty">Choose a target or coordinates to generate profiles.</div>
+        {:else}
+          <div class="solution-table">
+            {#each navSolutions as solution}
+              <button type="button" class:selected={profile === solution.profile} class="solution-card" on:click={() => (profile = solution.profile)}>
+                <div class="solution-header">
+                  <strong>{solution.profile.toUpperCase()}</strong>
+                  <span>{solution.riskLevel.toUpperCase()}</span>
+                </div>
+                <div class="solution-row"><span>ETA</span><span>{formatDuration(solution.totalTime)}</span></div>
+                <div class="solution-row"><span>Fuel</span><span>{(solution.fuelCost * 100).toFixed(1)}%</span></div>
+                <div class="solution-row"><span>Accuracy</span><span>{formatDistance(solution.accuracy)}</span></div>
+                <div class="solution-row"><span>Flip</span><span>{formatDuration(solution.estimatedFlipTime)}</span></div>
+                <div class="solution-row"><span>Max thrust</span><span>{(solution.maxThrust * 100).toFixed(0)}%</span></div>
+                <p>{solution.description}</p>
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/if}
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .content {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .selector-row,
+  .assist-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  label {
+    display: grid;
+    gap: 4px;
+    min-width: 0;
+    flex: 1;
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  select,
+  input {
+    width: 100%;
+  }
+
+  .profile-selector,
+  .command-grid {
+    display: grid;
+    gap: var(--space-xs);
+  }
+
+  .profile-selector {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    flex: 1;
+  }
+
+  .profile-selector button.selected,
+  .solution-card.selected {
+    border-color: rgba(var(--tier-accent-rgb), 0.55);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  .coordinate-grid,
+  .velocity-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .command-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .command-grid.arcade {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .command-grid.arcade button {
+    min-height: 74px;
+    font-family: var(--font-mono);
+    letter-spacing: 0.08em;
+  }
+
+  .command-grid .wide {
+    grid-column: span 2;
+  }
+
+  .command-grid .secondary {
+    border-style: dashed;
+  }
+
+  .solutions-shell,
+  .assist-shell {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .solution-table {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .solution-card,
+  .assist-card {
+    display: grid;
+    gap: 6px;
+    padding: 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.02);
+    text-align: left;
+  }
+
+  .solution-header,
+  .solution-row,
+  .assist-stat {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: baseline;
+  }
+
+  .solution-card strong,
+  .assist-title,
+  .assist-stat strong {
+    font-family: var(--font-mono);
+  }
+
+  .solution-card p,
+  .assist-notes,
+  .empty,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  .eyebrow {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-dim);
+  }
+
+  .assist-title {
+    font-size: 1rem;
+  }
+
+  .assist-card {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (max-width: 900px) {
+    .selector-row,
+    .assist-header {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .solution-table,
+    .assist-card,
+    .coordinate-grid,
+    .velocity-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/gui-svelte/src/components/helm/FlightDataPanel.svelte
+++ b/gui-svelte/src/components/helm/FlightDataPanel.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import {
+    computeRelativeSpeed,
+    extractShipState,
+    formatDistance,
+    formatSpeed,
+    formatVector,
+    getAutopilotSnapshot,
+    getDeltaV,
+    getOrientation,
+    getPONR,
+    getPosition,
+    getVelocity,
+    magnitude,
+    signed,
+    toNumber,
+    toPercent,
+    toStringValue,
+  } from "./helmData.js";
+
+  $: ship = extractShipState($gameState);
+  $: position = getPosition(ship);
+  $: velocity = getVelocity(ship);
+  $: heading = getOrientation(ship);
+  $: speed = magnitude(velocity);
+  $: autopilot = getAutopilotSnapshot(ship);
+  $: relativeSpeed = computeRelativeSpeed(ship, autopilot.targetId || toStringValue(ship.target_id));
+  $: deltaV = getDeltaV(ship);
+  $: ponr = getPONR(ship);
+  $: pastPonr = Boolean(ponr.past_ponr);
+  $: manualLike = $tier === "manual" || $tier === "raw";
+  $: showRawVectors = manualLike;
+  $: stopMargin = toNumber(ponr.dv_margin);
+</script>
+
+<Panel title="Flight Data" domain="helm" priority={$tier === "manual" ? "primary" : "secondary"} className="flight-data-panel">
+  <div class="stack">
+    {#if pastPonr}
+      <div class="alert critical">PAST POINT OF NO RETURN</div>
+    {:else if toNumber(ponr.margin_percent, 100) < 25 && toNumber(ponr.dv_to_stop) > 0}
+      <div class="alert warning">Brake margin {toPercent(toNumber(ponr.margin_percent), 0)} · reserve {formatSpeed(stopMargin)}</div>
+    {/if}
+
+    <section class="section">
+      <div class="section-title">Position</div>
+      <div class="metric-row">
+        <span class="label">X</span>
+        <span class="value">{formatDistance(position.x)}</span>
+      </div>
+      <div class="metric-row">
+        <span class="label">Y</span>
+        <span class="value">{formatDistance(position.y)}</span>
+      </div>
+      <div class="metric-row">
+        <span class="label">Z</span>
+        <span class="value">{formatDistance(position.z)}</span>
+      </div>
+      {#if showRawVectors}
+        <div class="vector-readout">{formatVector(position, 1)}</div>
+      {/if}
+    </section>
+
+    <section class="section">
+      <div class="section-title">Velocity</div>
+      <div class="hero">{formatSpeed(speed)}</div>
+      <div class="metric-row">
+        <span class="label">Vs Target</span>
+        <span class="value accent">{relativeSpeed == null ? "--" : formatSpeed(relativeSpeed)}</span>
+      </div>
+      {#if showRawVectors}
+        <div class="metric-row">
+          <span class="label">Vector</span>
+          <span class="value">{formatVector(velocity, 1)}</span>
+        </div>
+      {/if}
+    </section>
+
+    <section class="section compact">
+      <div class="section-title">Attitude</div>
+      <div class="triple">
+        <div>
+          <div class="micro-label">Pitch</div>
+          <div class="micro-value">{signed(heading.pitch, 1)}°</div>
+        </div>
+        <div>
+          <div class="micro-label">Yaw</div>
+          <div class="micro-value">{signed(heading.yaw, 1)}°</div>
+        </div>
+        <div>
+          <div class="micro-label">Roll</div>
+          <div class="micro-value">{signed(heading.roll, 1)}°</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section compact">
+      <div class="section-title">Budget</div>
+      <div class="metric-row">
+        <span class="label">Delta-V</span>
+        <span class="value accent">{formatSpeed(deltaV)}</span>
+      </div>
+      <div class="metric-row">
+        <span class="label">Stop Burn</span>
+        <span class="value">{formatSpeed(toNumber(ponr.dv_to_stop))}</span>
+      </div>
+      <div class="metric-row">
+        <span class="label">Target Range</span>
+        <span class="value">{formatDistance(autopilot.distance)}</span>
+      </div>
+    </section>
+  </div>
+</Panel>
+
+<style>
+  .stack {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .section {
+    display: grid;
+    gap: 6px;
+    padding: 10px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+  }
+
+  .section.compact {
+    gap: 8px;
+  }
+
+  .section-title {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+  }
+
+  .metric-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  .label,
+  .micro-label {
+    color: var(--text-dim);
+    font-size: var(--font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .value,
+  .micro-value,
+  .hero,
+  .vector-readout {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .hero {
+    font-size: 1.25rem;
+    color: var(--tier-accent);
+  }
+
+  .accent {
+    color: var(--status-info);
+  }
+
+  .vector-readout {
+    padding-top: 4px;
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+    word-break: break-word;
+  }
+
+  .triple {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .alert {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .alert.warning {
+    color: var(--status-warning);
+    border: 1px solid rgba(255, 170, 0, 0.4);
+    background: rgba(255, 170, 0, 0.09);
+  }
+
+  .alert.critical {
+    color: var(--status-critical);
+    border: 1px solid rgba(255, 68, 68, 0.45);
+    background: rgba(255, 68, 68, 0.1);
+    box-shadow: var(--glow-critical);
+  }
+</style>

--- a/gui-svelte/src/components/helm/HelmQueuePanel.svelte
+++ b/gui-svelte/src/components/helm/HelmQueuePanel.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { asRecord, extractShipState, formatDuration, getQueueState, toNumber, toStringValue } from "./helmData.js";
+
+  interface QueueEntry {
+    id: number | null;
+    command: string;
+    status: string;
+    elapsed: number;
+    target: string;
+  }
+
+  let polledQueue: { active: QueueEntry | null; pending: QueueEntry[] } = { active: null, pending: [] };
+  let feedback = "";
+  let pollHandle: number | null = null;
+
+  $: ship = extractShipState($gameState);
+  $: storeQueue = getQueueState(ship);
+  $: queue = polledQueue.active || polledQueue.pending.length ? polledQueue : storeQueue;
+
+  onMount(() => {
+    void refreshQueue();
+    pollHandle = window.setInterval(() => void refreshQueue(), 2000);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  function parseEntry(value: unknown): QueueEntry | null {
+    const entry = asRecord(value);
+    if (!entry) return null;
+    return {
+      id: entry.id == null ? null : toNumber(entry.id),
+      command: toStringValue(entry.command, "unknown"),
+      status: toStringValue(entry.status, "pending"),
+      elapsed: toNumber(entry.elapsed),
+      target: toStringValue(entry.target),
+    };
+  }
+
+  async function refreshQueue() {
+    try {
+      const response = await wsClient.sendShipCommand("helm_queue_status", {});
+      const record = asRecord(response);
+      const queueState = asRecord(record?.queue) ?? record;
+      polledQueue = {
+        active: parseEntry(queueState?.active),
+        pending: Array.isArray(queueState?.pending) ? queueState.pending.map(parseEntry).filter((entry): entry is QueueEntry => Boolean(entry)) : [],
+      };
+    } catch {
+      polledQueue = { active: null, pending: [] };
+    }
+  }
+
+  async function clearQueue() {
+    await wsClient.sendShipCommand("clear_helm_queue", {});
+    feedback = "Queue cleared";
+    await refreshQueue();
+  }
+
+  async function interruptQueue() {
+    await wsClient.sendShipCommand("interrupt_helm_queue", {});
+    feedback = "Active command interrupted";
+    await refreshQueue();
+  }
+</script>
+
+<Panel title="Helm Queue" domain="helm" priority="secondary" className="helm-queue-panel">
+  <div class="shell">
+    <div class="actions">
+      <button on:click={interruptQueue} disabled={!queue.active}>Interrupt Current</button>
+      <button on:click={clearQueue} disabled={!queue.active && queue.pending.length === 0}>Clear Queue</button>
+    </div>
+
+    {#if queue.active}
+      <div class="active-card">
+        <div class="eyebrow">Active</div>
+        <strong>{queue.active.command.toUpperCase()}</strong>
+        <span>{queue.active.target || "ship-local"}</span>
+        <span>Elapsed {formatDuration(queue.active.elapsed)}</span>
+      </div>
+    {/if}
+
+    <div class="pending-shell">
+      <div class="eyebrow">Pending</div>
+      {#if queue.pending.length === 0}
+        <div class="empty">No queued helm commands.</div>
+      {:else}
+        {#each queue.pending as entry}
+          <div class="pending-row">
+            <strong>{entry.command}</strong>
+            <span>{entry.target || "ship-local"}</span>
+            <span>{entry.status}</span>
+          </div>
+        {/each}
+      {/if}
+    </div>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell,
+  .pending-shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-xs);
+  }
+
+  .active-card,
+  .pending-row {
+    display: grid;
+    gap: 4px;
+    padding: 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: rgba(var(--tier-accent-rgb), 0.08);
+  }
+
+  .pending-row {
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .eyebrow,
+  .empty,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+  }
+</style>

--- a/gui-svelte/src/components/helm/HelmWorkflowStrip.svelte
+++ b/gui-svelte/src/components/helm/HelmWorkflowStrip.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { deriveWorkflowStep, extractShipState } from "./helmData.js";
+
+  const STEPS = {
+    manual: ["PLAN", "ORIENT", "BURN", "CHECK"],
+    raw: ["PLAN", "ORIENT", "BURN", "CHECK"],
+    arcade: ["SENSE", "AIM", "FIRE"],
+    "cpu-assist": ["ASSESS", "ORDER", "QUEUE", "MONITOR"],
+  } as const;
+
+  $: ship = extractShipState($gameState);
+  $: steps = STEPS[$tier];
+  $: currentStep = deriveWorkflowStep(ship, $tier);
+</script>
+
+<div class="workflow-strip" aria-label="Helm workflow">
+  {#each steps as step, index}
+    <div class:done={index < currentStep} class:current={index === currentStep} class="step">
+      <span class="index">{index + 1}</span>
+      <span>{step}</span>
+    </div>
+    {#if index < steps.length - 1}
+      <div class="connector"></div>
+    {/if}
+  {/each}
+</div>
+
+<style>
+  .workflow-strip {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    width: 100%;
+    min-height: 42px;
+    padding: 6px 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background:
+      linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.08), transparent 45%),
+      var(--bg-panel);
+    overflow-x: auto;
+  }
+
+  .step {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    white-space: nowrap;
+    padding: 6px 10px;
+    border-radius: 999px;
+    color: var(--text-dim);
+    border: 1px solid transparent;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .step.done {
+    color: var(--status-nominal);
+  }
+
+  .step.current {
+    color: var(--text-primary);
+    border-color: rgba(var(--tier-accent-rgb), 0.4);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+    box-shadow: var(--glow-tier);
+  }
+
+  .index {
+    width: 18px;
+    height: 18px;
+    display: inline-grid;
+    place-items: center;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.06);
+    font-size: 0.62rem;
+  }
+
+  .connector {
+    flex: 1 0 22px;
+    max-width: 48px;
+    height: 1px;
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.4), transparent);
+  }
+</style>

--- a/gui-svelte/src/components/helm/ManeuverPlanner.svelte
+++ b/gui-svelte/src/components/helm/ManeuverPlanner.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { selectedHelmTargetId } from "../../lib/stores/helmUi.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    asRecord,
+    clamp,
+    computeRelativeSpeed,
+    extractShipState,
+    findContact,
+    formatDuration,
+    formatSpeed,
+    getContacts,
+    getMaxAccel,
+    getOrientation,
+    getVelocity,
+    magnitude,
+    normalizeAngle,
+    toStringValue,
+  } from "./helmData.js";
+
+  let executionMode: "autopilot" | "plan" | "burn" = "autopilot";
+  let burnDuration = 18;
+  let burnThrottle = 0.55;
+  let feedback = "";
+
+  $: ship = extractShipState($gameState);
+  $: contacts = getContacts(ship);
+  $: targetId = $selectedHelmTargetId || toStringValue(ship.target_id);
+  $: contact = targetId ? findContact(ship, targetId) : null;
+  $: speed = magnitude(getVelocity(ship));
+  $: relativeSpeed = computeRelativeSpeed(ship, targetId);
+  $: maxAccel = Math.max(getMaxAccel(ship), 0.01);
+  $: range = contact?.distance ?? 0;
+  $: heading = getOrientation(ship);
+  $: rcsState = asRecord(asRecord(ship.systems)?.rcs);
+  $: rcsController = asRecord(rcsState?.controller);
+  $: flipTime = 180 / Math.max(toNumber(rcsController?.max_rate, 30), 1) * 1.4;
+  $: flipBurnEta = range > 0 ? 2 * Math.sqrt(range / maxAccel) + flipTime : 0;
+  $: interceptTime = range > 0 ? range / Math.max(relativeSpeed ?? speed, 20) : 0;
+  $: deltaVCost = range > 0 ? Math.sqrt(2 * range * maxAccel) : 0;
+
+  function toNumber(value: unknown, fallback = 0): number {
+    return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+  }
+
+  function onTargetChange(event: Event) {
+    selectedHelmTargetId.set((event.currentTarget as HTMLSelectElement).value);
+  }
+
+  function retrogradeHeading() {
+    const velocity = getVelocity(ship);
+    if (magnitude(velocity) <= 0.01) {
+      return { pitch: heading.pitch, yaw: normalizeAngle(heading.yaw + 180) };
+    }
+    const opposite = { x: -velocity.x, y: -velocity.y, z: -velocity.z };
+    const horizontal = Math.sqrt(opposite.x * opposite.x + opposite.y * opposite.y);
+    return {
+      pitch: Math.atan2(opposite.z, Math.max(horizontal, 0.001)) * 180 / Math.PI,
+      yaw: normalizeAngle(Math.atan2(opposite.y, opposite.x) * 180 / Math.PI),
+    };
+  }
+
+  function buildPlan() {
+    return {
+      name: targetId ? `Intercept ${targetId}` : "Helm burn plan",
+      type: "helm_sequence",
+      source: "svelte_helm",
+      target: targetId ? { id: targetId } : undefined,
+      steps: [
+        { action: "point_at", detail: targetId ? `Acquire ${targetId}` : "Acquire burn heading" },
+        { action: "burn", detail: `Burn ${Math.round(burnThrottle * 100)}% for ${burnDuration}s` },
+        { action: "hold", detail: "Stabilize and reassess" },
+      ],
+    };
+  }
+
+  async function executePlan() {
+    feedback = "";
+    try {
+      if (executionMode === "autopilot") {
+        if (!targetId) {
+          feedback = "Select a target for intercept autopilot";
+          return;
+        }
+        await wsClient.sendShipCommand("autopilot", {
+          enable: true,
+          program: "intercept",
+          target: targetId,
+        });
+        feedback = `Intercept autopilot engaged for ${targetId}`;
+        return;
+      }
+
+      if (executionMode === "plan") {
+        await wsClient.sendShipCommand("set_plan", { plan: buildPlan() });
+        feedback = "Flight plan queued";
+        return;
+      }
+
+      const retro = retrogradeHeading();
+      await wsClient.sendShipCommand("execute_burn", {
+        duration: burnDuration,
+        throttle: burnThrottle,
+        pitch: retro.pitch,
+        yaw: retro.yaw,
+      });
+      feedback = "Timed burn queued";
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Planner execution failed";
+    }
+  }
+</script>
+
+<Panel title="Maneuver Planner" domain="helm" priority="secondary" className="maneuver-planner-panel">
+  <div class="shell">
+    <label>
+      Target
+      <select value={targetId} on:change={onTargetChange}>
+        <option value="">Select a contact</option>
+        {#each contacts as entry}
+          <option value={entry.id}>{entry.id} · {entry.name}</option>
+        {/each}
+      </select>
+    </label>
+
+    <div class="metrics">
+      <div><span>Flip-and-burn ETA</span><strong>{flipBurnEta ? formatDuration(flipBurnEta) : "--"}</strong></div>
+      <div><span>Intercept time</span><strong>{interceptTime ? formatDuration(interceptTime) : "--"}</strong></div>
+      <div><span>Delta-V cost</span><strong>{deltaVCost ? formatSpeed(deltaVCost) : "--"}</strong></div>
+    </div>
+
+    <div class="controls">
+      <label><span>Execute as</span><select bind:value={executionMode}><option value="autopilot">Autopilot</option><option value="plan">Queued plan</option><option value="burn">Timed burn</option></select></label>
+      <label><span>Burn duration</span><input type="range" min="2" max="60" step="1" bind:value={burnDuration} /><strong>{burnDuration}s</strong></label>
+      <label><span>Throttle</span><input type="range" min="0.1" max="1" step="0.05" bind:value={burnThrottle} /><strong>{Math.round(burnThrottle * 100)}%</strong></label>
+    </div>
+
+    <button on:click={executePlan}>
+      {executionMode === "autopilot" ? "EXECUTE INTERCEPT" : executionMode === "plan" ? "QUEUE FLIGHT PLAN" : "EXECUTE BURN"}
+    </button>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell,
+  .metrics,
+  .controls,
+  label {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .shell {
+    padding: var(--space-sm);
+  }
+
+  .metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .metrics div {
+    display: grid;
+    gap: 4px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .metrics span,
+  label span,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .metrics strong,
+  label strong {
+    font-family: var(--font-mono);
+  }
+
+  @media (max-width: 900px) {
+    .metrics {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/gui-svelte/src/components/helm/ManualFlightPanel.svelte
+++ b/gui-svelte/src/components/helm/ManualFlightPanel.svelte
@@ -1,0 +1,264 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    computeEta,
+    distance,
+    extractShipState,
+    formatDistance,
+    formatDuration,
+    getOrientation,
+    getPosition,
+    getThrottle,
+    getVelocity,
+    getWaypoint,
+    magnitude,
+    normalizeAngle,
+  } from "./helmData.js";
+
+  let throttlePercent = 0;
+  let draftPitch = 0;
+  let draftYaw = 0;
+  let draftRoll = 0;
+  let courseX = "";
+  let courseY = "";
+  let courseZ = "";
+  let feedback = "";
+  let throttleTimer: number | null = null;
+
+  $: ship = extractShipState($gameState);
+  $: currentPosition = getPosition(ship);
+  $: currentVelocity = getVelocity(ship);
+  $: currentHeading = getOrientation(ship);
+  $: waypoint = getWaypoint(ship);
+  $: waypointDistance = waypoint ? distance(waypoint, currentPosition) : 0;
+  $: waypointEta = waypoint ? computeEta(waypointDistance, magnitude(currentVelocity)) : null;
+  $: throttlePercent = Math.round(getThrottle(ship) * 100);
+  $: draftPitch = currentHeading.pitch;
+  $: draftYaw = currentHeading.yaw;
+  $: draftRoll = currentHeading.roll;
+
+  function scheduleThrottle(value: number) {
+    throttlePercent = value;
+    if (throttleTimer != null) window.clearTimeout(throttleTimer);
+    throttleTimer = window.setTimeout(() => {
+      void wsClient.sendShipCommand("set_thrust", { thrust: value / 100 });
+    }, 40);
+  }
+
+  async function applyOrientation() {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("set_orientation", {
+        pitch: draftPitch,
+        yaw: draftYaw,
+        roll: draftRoll,
+      });
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Heading command failed";
+    }
+  }
+
+  async function uploadCourse() {
+    if (![courseX, courseY, courseZ].every((value) => value.trim() !== "")) {
+      feedback = "Enter waypoint coordinates first";
+      return;
+    }
+
+    try {
+      await wsClient.sendShipCommand("set_course", {
+        x: Number(courseX),
+        y: Number(courseY),
+        z: Number(courseZ),
+        stop: true,
+      });
+      feedback = "Waypoint uploaded";
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Course upload failed";
+    }
+  }
+
+  function nudgeOrientation(axis: "pitch" | "yaw" | "roll", amount: number) {
+    if (axis === "pitch") draftPitch = Math.max(-90, Math.min(90, draftPitch + amount));
+    if (axis === "yaw") draftYaw = normalizeAngle(draftYaw + amount);
+    if (axis === "roll") draftRoll = normalizeAngle(draftRoll + amount);
+    void applyOrientation();
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if ($tier !== "manual") return;
+    if (event.target instanceof HTMLElement && ["INPUT", "TEXTAREA", "SELECT"].includes(event.target.tagName)) return;
+
+    const step = 4;
+
+    switch (event.key.toLowerCase()) {
+      case "w":
+        event.preventDefault();
+        nudgeOrientation("pitch", step);
+        break;
+      case "s":
+        event.preventDefault();
+        nudgeOrientation("pitch", -step);
+        break;
+      case "a":
+        event.preventDefault();
+        nudgeOrientation("yaw", -step);
+        break;
+      case "d":
+        event.preventDefault();
+        nudgeOrientation("yaw", step);
+        break;
+      case "q":
+        event.preventDefault();
+        nudgeOrientation("roll", -step);
+        break;
+      case "e":
+        event.preventDefault();
+        nudgeOrientation("roll", step);
+        break;
+    }
+  }
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+<Panel title="Manual Flight" domain="helm" priority={$tier === "manual" ? "primary" : "secondary"} className="manual-flight-panel">
+  <div class="shell">
+    <div class="throttle">
+      <div class="row-head">
+        <span>Throttle</span>
+        <strong>{throttlePercent}%</strong>
+      </div>
+      <input type="range" min="0" max="100" step="1" value={throttlePercent} on:input={(event) => scheduleThrottle(Number((event.currentTarget as HTMLInputElement).value))} />
+      <input type="number" min="0" max="100" step="1" value={throttlePercent} on:change={(event) => scheduleThrottle(Number((event.currentTarget as HTMLInputElement).value))} />
+    </div>
+
+    {#if $tier !== "arcade"}
+      <div class="heading-grid">
+        <div class="axis">
+          <span>Pitch</span>
+          <div class="axis-row">
+            <button type="button" on:click={() => nudgeOrientation("pitch", -5)}>-</button>
+            <input type="number" bind:value={draftPitch} on:change={applyOrientation} />
+            <button type="button" on:click={() => nudgeOrientation("pitch", 5)}>+</button>
+          </div>
+        </div>
+        <div class="axis">
+          <span>Yaw</span>
+          <div class="axis-row">
+            <button type="button" on:click={() => nudgeOrientation("yaw", -5)}>-</button>
+            <input type="number" bind:value={draftYaw} on:change={applyOrientation} />
+            <button type="button" on:click={() => nudgeOrientation("yaw", 5)}>+</button>
+          </div>
+        </div>
+        <div class="axis">
+          <span>Roll</span>
+          <div class="axis-row">
+            <button type="button" on:click={() => nudgeOrientation("roll", -5)}>-</button>
+            <input type="number" bind:value={draftRoll} on:change={applyOrientation} />
+            <button type="button" on:click={() => nudgeOrientation("roll", 5)}>+</button>
+          </div>
+        </div>
+      </div>
+    {/if}
+
+    <div class="waypoint">
+      <div class="row-head">
+        <span>Waypoint</span>
+        <strong>{waypoint ? "ACTIVE" : "NONE"}</strong>
+      </div>
+      <div class="waypoint-grid">
+        <div><span>Range</span><strong>{waypoint ? formatDistance(waypointDistance) : "--"}</strong></div>
+        <div><span>ETA</span><strong>{waypointEta ? formatDuration(waypointEta) : "--"}</strong></div>
+      </div>
+    </div>
+
+    {#if $tier !== "arcade"}
+      <div class="course-grid">
+        <label><span>X</span><input bind:value={courseX} placeholder="0" /></label>
+        <label><span>Y</span><input bind:value={courseY} placeholder="0" /></label>
+        <label><span>Z</span><input bind:value={courseZ} placeholder="0" /></label>
+      </div>
+      <button on:click={uploadCourse}>SET COURSE</button>
+    {/if}
+
+    {#if $tier === "manual"}
+      <div class="keyboard-strip">Keyboard: W/S pitch · A/D yaw · Q/E roll</div>
+    {/if}
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .throttle,
+  .waypoint,
+  .axis,
+  .course-grid label {
+    display: grid;
+    gap: 6px;
+  }
+
+  .row-head,
+  .waypoint-grid {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  .row-head span,
+  .axis span,
+  .course-grid span,
+  .keyboard-strip {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .row-head strong,
+  .waypoint-grid strong {
+    font-family: var(--font-mono);
+  }
+
+  .heading-grid,
+  .course-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .axis-row {
+    display: grid;
+    grid-template-columns: 40px 1fr 40px;
+    gap: 4px;
+  }
+
+  .keyboard-strip,
+  .feedback {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    background: rgba(var(--tier-accent-rgb), 0.08);
+  }
+
+  .feedback {
+    color: var(--text-primary);
+  }
+
+  @media (max-width: 900px) {
+    .heading-grid,
+    .course-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/gui-svelte/src/components/helm/RcsControls.svelte
+++ b/gui-svelte/src/components/helm/RcsControls.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { selectedHelmTargetId } from "../../lib/stores/helmUi.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    extractShipState,
+    getContacts,
+    getOrientation,
+    normalizeAngle,
+    toStringValue,
+  } from "./helmData.js";
+
+  let pitchRate = 0;
+  let yawRate = 0;
+  let rollRate = 0;
+  let feedback = "";
+
+  $: ship = extractShipState($gameState);
+  $: contacts = getContacts(ship);
+  $: activeTargetId = $selectedHelmTargetId || toStringValue(ship.target_id);
+  $: heading = getOrientation(ship);
+
+  async function setRate(nextPitch = pitchRate, nextYaw = yawRate, nextRoll = rollRate) {
+    pitchRate = nextPitch;
+    yawRate = nextYaw;
+    rollRate = nextRoll;
+    try {
+      await wsClient.sendShipCommand("set_angular_velocity", {
+        pitch: pitchRate,
+        yaw: yawRate,
+        roll: rollRate,
+      });
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "RCS rate command failed";
+    }
+  }
+
+  async function flip180() {
+    await wsClient.sendShipCommand("set_orientation", {
+      pitch: heading.pitch,
+      yaw: normalizeAngle(heading.yaw + 180),
+      roll: heading.roll,
+    });
+  }
+
+  async function pointAtTarget() {
+    if (!activeTargetId) {
+      feedback = "Select a target first";
+      return;
+    }
+    await wsClient.sendShipCommand("point_at", { target: activeTargetId });
+  }
+
+  async function cancelRotation() {
+    await wsClient.sendShipCommand("set_orientation", {
+      pitch: heading.pitch,
+      yaw: heading.yaw,
+      roll: heading.roll,
+    });
+    await killRotation();
+  }
+
+  async function killRotation() {
+    await setRate(0, 0, 0);
+  }
+
+  function onTargetChange(event: Event) {
+    selectedHelmTargetId.set((event.currentTarget as HTMLSelectElement).value);
+  }
+</script>
+
+<Panel title="RCS Controls" domain="helm" priority="secondary" className="rcs-controls-panel">
+  <div class="shell">
+    <label>
+      Point-at target
+      <select on:change={onTargetChange} value={activeTargetId}>
+        <option value="">No target selected</option>
+        {#each contacts as contact}
+          <option value={contact.id}>{contact.id} · {contact.name}</option>
+        {/each}
+      </select>
+    </label>
+
+    <div class="quick-grid">
+      <button on:click={flip180}>FLIP 180</button>
+      <button on:click={pointAtTarget} disabled={!activeTargetId}>POINT AT TARGET</button>
+      <button on:click={cancelRotation}>CANCEL ROTATION</button>
+      <button on:click={killRotation}>KILL ROTATION</button>
+    </div>
+
+    <div class="slider-grid">
+      <label><span>Pitch rate</span><input type="range" min="-20" max="20" step="0.5" value={pitchRate} on:input={(event) => setRate(Number((event.currentTarget as HTMLInputElement).value), yawRate, rollRate)} /><strong>{pitchRate.toFixed(1)}°/s</strong></label>
+      <label><span>Yaw rate</span><input type="range" min="-20" max="20" step="0.5" value={yawRate} on:input={(event) => setRate(pitchRate, Number((event.currentTarget as HTMLInputElement).value), rollRate)} /><strong>{yawRate.toFixed(1)}°/s</strong></label>
+      <label><span>Roll rate</span><input type="range" min="-20" max="20" step="0.5" value={rollRate} on:input={(event) => setRate(pitchRate, yawRate, Number((event.currentTarget as HTMLInputElement).value))} /><strong>{rollRate.toFixed(1)}°/s</strong></label>
+    </div>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell,
+  .slider-grid,
+  label {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .shell {
+    padding: var(--space-sm);
+  }
+
+  .quick-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-xs);
+  }
+
+  label span {
+    font-size: var(--font-size-xs);
+    text-transform: uppercase;
+    color: var(--text-secondary);
+    letter-spacing: 0.06em;
+  }
+
+  label strong {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--text-primary);
+  }
+
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+</style>

--- a/gui-svelte/src/components/helm/RcsThrusterDisplay.svelte
+++ b/gui-svelte/src/components/helm/RcsThrusterDisplay.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { extractShipState, getThrusters } from "./helmData.js";
+
+  interface DiagramThruster {
+    id: string;
+    x: number;
+    y: number;
+    throttle: number;
+  }
+
+  const THRUSTER_LAYOUT: Record<string, { x: number; y: number }> = {
+    pitch_up: { x: 76, y: 48 },
+    pitch_down: { x: 164, y: 48 },
+    pitch_up_aft: { x: 76, y: 264 },
+    pitch_down_aft: { x: 164, y: 264 },
+    yaw_left: { x: 50, y: 88 },
+    yaw_right: { x: 190, y: 88 },
+    yaw_left_aft: { x: 50, y: 224 },
+    yaw_right_aft: { x: 190, y: 224 },
+    roll_cw: { x: 76, y: 146 },
+    roll_ccw: { x: 164, y: 146 },
+    roll_cw_2: { x: 76, y: 178 },
+    roll_ccw_2: { x: 164, y: 178 },
+  };
+
+  let feedback = "";
+
+  $: ship = extractShipState($gameState);
+  $: thrusters = getThrusters(ship);
+  $: interactive = $tier === "manual" || $tier === "raw";
+  $: diagramThrusters = thrusters.map((thruster, index) => layoutThruster(thruster.id, thruster.throttle, index));
+
+  function layoutThruster(id: string, throttle: number, index: number): DiagramThruster {
+    const fallbackX = 58 + (index % 4) * 42;
+    const fallbackY = 70 + Math.floor(index / 4) * 60;
+    const point = THRUSTER_LAYOUT[id] ?? { x: fallbackX, y: fallbackY };
+    return { id, throttle, ...point };
+  }
+
+  async function pulseThruster(thrusterId: string, active: boolean) {
+    if (!interactive) return;
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("rcs_fire_thruster", {
+        thruster_id: thrusterId,
+        throttle: active ? 0 : 1,
+        duration: active ? 0 : 0.3,
+      });
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Thruster command failed";
+    }
+  }
+
+  function onThrusterKeydown(event: KeyboardEvent, thrusterId: string, active: boolean) {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    void pulseThruster(thrusterId, active);
+  }
+</script>
+
+<Panel title="Thruster Map" domain="helm" priority="secondary" className="rcs-thruster-panel">
+  <div class="shell">
+    <svg viewBox="0 0 240 320" class="diagram" aria-label="RCS thruster display">
+      <path d="M120 24 L168 72 L168 248 L120 296 L72 248 L72 72 Z" class="hull" />
+      <rect x="106" y="48" width="28" height="224" rx="10" class="spine" />
+
+      {#each diagramThrusters as thruster}
+        <g class="thruster-group">
+          <a
+            href={`#${thruster.id}`}
+            aria-label={`Pulse ${thruster.id}`}
+            on:click|preventDefault={() => pulseThruster(thruster.id, thruster.throttle > 0.05)}
+            on:keydown={(event) => onThrusterKeydown(event, thruster.id, thruster.throttle > 0.05)}
+          >
+            <circle
+              class:active={thruster.throttle > 0.05}
+              class:interactive={interactive}
+              cx={thruster.x}
+              cy={thruster.y}
+              r="10"
+            />
+          </a>
+          <text x={thruster.x} y={thruster.y + 23}>{thruster.id}</text>
+        </g>
+      {/each}
+    </svg>
+
+    <div class="legend">
+      <span>Active thrusters: {diagramThrusters.filter((thruster) => thruster.throttle > 0.05).length}</span>
+      <span>{interactive ? "Click any thruster to pulse it." : "Live telemetry only."}</span>
+    </div>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .diagram {
+    width: 100%;
+    height: auto;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: radial-gradient(circle at center, rgba(255, 255, 255, 0.04), transparent 65%), #0b1017;
+  }
+
+  .hull,
+  .spine {
+    fill: rgba(255, 255, 255, 0.06);
+    stroke: rgba(255, 255, 255, 0.18);
+  }
+
+  circle {
+    fill: rgba(0, 170, 255, 0.16);
+    stroke: rgba(0, 170, 255, 0.45);
+    transition: fill var(--transition-fast), transform var(--transition-fast);
+  }
+
+  circle.active {
+    fill: rgba(255, 170, 0, 0.8);
+    stroke: rgba(255, 170, 0, 1);
+    filter: drop-shadow(0 0 8px rgba(255, 170, 0, 0.55));
+  }
+
+  circle.interactive {
+    cursor: pointer;
+  }
+
+  circle.interactive:hover {
+    transform: scale(1.05);
+  }
+
+  text {
+    fill: rgba(255, 255, 255, 0.62);
+    font: 7px "JetBrains Mono", monospace;
+    text-anchor: middle;
+  }
+
+  .legend,
+  .feedback {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+</style>

--- a/gui-svelte/src/components/helm/helmData.ts
+++ b/gui-svelte/src/components/helm/helmData.ts
@@ -1,0 +1,432 @@
+import type { Tier } from "../../lib/stores/tier.js";
+
+export type JsonMap = Record<string, unknown>;
+
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface Orientation {
+  pitch: number;
+  yaw: number;
+  roll: number;
+}
+
+export interface ContactSummary {
+  id: string;
+  name: string;
+  classification: string;
+  distance: number;
+  position: Vec3;
+  velocity: Vec3;
+}
+
+export interface AutopilotSnapshot {
+  active: boolean;
+  mode: string;
+  program: string;
+  phase: string;
+  status: string;
+  targetId: string;
+  distance: number | null;
+  eta: number | null;
+  progress: number;
+}
+
+export interface DockingSnapshot {
+  status: string;
+  targetId: string;
+  range: number | null;
+  relativeVelocity: number | null;
+  dockingRange: number;
+  maxRelativeVelocity: number;
+  serviceReport: JsonMap | null;
+}
+
+export interface QueueEntry {
+  id: number | null;
+  command: string;
+  status: string;
+  elapsed: number;
+  target: string;
+  params: JsonMap;
+}
+
+export interface ThrusterState {
+  id: string;
+  throttle: number;
+  position: Vec3;
+  direction: Vec3;
+  torque: Vec3;
+  maxThrust: number;
+}
+
+const ZERO_VEC: Vec3 = { x: 0, y: 0, z: 0 };
+const ZERO_ORIENTATION: Orientation = { pitch: 0, yaw: 0, roll: 0 };
+
+export function asRecord(value: unknown): JsonMap | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonMap)
+    : null;
+}
+
+export function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+export function toStringValue(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+export function toVec3(value: unknown, fallback: Vec3 = ZERO_VEC): Vec3 {
+  const rec = asRecord(value);
+  if (rec) {
+    return {
+      x: toNumber(rec.x, fallback.x),
+      y: toNumber(rec.y, fallback.y),
+      z: toNumber(rec.z, fallback.z),
+    };
+  }
+
+  if (Array.isArray(value)) {
+    return {
+      x: toNumber(value[0], fallback.x),
+      y: toNumber(value[1], fallback.y),
+      z: toNumber(value[2], fallback.z),
+    };
+  }
+
+  return fallback;
+}
+
+export function toOrientation(value: unknown, fallback: Orientation = ZERO_ORIENTATION): Orientation {
+  const rec = asRecord(value);
+  if (!rec) return fallback;
+  return {
+    pitch: toNumber(rec.pitch, fallback.pitch),
+    yaw: normalizeAngle(toNumber(rec.yaw, fallback.yaw)),
+    roll: normalizeAngle(toNumber(rec.roll, fallback.roll)),
+  };
+}
+
+export function extractShipState(gameState: JsonMap | null | undefined): JsonMap {
+  const state = asRecord(gameState);
+  if (!state) return {};
+
+  const topState = asRecord(state.state);
+  if (topState) return topState;
+
+  const ship = asRecord(state.ship);
+  if (ship) return ship;
+
+  const ships = asRecord(state.ships);
+  if (ships) {
+    const first = Object.values(ships)[0];
+    return asRecord(first) ?? {};
+  }
+
+  const list = Array.isArray(state.ships) ? state.ships : [];
+  if (list.length > 0) return asRecord(list[0]) ?? {};
+
+  return state;
+}
+
+export function getSystem(ship: JsonMap, name: string): JsonMap {
+  const systems = asRecord(ship.systems);
+  return asRecord(systems?.[name]) ?? {};
+}
+
+export function getPosition(ship: JsonMap): Vec3 {
+  return toVec3(ship.position);
+}
+
+export function getVelocity(ship: JsonMap): Vec3 {
+  const nav = asRecord(ship.navigation);
+  return toVec3(ship.velocity, toVec3(nav?.velocity));
+}
+
+export function getOrientation(ship: JsonMap): Orientation {
+  const nav = asRecord(ship.navigation);
+  return toOrientation(ship.orientation, toOrientation(nav?.heading));
+}
+
+export function magnitude(vec: Vec3): number {
+  return Math.sqrt(vec.x * vec.x + vec.y * vec.y + vec.z * vec.z);
+}
+
+export function subtract(a: Vec3, b: Vec3): Vec3 {
+  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z };
+}
+
+export function distance(a: Vec3, b: Vec3): number {
+  return magnitude(subtract(a, b));
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function normalizeAngle(value: number): number {
+  let normalized = value % 360;
+  if (normalized > 180) normalized -= 360;
+  if (normalized <= -180) normalized += 360;
+  return normalized;
+}
+
+export function formatDistance(meters: number | null | undefined): string {
+  if (meters == null || !Number.isFinite(meters)) return "--";
+  const abs = Math.abs(meters);
+  if (abs >= 1_000_000) return `${(meters / 1000).toLocaleString(undefined, { maximumFractionDigits: 0 })} km`;
+  if (abs >= 1000) return `${(meters / 1000).toFixed(abs >= 10_000 ? 0 : 1)} km`;
+  return `${meters.toFixed(abs >= 100 ? 0 : 1)} m`;
+}
+
+export function formatSpeed(speed: number | null | undefined): string {
+  if (speed == null || !Number.isFinite(speed)) return "--";
+  const abs = Math.abs(speed);
+  if (abs >= 1000) return `${(speed / 1000).toFixed(2)} km/s`;
+  if (abs >= 100) return `${speed.toFixed(0)} m/s`;
+  return `${speed.toFixed(1)} m/s`;
+}
+
+export function formatDuration(seconds: number | null | undefined): string {
+  if (seconds == null || !Number.isFinite(seconds)) return "--";
+  if (seconds <= 0) return "0s";
+  const whole = Math.round(seconds);
+  if (whole < 60) return `${whole}s`;
+  const minutes = Math.floor(whole / 60);
+  const secs = whole % 60;
+  if (minutes < 60) return `${minutes}m ${String(secs).padStart(2, "0")}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${String(remainingMinutes).padStart(2, "0")}m`;
+}
+
+export function formatVector(vec: Vec3, digits = 1): string {
+  return `${signed(vec.x, digits)} ${signed(vec.y, digits)} ${signed(vec.z, digits)}`;
+}
+
+export function signed(value: number, digits = 1): string {
+  const prefix = value >= 0 ? "+" : "";
+  return `${prefix}${value.toFixed(digits)}`;
+}
+
+export function toPercent(value: number, digits = 0): string {
+  return `${value.toFixed(digits)}%`;
+}
+
+export function getContacts(ship: JsonMap): ContactSummary[] {
+  const topSensors = asRecord(ship.sensors);
+  const systemSensors = getSystem(ship, "sensors");
+  const source = Array.isArray(topSensors?.contacts)
+    ? topSensors.contacts
+    : Array.isArray(systemSensors.contacts)
+      ? systemSensors.contacts
+      : [];
+
+  return source
+    .map((item) => asRecord(item))
+    .filter((item): item is JsonMap => Boolean(item))
+    .map((item) => ({
+      id: toStringValue(item.id, "unknown"),
+      name: toStringValue(item.name) || toStringValue(item.classification) || toStringValue(item.id, "Unknown"),
+      classification: toStringValue(item.classification, "Unknown"),
+      distance: toNumber(item.distance, Number.POSITIVE_INFINITY),
+      position: toVec3(item.position),
+      velocity: toVec3(item.velocity),
+    }))
+    .sort((a, b) => a.distance - b.distance);
+}
+
+export function findContact(ship: JsonMap, targetId: string): ContactSummary | null {
+  return getContacts(ship).find((contact) => contact.id === targetId) ?? null;
+}
+
+export function getAutopilotSnapshot(ship: JsonMap): AutopilotSnapshot {
+  const nav = getSystem(ship, "navigation");
+  const helm = getSystem(ship, "helm");
+  const flightComputer = asRecord(ship.flight_computer) ?? getSystem(ship, "flight_computer");
+  const autopilotState = asRecord(ship.autopilot_state)
+    ?? asRecord(nav.autopilot_state)
+    ?? asRecord(ship.autopilot)
+    ?? {};
+  const course = asRecord(ship.course) ?? asRecord(nav.course) ?? {};
+  const program = toStringValue(ship.autopilot_program)
+    || toStringValue(nav.current_program)
+    || toStringValue(helm.autopilot_program);
+  const phase = toStringValue(autopilotState.phase) || toStringValue(helm.autopilot_phase);
+  const mode = toStringValue(ship.nav_mode)
+    || toStringValue(nav.mode)
+    || toStringValue(helm.mode, "manual");
+  const distanceValue = autopilotState.range ?? autopilotState.distance ?? course.distance ?? null;
+  const etaValue = autopilotState.time_to_arrival ?? flightComputer.eta ?? null;
+  const active = Boolean(program) || Boolean(nav.autopilot_enabled) || mode === "autopilot";
+
+  return {
+    active,
+    mode,
+    program,
+    phase,
+    status: toStringValue(autopilotState.status) || toStringValue(flightComputer.status_text),
+    targetId: toStringValue(ship.target_id) || toStringValue(nav.target_id),
+    distance: distanceValue == null ? null : toNumber(distanceValue),
+    eta: etaValue == null ? null : toNumber(etaValue),
+    progress: clamp(toNumber(flightComputer.progress, 0) * 100, 0, 100),
+  };
+}
+
+export function getDockingSnapshot(ship: JsonMap): DockingSnapshot {
+  const docking = asRecord(ship.docking) ?? getSystem(ship, "docking");
+  const lastCheck = asRecord(docking.last_check);
+  return {
+    status: normalizeDockingState(toStringValue(docking.status, "idle")),
+    targetId: toStringValue(docking.target),
+    range: lastCheck?.range == null ? null : toNumber(lastCheck.range),
+    relativeVelocity: lastCheck?.relative_velocity == null ? null : toNumber(lastCheck.relative_velocity),
+    dockingRange: toNumber(docking.docking_range, 50),
+    maxRelativeVelocity: toNumber(docking.max_relative_velocity, 1),
+    serviceReport: asRecord(docking.service_report),
+  };
+}
+
+function normalizeDockingState(state: string): string {
+  const normalized = state.toLowerCase();
+  if (["docking_initiated", "requested", "requesting"].includes(normalized)) return "approaching";
+  return normalized;
+}
+
+export function getQueueState(ship: JsonMap): { active: QueueEntry | null; pending: QueueEntry[] } {
+  const topQueue = asRecord(ship.helm_queue);
+  const helm = getSystem(ship, "helm");
+  const queue = asRecord(topQueue) ?? asRecord(helm.command_queue) ?? {};
+  return {
+    active: formatQueueEntry(queue.active),
+    pending: Array.isArray(queue.pending) ? queue.pending.map(formatQueueEntry).filter((item): item is QueueEntry => Boolean(item)) : [],
+  };
+}
+
+function formatQueueEntry(value: unknown): QueueEntry | null {
+  const entry = asRecord(value);
+  if (!entry) return null;
+  return {
+    id: entry.id == null ? null : toNumber(entry.id),
+    command: toStringValue(entry.command, "unknown"),
+    status: toStringValue(entry.status, "pending"),
+    elapsed: toNumber(entry.elapsed, 0),
+    target: toStringValue(entry.target),
+    params: asRecord(entry.params) ?? {},
+  };
+}
+
+export function getThrusters(ship: JsonMap): ThrusterState[] {
+  const rcs = getSystem(ship, "rcs");
+  const thrusters = Array.isArray(rcs.thrusters) ? rcs.thrusters : [];
+  return thrusters
+    .map((item) => asRecord(item))
+    .filter((item): item is JsonMap => Boolean(item))
+    .map((item) => ({
+      id: toStringValue(item.id, "thruster"),
+      throttle: toNumber(item.throttle, 0),
+      position: toVec3(item.position),
+      direction: toVec3(item.direction),
+      torque: toVec3(item.torque),
+      maxThrust: toNumber(item.max_thrust, 0),
+    }));
+}
+
+export function getDeltaV(ship: JsonMap): number {
+  const prop = getSystem(ship, "propulsion");
+  return toNumber(ship.delta_v_remaining, toNumber(prop.delta_v));
+}
+
+export function getPONR(ship: JsonMap): JsonMap {
+  return asRecord(ship.ponr) ?? {};
+}
+
+export function getMaxAccel(ship: JsonMap): number {
+  const propulsion = getSystem(ship, "propulsion");
+  const mass = toNumber(ship.mass, 1);
+  const thrust = toNumber(propulsion.max_thrust, 0);
+  return mass > 0 ? thrust / mass : 0;
+}
+
+export function getThrottle(ship: JsonMap): number {
+  const helm = getSystem(ship, "helm");
+  const propulsion = getSystem(ship, "propulsion");
+  const raw = helm.manual_throttle ?? propulsion.throttle ?? ship.throttle;
+  return clamp(toNumber(raw, 0), 0, 1);
+}
+
+export function getFlightComputer(ship: JsonMap): JsonMap {
+  return asRecord(ship.flight_computer) ?? getSystem(ship, "flight_computer");
+}
+
+export function getCourse(ship: JsonMap): JsonMap {
+  const nav = getSystem(ship, "navigation");
+  return asRecord(ship.course) ?? asRecord(nav.course) ?? {};
+}
+
+export function getWaypoint(ship: JsonMap): Vec3 | null {
+  const course = getCourse(ship);
+  const destination = asRecord(course.destination)
+    ?? asRecord(course.target_position)
+    ?? asRecord(asRecord(ship.autopilot_state)?.destination);
+  return destination ? toVec3(destination) : null;
+}
+
+export function computeEta(distanceMeters: number, speedMetersPerSecond: number): number | null {
+  if (distanceMeters <= 0 || speedMetersPerSecond <= 0.01) return null;
+  return distanceMeters / speedMetersPerSecond;
+}
+
+export function computeRelativeSpeed(ship: JsonMap, targetId: string): number | null {
+  if (!targetId) return null;
+  const contact = findContact(ship, targetId);
+  if (!contact) return null;
+  const shipVelocity = getVelocity(ship);
+  return magnitude(subtract(shipVelocity, contact.velocity));
+}
+
+export function headingToTarget(ship: JsonMap, target: Vec3): Orientation {
+  const from = getPosition(ship);
+  const delta = subtract(target, from);
+  const horizontal = Math.sqrt(delta.x * delta.x + delta.y * delta.y);
+  return {
+    pitch: Math.atan2(delta.z, Math.max(horizontal, 0.001)) * 180 / Math.PI,
+    yaw: normalizeAngle(Math.atan2(delta.y, delta.x) * 180 / Math.PI),
+    roll: getOrientation(ship).roll,
+  };
+}
+
+export function deriveWorkflowStep(ship: JsonMap, tier: Tier): number {
+  const contacts = getContacts(ship);
+  const autopilot = getAutopilotSnapshot(ship);
+  const queue = getQueueState(ship);
+  const throttle = getThrottle(ship);
+  const hasTarget = Boolean(autopilot.targetId || toStringValue(ship.target_id));
+
+  if (tier === "arcade") {
+    if (!contacts.length) return 0;
+    if (!hasTarget) return 1;
+    return autopilot.active || throttle > 0.02 ? 2 : 1;
+  }
+
+  if (tier === "cpu-assist") {
+    if (!contacts.length) return 0;
+    if (!hasTarget) return 1;
+    if (queue.active || queue.pending.length > 0) return 3;
+    return autopilot.active ? 2 : 1;
+  }
+
+  if (!contacts.length && throttle <= 0.02) return 0;
+  if (!hasTarget) return 1;
+  if (throttle > 0.02 || autopilot.active) return 2;
+  return 3;
+}

--- a/gui-svelte/src/components/mission/CampaignHub.svelte
+++ b/gui-svelte/src/components/mission/CampaignHub.svelte
@@ -1,0 +1,344 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+
+  interface CampaignStatus {
+    name?: string;
+    description?: string;
+    credits?: number;
+    reputation?: number;
+    completed_missions?: number;
+    total_missions?: number;
+    next_missions?: Array<{ id: string; name?: string; description?: string; difficulty?: string }>;
+    ship_status?: { hull?: number; fuel?: number; systems?: Record<string, unknown> };
+    crew?: Array<{ name?: string; station?: string; health?: number }>;
+  }
+
+  let campaign: CampaignStatus | null = null;
+  let loading = false;
+  let gen = 0;
+  let newCampaignName = "";
+  let saving = false;
+  let statusMsg = "";
+
+  async function fetchCampaign() {
+    loading = true;
+    try {
+      const resp = await wsClient.send("campaign_status", {}) as { ok?: boolean; campaign?: CampaignStatus };
+      if (resp?.ok !== false) campaign = resp?.campaign ?? null;
+    } catch { /* skip */ }
+    finally { loading = false; }
+  }
+
+  async function loadCampaignMission(missionId: string) {
+    try {
+      await wsClient.send("campaign_load", { mission: missionId });
+      statusMsg = "Mission loaded.";
+      setTimeout(() => statusMsg = "", 2000);
+    } catch { statusMsg = "Failed to load mission."; }
+  }
+
+  async function saveCampaign() {
+    saving = true;
+    try {
+      await wsClient.send("campaign_save", {});
+      statusMsg = "Campaign saved.";
+      setTimeout(() => statusMsg = "", 2000);
+    } catch { statusMsg = "Save failed."; }
+    finally { saving = false; }
+  }
+
+  async function newCampaign() {
+    if (!newCampaignName.trim()) return;
+    try {
+      await wsClient.send("campaign_new", { name: newCampaignName.trim() });
+      newCampaignName = "";
+      statusMsg = "Campaign started.";
+      fetchCampaign();
+    } catch { statusMsg = "Failed to create campaign."; }
+  }
+
+  onMount(() => { fetchCampaign(); });
+  onDestroy(() => { gen++; });
+</script>
+
+<div class="hub-root">
+  <div class="hub-header">
+    <span class="hub-title">CAMPAIGN HUB</span>
+    <button class="btn-icon" title="Save" on:click={saveCampaign} disabled={saving}>
+      {saving ? "..." : "💾"}
+    </button>
+    <button class="btn-icon" title="Refresh" on:click={fetchCampaign} disabled={loading}>⟳</button>
+  </div>
+
+  {#if statusMsg}<div class="status-msg">{statusMsg}</div>{/if}
+
+  {#if loading}
+    <div class="loading">Loading campaign...</div>
+  {:else if !campaign}
+    <div class="no-campaign">
+      <p>No active campaign.</p>
+      <div class="new-campaign-row">
+        <input class="campaign-input" type="text" placeholder="Campaign name..." bind:value={newCampaignName} />
+        <button class="action-btn" on:click={newCampaign}>NEW CAMPAIGN</button>
+      </div>
+    </div>
+  {:else}
+    <!-- Campaign info -->
+    {#if campaign.name}
+      <div class="campaign-name">{campaign.name}</div>
+    {/if}
+    {#if campaign.description}
+      <div class="campaign-desc">{campaign.description}</div>
+    {/if}
+
+    <!-- Stats row -->
+    <div class="stats-row">
+      {#if campaign.credits !== undefined}
+        <div class="stat-item">
+          <span class="stat-label">CREDITS</span>
+          <span class="stat-value">{campaign.credits.toLocaleString()}</span>
+        </div>
+      {/if}
+      {#if campaign.reputation !== undefined}
+        <div class="stat-item">
+          <span class="stat-label">REPUTATION</span>
+          <span class="stat-value">{campaign.reputation}</span>
+        </div>
+      {/if}
+      {#if campaign.completed_missions !== undefined && campaign.total_missions !== undefined}
+        <div class="stat-item">
+          <span class="stat-label">MISSIONS</span>
+          <span class="stat-value">{campaign.completed_missions}/{campaign.total_missions}</span>
+        </div>
+      {/if}
+    </div>
+
+    <!-- Ship status -->
+    {#if campaign.ship_status}
+      <div class="section-header">SHIP STATUS</div>
+      <div class="ship-status-row">
+        {#if campaign.ship_status.hull !== undefined}
+          <div class="bar-item">
+            <span class="bar-label">HULL</span>
+            <div class="bar-track"><div class="bar-fill hull" style="width: {Math.round((campaign.ship_status.hull ?? 0) * 100)}%"></div></div>
+            <span class="bar-val">{Math.round((campaign.ship_status.hull ?? 0) * 100)}%</span>
+          </div>
+        {/if}
+        {#if campaign.ship_status.fuel !== undefined}
+          <div class="bar-item">
+            <span class="bar-label">FUEL</span>
+            <div class="bar-track"><div class="bar-fill fuel" style="width: {Math.round((campaign.ship_status.fuel ?? 0) * 100)}%"></div></div>
+            <span class="bar-val">{Math.round((campaign.ship_status.fuel ?? 0) * 100)}%</span>
+          </div>
+        {/if}
+      </div>
+    {/if}
+
+    <!-- Crew summary -->
+    {#if campaign.crew && campaign.crew.length > 0}
+      <div class="section-header">CREW</div>
+      <div class="crew-list">
+        {#each campaign.crew.slice(0, 6) as member}
+          <div class="crew-row">
+            <span class="crew-name">{member.name ?? "Unknown"}</span>
+            <span class="crew-station">{member.station ?? "--"}</span>
+            {#if member.health !== undefined}
+              <span class="crew-health" class:injured={member.health < 0.75}>{Math.round(member.health * 100)}%</span>
+            {/if}
+          </div>
+        {/each}
+        {#if campaign.crew.length > 6}
+          <div class="crew-more">+{campaign.crew.length - 6} more</div>
+        {/if}
+      </div>
+    {/if}
+
+    <!-- Next missions -->
+    {#if campaign.next_missions && campaign.next_missions.length > 0}
+      <div class="section-header">AVAILABLE MISSIONS</div>
+      <div class="next-missions">
+        {#each campaign.next_missions as nm}
+          <div class="next-mission-card">
+            <div class="nm-info">
+              <span class="nm-name">{nm.name ?? nm.id}</span>
+              {#if nm.difficulty}
+                <span class="nm-diff diff-{nm.difficulty}">{nm.difficulty.toUpperCase()}</span>
+              {/if}
+            </div>
+            {#if nm.description}
+              <div class="nm-desc">{nm.description}</div>
+            {/if}
+            <button class="action-btn nm-launch" on:click={() => loadCampaignMission(nm.id)}>LOAD</button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .hub-root {
+    padding: var(--space-sm);
+    font-family: var(--font-sans);
+    color: var(--text-primary);
+  }
+
+  .hub-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    margin-bottom: var(--space-sm);
+  }
+
+  .hub-title {
+    flex: 1;
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--text-secondary);
+  }
+
+  .btn-icon {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-dim);
+    font-size: 0.9rem;
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+    transition: color var(--transition-fast);
+  }
+  .btn-icon:hover:not(:disabled) { color: var(--text-primary); }
+
+  .status-msg {
+    font-size: var(--font-size-xs);
+    color: var(--status-nominal);
+    font-family: var(--font-mono);
+    margin-bottom: var(--space-xs);
+  }
+
+  .loading, .no-campaign {
+    text-align: center;
+    padding: var(--space-lg);
+    color: var(--text-dim);
+    font-size: var(--font-size-sm);
+  }
+
+  .new-campaign-row {
+    display: flex;
+    gap: var(--space-xs);
+    margin-top: var(--space-sm);
+    justify-content: center;
+  }
+
+  .campaign-input {
+    background: var(--bg-input);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    padding: 4px 8px;
+    width: 160px;
+  }
+
+  .campaign-name {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-base);
+    font-weight: 600;
+    color: var(--tier-accent, var(--hud-primary));
+    margin-bottom: 2px;
+  }
+
+  .campaign-desc {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    margin-bottom: var(--space-sm);
+  }
+
+  .stats-row {
+    display: flex;
+    gap: var(--space-md);
+    margin-bottom: var(--space-sm);
+    padding: var(--space-xs) var(--space-sm);
+    background: var(--bg-input);
+    border-radius: var(--radius-sm);
+  }
+
+  .stat-item { display: flex; flex-direction: column; }
+  .stat-label { font-family: var(--font-mono); font-size: 0.6rem; color: var(--text-dim); text-transform: uppercase; }
+  .stat-value { font-family: var(--font-mono); font-size: var(--font-size-sm); font-weight: 600; color: var(--text-primary); }
+
+  .section-header {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin: var(--space-sm) 0 var(--space-xs);
+    padding-bottom: 4px;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .ship-status-row { display: flex; flex-direction: column; gap: 4px; margin-bottom: var(--space-sm); }
+
+  .bar-item { display: flex; align-items: center; gap: var(--space-xs); }
+  .bar-label { font-family: var(--font-mono); font-size: 0.6rem; color: var(--text-dim); width: 36px; }
+  .bar-track { flex: 1; height: 6px; background: var(--bg-input); border-radius: 3px; overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 3px; transition: width 0.5s ease; }
+  .bar-fill.hull { background: var(--status-nominal); }
+  .bar-fill.fuel { background: var(--status-info); }
+  .bar-val { font-family: var(--font-mono); font-size: 0.6rem; color: var(--text-secondary); width: 32px; text-align: right; }
+
+  .crew-list { display: flex; flex-direction: column; gap: 2px; margin-bottom: var(--space-sm); }
+  .crew-row { display: flex; gap: var(--space-xs); align-items: center; padding: 3px 0; }
+  .crew-name { flex: 1; font-size: var(--font-size-xs); color: var(--text-primary); }
+  .crew-station { font-family: var(--font-mono); font-size: 0.6rem; color: var(--text-dim); }
+  .crew-health { font-family: var(--font-mono); font-size: 0.6rem; color: var(--status-nominal); }
+  .crew-health.injured { color: var(--status-warning); }
+  .crew-more { font-size: var(--font-size-xs); color: var(--text-dim); text-align: center; padding: 2px; }
+
+  .next-missions { display: flex; flex-direction: column; gap: var(--space-xs); }
+
+  .next-mission-card {
+    background: var(--bg-input);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    padding: var(--space-xs) var(--space-sm);
+  }
+
+  .nm-info { display: flex; align-items: center; gap: var(--space-xs); margin-bottom: 2px; }
+  .nm-name { font-size: var(--font-size-xs); font-weight: 600; color: var(--text-primary); flex: 1; }
+  .nm-diff { font-family: var(--font-mono); font-size: 0.6rem; padding: 1px 6px; border-radius: 3px; font-weight: 600; }
+  .nm-diff.diff-easy { color: var(--status-nominal); background: rgba(0,255,136,0.1); }
+  .nm-diff.diff-medium { color: var(--status-warning); background: rgba(255,170,0,0.1); }
+  .nm-diff.diff-hard { color: var(--alert-warning); background: rgba(255,102,0,0.1); }
+  .nm-diff.diff-extreme { color: var(--status-critical); background: rgba(255,68,68,0.1); }
+  .nm-diff.diff-tutorial { color: var(--status-info); background: rgba(0,170,255,0.1); }
+
+  .nm-desc { font-size: 0.65rem; color: var(--text-secondary); margin-bottom: var(--space-xs); line-height: 1.3; }
+
+  .nm-launch {
+    font-size: 0.65rem;
+    padding: 2px 10px;
+  }
+
+  .action-btn {
+    background: var(--tier-accent, var(--hud-primary));
+    border: none;
+    border-radius: var(--radius-sm);
+    color: #0a0a0f;
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    padding: 4px 12px;
+    cursor: pointer;
+    letter-spacing: 0.5px;
+    transition: filter var(--transition-fast);
+  }
+  .action-btn:hover { filter: brightness(1.15); }
+  .action-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+</style>

--- a/gui-svelte/src/components/mission/CommandPrompt.svelte
+++ b/gui-svelte/src/components/mission/CommandPrompt.svelte
@@ -1,0 +1,284 @@
+<script lang="ts">
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { playerShipId } from "../../lib/stores/playerShip.js";
+
+  const KNOWN_COMMANDS = [
+    "get_state", "get_events", "get_mission", "list_scenarios", "load_scenario",
+    "list_ships", "station_status", "my_status", "assign_ship", "claim_station",
+    "set_thrust", "set_orientation", "autopilot", "set_course", "ping_sensors",
+    "lock_target", "unlock_target", "fire_railgun", "launch_torpedo", "launch_missile",
+    "set_pdc_mode", "toggle_system", "set_power_allocation", "set_reactor_output",
+    "helm_queue_status", "interrupt_helm_queue", "clear_helm_queue",
+    "rotate", "set_angular_velocity", "point_at", "maneuver",
+    "fleet_status", "fleet_form", "fleet_maneuver",
+    "rcon_auth", "rcon_status", "rcon_pause", "rcon_reload",
+  ];
+  const SHIP_COMMANDS = new Set([
+    "set_thrust", "set_orientation", "autopilot", "set_course", "ping_sensors",
+    "lock_target", "unlock_target", "fire_railgun", "launch_torpedo", "launch_missile",
+    "set_pdc_mode", "toggle_system", "set_power_allocation", "set_reactor_output",
+    "helm_queue_status", "interrupt_helm_queue", "clear_helm_queue",
+    "rotate", "set_angular_velocity", "point_at", "maneuver",
+  ]);
+
+  const STORAGE_KEY = "flaxos_command_history";
+  const MAX_HISTORY = 50;
+
+  // Output entries
+  interface LogEntry { type: "input" | "output" | "error"; text: string; time: string; }
+
+  let input = "";
+  let log: LogEntry[] = [];
+  let history: string[] = [];
+  let historyIdx = -1;
+  let savedInput = "";
+  let suggestions: string[] = [];
+  let inputEl: HTMLInputElement | undefined;
+
+  // Load history from localStorage
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) history = JSON.parse(stored) as string[];
+  } catch { /* ignore */ }
+
+  function saveHistory() {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(history.slice(-MAX_HISTORY))); } catch { /* ignore */ }
+  }
+
+  function addLog(type: LogEntry["type"], text: string) {
+    const time = new Date().toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" });
+    log = [...log.slice(-200), { type, text, time }];
+    // Auto-scroll happens via DOM
+  }
+
+  function getSuggestions(val: string): string[] {
+    if (!val.trim()) return [];
+    const parts = val.trim().split(/\s+/);
+    const cmd = parts[0];
+    if (parts.length === 1) {
+      return KNOWN_COMMANDS.filter(c => c.startsWith(cmd) && c !== cmd).slice(0, 6);
+    }
+    return [];
+  }
+
+  function onInput() {
+    historyIdx = -1;
+    suggestions = getSuggestions(input);
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (history.length === 0) return;
+      if (historyIdx === -1) savedInput = input;
+      historyIdx = Math.min(historyIdx + 1, history.length - 1);
+      input = history[history.length - 1 - historyIdx];
+      suggestions = [];
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (historyIdx <= 0) { historyIdx = -1; input = savedInput; suggestions = getSuggestions(input); return; }
+      historyIdx--;
+      input = history[history.length - 1 - historyIdx];
+    } else if (e.key === "Tab" && suggestions.length > 0) {
+      e.preventDefault();
+      input = suggestions[0] + " ";
+      suggestions = [];
+    } else if (e.key === "Enter") {
+      submit();
+    } else if (e.key === "Escape") {
+      suggestions = [];
+    }
+  }
+
+  function applySuggestion(s: string) {
+    input = s + " ";
+    suggestions = [];
+    inputEl?.focus();
+  }
+
+  async function submit() {
+    const line = input.trim();
+    if (!line) return;
+
+    // Push to history
+    if (history[history.length - 1] !== line) {
+      history = [...history, line];
+      saveHistory();
+    }
+    historyIdx = -1;
+    input = "";
+    suggestions = [];
+
+    addLog("input", `> ${line}`);
+
+    // Parse: "cmd [{json}]" or "cmd key=value key=value"
+    const parts = line.split(/\s+/);
+    const cmd = parts[0];
+    let params: Record<string, unknown> = {};
+
+    const jsonPart = line.slice(cmd.length).trim();
+    if (jsonPart.startsWith("{")) {
+      try { params = JSON.parse(jsonPart); } catch { addLog("error", "Invalid JSON args"); return; }
+    } else if (jsonPart) {
+      // key=value pairs
+      for (const kv of jsonPart.split(/\s+/)) {
+        const [k, ...v] = kv.split("=");
+        if (k && v.length) {
+          const val = v.join("=");
+          const num = parseFloat(val);
+          params[k] = isNaN(num) ? (val === "true" ? true : val === "false" ? false : val) : num;
+        }
+      }
+    }
+
+    let currentShipId: string | null = null;
+    playerShipId.subscribe(id => { currentShipId = id; })();
+
+    if (SHIP_COMMANDS.has(cmd) && currentShipId && !params.ship) {
+      params = { ...params, ship: currentShipId };
+    }
+
+    try {
+      const resp = await wsClient.send(cmd, params);
+      addLog("output", JSON.stringify(resp, null, 2));
+    } catch (e) {
+      addLog("error", `Error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+</script>
+
+<div class="prompt-root">
+  <div class="log-area" aria-live="polite" aria-label="Command log">
+    {#if log.length === 0}
+      <div class="log-hint">Type a command and press Enter. Tab to autocomplete. ↑↓ for history.</div>
+    {/if}
+    {#each log as entry}
+      <div class="log-entry log-{entry.type}">
+        <span class="log-time">{entry.time}</span>
+        <pre class="log-text">{entry.text}</pre>
+      </div>
+    {/each}
+  </div>
+
+  {#if suggestions.length > 0}
+    <div class="suggestions">
+      {#each suggestions as s}
+        <button class="suggest-btn" on:click={() => applySuggestion(s)}>{s}</button>
+      {/each}
+    </div>
+  {/if}
+
+  <div class="input-row">
+    <span class="prompt-prefix">&gt;</span>
+    <input
+      bind:this={inputEl}
+      class="prompt-input"
+      type="text"
+      placeholder="command [args...]"
+      spellcheck="false"
+      autocomplete="off"
+      bind:value={input}
+      on:input={onInput}
+      on:keydown={onKeydown}
+    />
+  </div>
+</div>
+
+<style>
+  .prompt-root {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+  }
+
+  .log-area {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-xs);
+    min-height: 0;
+    background: var(--bg-void);
+  }
+
+  .log-hint {
+    color: var(--text-dim);
+    padding: var(--space-xs);
+    font-style: italic;
+  }
+
+  .log-entry {
+    display: flex;
+    gap: var(--space-xs);
+    margin-bottom: 2px;
+    align-items: flex-start;
+  }
+
+  .log-time {
+    color: var(--text-dim);
+    font-size: 0.6rem;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  .log-text {
+    flex: 1;
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-all;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: 1.4;
+  }
+
+  .log-input .log-text { color: var(--tier-accent, var(--hud-primary)); }
+  .log-output .log-text { color: var(--text-primary); }
+  .log-error .log-text { color: var(--status-critical); }
+
+  .suggestions {
+    display: flex;
+    gap: 4px;
+    padding: 4px var(--space-xs);
+    background: var(--bg-input);
+    flex-wrap: wrap;
+  }
+
+  .suggest-btn {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-default);
+    border-radius: 3px;
+    color: var(--tier-accent, var(--hud-primary));
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    padding: 2px 8px;
+    cursor: pointer;
+    transition: background var(--transition-fast);
+  }
+  .suggest-btn:hover { background: var(--bg-hover); }
+
+  .input-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    padding: var(--space-xs);
+    background: var(--bg-input);
+    border-top: 1px solid var(--border-default);
+  }
+
+  .prompt-prefix {
+    color: var(--tier-accent, var(--hud-primary));
+    font-weight: 700;
+    user-select: none;
+  }
+
+  .prompt-input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    caret-color: var(--tier-accent, var(--hud-primary));
+  }
+</style>

--- a/gui-svelte/src/components/mission/MissionObjectives.svelte
+++ b/gui-svelte/src/components/mission/MissionObjectives.svelte
@@ -1,0 +1,302 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+
+  interface Objective {
+    id?: string;
+    description?: string;
+    status?: "pending" | "completed" | "failed";
+    required?: boolean;
+    type?: string;
+    progress?: string | number;
+  }
+
+  interface Mission {
+    name?: string;
+    description?: string;
+    briefing?: string;
+    mission_status?: string;
+    status?: string;
+    objectives?: Objective[] | Record<string, Objective>;
+    time_remaining?: number;
+    time_elapsed?: number;
+    time_limit?: number;
+    hints?: Array<{ message?: string } | string>;
+    success_message?: string;
+    failure_message?: string;
+    next_scenario?: string;
+    available?: boolean;
+  }
+
+  let mission: Mission | null = null;
+  let gen = 0;
+
+  function formatSeconds(s: number): string {
+    const m = Math.floor(s / 60);
+    const sec = Math.floor(s % 60);
+    return `${m}:${sec.toString().padStart(2, "0")}`;
+  }
+
+  function formatTime(m: Mission): string {
+    if (typeof m.time_remaining === "number" && m.time_remaining > 0) {
+      return `${formatSeconds(m.time_remaining)} remaining`;
+    }
+    if (typeof m.time_elapsed === "number") {
+      const elapsed = formatSeconds(m.time_elapsed);
+      if (typeof m.time_limit === "number") return `${elapsed} / ${formatSeconds(m.time_limit)}`;
+      return elapsed;
+    }
+    return "--:--";
+  }
+
+  function getObjectives(m: Mission): Objective[] {
+    if (!m.objectives) return [];
+    if (Array.isArray(m.objectives)) return m.objectives;
+    return Object.entries(m.objectives).map(([id, obj]) => ({ id, ...obj }));
+  }
+
+  async function poll(g: number) {
+    if (g !== gen) return;
+    try {
+      const resp = await wsClient.send("get_mission", {}) as { ok?: boolean; mission?: Mission } & Mission;
+      if (g !== gen) return;
+      if (resp?.ok !== false) {
+        mission = resp?.mission ?? (resp?.name ? resp : null);
+      }
+    } catch { /* skip */ }
+    if (g === gen) setTimeout(() => poll(g), 2000);
+  }
+
+  let scenarioHandler: ((e: Event) => void) | null = null;
+
+  onMount(() => {
+    gen++;
+    poll(gen);
+
+    scenarioHandler = (e: Event) => {
+      const detail = (e as CustomEvent<{ mission?: Mission }>).detail;
+      if (detail?.mission) mission = detail.mission;
+      else { gen++; poll(gen); }
+    };
+    document.addEventListener("scenario-loaded", scenarioHandler);
+  });
+
+  onDestroy(() => {
+    gen++;
+    if (scenarioHandler) document.removeEventListener("scenario-loaded", scenarioHandler);
+  });
+
+  $: status = mission?.mission_status ?? mission?.status ?? "in_progress";
+  $: objectives = mission ? getObjectives(mission) : [];
+  $: hints = (mission?.hints ?? []) as Array<{ message?: string } | string>;
+</script>
+
+<div class="objectives-root">
+  {#if !mission || mission.available === false}
+    <div class="no-mission">No mission loaded</div>
+  {:else}
+    <div class="mission-header">
+      <div class="mission-name">{mission.name ?? "Mission"}</div>
+      {#if mission.description || mission.briefing}
+        <div class="mission-desc">{mission.description ?? mission.briefing}</div>
+      {/if}
+    </div>
+
+    <div class="status-row">
+      <div class="status-indicator">
+        <span class="status-dot" class:in-progress={status === "in_progress"} class:success={status === "success"} class:failure={status === "failure"}></span>
+        <span class="status-text {status.replace('_', '-')}">{status.replace("_", " ").toUpperCase()}</span>
+      </div>
+      <div class="time-display">{formatTime(mission)}</div>
+    </div>
+
+    {#if objectives.length > 0}
+      <div class="objectives-list">
+        {#each objectives as obj}
+          {@const objStatus = obj.status ?? "pending"}
+          {@const isRequired = obj.required !== false}
+          <div class="objective" class:completed={objStatus === "completed"} class:failed={objStatus === "failed"} class:required={isRequired}>
+            <div class="obj-header">
+              <span class="obj-check" class:completed={objStatus === "completed"} class:failed={objStatus === "failed"}>
+                {objStatus === "completed" ? "☑" : objStatus === "failed" ? "☒" : "☐"}
+              </span>
+              <span class="obj-text">{obj.description ?? obj.id ?? ""}</span>
+              {#if !isRequired}<span class="optional-tag">Optional</span>{/if}
+            </div>
+            {#if obj.type || obj.progress}
+              <div class="obj-meta">
+                {#if obj.type}Type: {obj.type}{/if}
+                {#if obj.progress} • Progress: {obj.progress}{/if}
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    {#if hints.length > 0}
+      <div class="hints-section">
+        <div class="hints-title">HINTS</div>
+        {#each hints as hint}
+          <div class="hint">{typeof hint === "string" ? hint : hint.message ?? ""}</div>
+        {/each}
+      </div>
+    {/if}
+
+    {#if status === "success"}
+      <div class="result-box success">
+        <div class="result-title">✓ MISSION COMPLETE</div>
+        <div class="result-text">{mission.success_message ?? "All objectives achieved."}</div>
+      </div>
+    {:else if status === "failure"}
+      <div class="result-box failure">
+        <div class="result-title">✕ MISSION FAILED</div>
+        <div class="result-text">{mission.failure_message ?? "Mission objectives not met."}</div>
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .objectives-root {
+    padding: var(--space-sm);
+    font-family: var(--font-sans);
+    color: var(--text-primary);
+  }
+
+  .no-mission {
+    text-align: center;
+    padding: var(--space-xl);
+    color: var(--text-dim);
+    font-style: italic;
+  }
+
+  .mission-header { margin-bottom: var(--space-sm); }
+
+  .mission-name {
+    font-size: var(--font-size-base);
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .mission-desc {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    margin-top: 2px;
+  }
+
+  .status-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--space-xs) var(--space-sm);
+    background: var(--bg-input);
+    border-radius: var(--radius-sm);
+    margin-bottom: var(--space-sm);
+  }
+
+  .status-indicator { display: flex; align-items: center; gap: 8px; }
+
+  .status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--border-default);
+  }
+
+  .status-dot.in-progress {
+    background: var(--status-info);
+    box-shadow: 0 0 8px var(--status-info);
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+
+  .status-dot.success { background: var(--status-nominal); box-shadow: 0 0 8px var(--status-nominal); }
+  .status-dot.failure { background: var(--status-critical); box-shadow: 0 0 8px var(--status-critical); }
+
+  @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+
+  .status-text { font-family: var(--font-mono); font-size: var(--font-size-xs); font-weight: 600; color: var(--text-secondary); }
+  .status-text.in-progress { color: var(--status-info); }
+  .status-text.success { color: var(--status-nominal); }
+  .status-text.failure { color: var(--status-critical); }
+
+  .time-display { font-family: var(--font-mono); font-size: var(--font-size-xs); color: var(--text-secondary); }
+
+  .objectives-list { display: flex; flex-direction: column; gap: var(--space-xs); margin-bottom: var(--space-sm); }
+
+  .objective {
+    padding: var(--space-xs) var(--space-sm);
+    background: var(--bg-input);
+    border-radius: var(--radius-sm);
+    border-left: 3px solid var(--border-default);
+  }
+
+  .objective.required { border-left-color: var(--status-info); }
+  .objective.completed { border-left-color: var(--status-nominal); opacity: 0.7; }
+  .objective.failed { border-left-color: var(--status-critical); opacity: 0.7; }
+
+  .obj-header { display: flex; align-items: center; gap: var(--space-xs); }
+
+  .obj-check { font-size: 0.9rem; }
+  .obj-check.completed { color: var(--status-nominal); }
+  .obj-check.failed { color: var(--status-critical); }
+
+  .obj-text { flex: 1; font-size: var(--font-size-xs); color: var(--text-primary); }
+  .objective.completed .obj-text { text-decoration: line-through; }
+
+  .optional-tag {
+    font-size: 0.6rem;
+    padding: 2px 6px;
+    background: rgba(255, 170, 0, 0.15);
+    color: var(--status-warning);
+    border-radius: 3px;
+  }
+
+  .obj-meta { font-size: 0.65rem; color: var(--text-dim); margin-top: 2px; }
+
+  .hints-section {
+    margin-top: var(--space-sm);
+    padding-top: var(--space-xs);
+    border-top: 1px solid var(--border-subtle);
+  }
+
+  .hints-title {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: var(--space-xs);
+  }
+
+  .hint {
+    padding: 6px var(--space-sm);
+    background: rgba(255, 170, 0, 0.08);
+    border-left: 3px solid var(--status-warning);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+    font-size: var(--font-size-xs);
+    color: var(--text-primary);
+    margin-bottom: 4px;
+  }
+
+  .result-box {
+    margin-top: var(--space-sm);
+    padding: var(--space-sm) var(--space-md);
+    border-radius: var(--radius-sm);
+    text-align: center;
+  }
+
+  .result-box.success { background: rgba(0, 255, 136, 0.08); border: 1px solid var(--status-nominal); }
+  .result-box.failure { background: rgba(255, 68, 68, 0.08); border: 1px solid var(--status-critical); }
+
+  .result-title {
+    font-size: var(--font-size-base);
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+
+  .result-box.success .result-title { color: var(--status-nominal); }
+  .result-box.failure .result-title { color: var(--status-critical); }
+
+  .result-text { font-size: var(--font-size-xs); color: var(--text-secondary); }
+</style>

--- a/gui-svelte/src/components/mission/ScenarioLoader.svelte
+++ b/gui-svelte/src/components/mission/ScenarioLoader.svelte
@@ -1,0 +1,993 @@
+<script lang="ts">
+  import { onMount, onDestroy, createEventDispatcher } from "svelte";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+
+  const dispatch = createEventDispatcher<{
+    "scenario-loaded": { ship_id?: string; station?: string; assignedShip?: string; started?: boolean };
+    "next-mission": Record<string, never>;
+  }>();
+
+  type MenuState = "title" | "mission_select" | "quick_play" | "lobby" | "post_mission";
+
+  interface Scenario {
+    id: string;
+    name?: string;
+    description?: string;
+    mission_description?: string;
+    difficulty?: string;
+    category?: string;
+    briefing?: string;
+    player_count?: string | number;
+  }
+
+  interface ShipStation {
+    station: string;
+    claimed: boolean;
+    player?: string;
+  }
+
+  interface LobbyShip {
+    id: string;
+    name?: string;
+    class?: string;
+    faction?: string;
+    stations?: ShipStation[];
+  }
+
+  interface SkirmishShip { class: string; count?: number; }
+
+  // ── State ─────────────────────────────────────────────────────────
+  let menuState: MenuState = "title";
+  let scenarios: Scenario[] = [];
+  let ships: LobbyShip[] = [];
+  let selectedScenario: string | null = null;
+  let expandedCard: string | null = null;
+  let activeScenario: string | null = null;
+  let isCaptain = false;
+  let isLoading = false;
+  let categoryFilter = "all";
+  let errorMsg = "";
+
+  // Skirmish configurator
+  let skirmishMode = "deathmatch";
+  let skirmishPlayerShips: SkirmishShip[] = [{ class: "corvette" }];
+  let skirmishEnemyShips: SkirmishShip[] = [{ class: "frigate", count: 1 }];
+  let skirmishRange = 50;
+  let skirmishTimeLimit: number | null = null;
+  let skirmishNewPlayerClass = "corvette";
+  let skirmishNewEnemyClass = "frigate";
+  let skirmishNewEnemyCount = 1;
+
+  const SKIRMISH_SHIP_CLASSES = ["fighter", "corvette", "gunship", "frigate", "destroyer", "cruiser", "battleship", "carrier"];
+  const SKIRMISH_MODES = [
+    { id: "deathmatch", label: "DEATHMATCH", desc: "All vs all, last team standing" },
+    { id: "team",       label: "TEAM",       desc: "Two teams, destroy all enemies" },
+    { id: "defend",     label: "DEFEND",     desc: "Protect a station from waves" },
+    { id: "escort",     label: "ESCORT",     desc: "Escort a freighter to safety" },
+  ];
+  const DIFFICULTY_ORDER: Record<string, number> = { tutorial: 0, easy: 1, medium: 2, hard: 3, extreme: 4 };
+  const DIFFICULTY_COLORS: Record<string, string> = {
+    tutorial: "#00aaff", easy: "#00ff88", medium: "#ffaa00", hard: "#ff6644", extreme: "#ff2222",
+  };
+  const CATEGORY_LABELS: Record<string, string> = {
+    tutorial: "TUTORIAL", combat: "COMBAT", stealth: "STEALTH", fleet: "FLEET", campaign: "CAMPAIGN",
+  };
+  const CATEGORIES = ["all", "tutorial", "combat", "stealth", "fleet", "campaign"];
+
+  // ── Derived ───────────────────────────────────────────────────────
+  $: filteredScenarios = [...scenarios]
+    .sort((a, b) => (DIFFICULTY_ORDER[a.difficulty ?? ""] ?? 99) - (DIFFICULTY_ORDER[b.difficulty ?? ""] ?? 99))
+    .filter(sc => categoryFilter === "all" || sc.category === categoryFilter);
+
+  // ── Lifecycle ─────────────────────────────────────────────────────
+  let statusHandler: ((e: Event) => void) | null = null;
+
+  onMount(() => {
+    statusHandler = (e: Event) => {
+      const detail = (e as CustomEvent<{ status: string }>).detail;
+      if (detail.status === "connected" && menuState === "lobby") {
+        fetchAndRenderLobby();
+      }
+    };
+    wsClient.addEventListener("status_change", statusHandler);
+  });
+
+  onDestroy(() => {
+    if (statusHandler) wsClient.removeEventListener("status_change", statusHandler);
+  });
+
+  // ── Navigation ────────────────────────────────────────────────────
+  async function goNewGame() {
+    errorMsg = "";
+    await fetchScenarios();
+    menuState = "mission_select";
+  }
+
+  async function goJoinGame() {
+    errorMsg = "";
+    await fetchAndRenderLobby();
+  }
+
+  function goQuickPlay() {
+    errorMsg = "";
+    menuState = "quick_play";
+  }
+
+  // ── Data Fetching ─────────────────────────────────────────────────
+  async function fetchScenarios() {
+    try {
+      const resp = await wsClient.send("list_scenarios", {}) as { ok?: boolean; scenarios?: Scenario[] };
+      scenarios = (resp?.ok !== false && resp?.scenarios) ? resp.scenarios : [];
+    } catch { scenarios = []; }
+  }
+
+  let lastLobbyFetch = 0;
+
+  async function fetchAndRenderLobby() {
+    if (isLoading) return;
+    const now = Date.now();
+    if (now - lastLobbyFetch < 2000) return;
+
+    isLoading = true;
+    errorMsg = "";
+
+    try {
+      if (wsClient.status !== "connected") {
+        try { await wsClient.connect(); } catch { /* continue */ }
+      }
+
+      const shipsResp = await wsClient.send("list_ships", {}) as { success?: boolean; data?: { ships: LobbyShip[] } };
+      ships = (shipsResp?.success && shipsResp?.data?.ships) ? shipsResp.data.ships : [];
+
+      const statusResp = await wsClient.send("my_status", {}) as { success?: boolean; data?: { station?: string } };
+      isCaptain = !!(statusResp?.success && statusResp?.data?.station === "captain");
+
+      const stateResp = await wsClient.send("get_state", {}) as { active_scenario?: string };
+      activeScenario = stateResp?.active_scenario ?? null;
+
+      await Promise.all(ships.map(async (ship) => {
+        try {
+          const sResp = await wsClient.send("station_status", { ship: ship.id }) as { success?: boolean; data?: { stations: ShipStation[] } };
+          ship.stations = sResp?.success ? (sResp.data?.stations ?? []) : [];
+        } catch { ship.stations = []; }
+      }));
+      ships = [...ships]; // trigger reactivity
+
+      lastLobbyFetch = Date.now();
+      menuState = "lobby";
+    } catch (e) {
+      errorMsg = "Failed to load lobby. Check server connection.";
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  // ── Mission Launch ─────────────────────────────────────────────────
+  let launching = false;
+
+  async function loadScenario(scenarioId: string) {
+    if (!scenarioId || launching) return;
+    launching = true;
+    errorMsg = "";
+
+    try {
+      if (wsClient.status !== "connected") {
+        try { await wsClient.connect(); } catch { /* continue */ }
+      }
+
+      const resp = await wsClient.send("load_scenario", { scenario: scenarioId }) as Record<string, unknown>;
+
+      if (resp?.ok === false) {
+        errorMsg = (resp.error as string) ?? "Failed to load scenario.";
+        return;
+      }
+
+      activeScenario = scenarioId;
+      selectedScenario = null;
+      expandedCard = null;
+
+      _dispatchScenarioLoaded(resp);
+      await fetchAndRenderLobby();
+    } catch (e) {
+      errorMsg = "Error loading scenario.";
+    } finally {
+      launching = false;
+    }
+  }
+
+  async function generateAndPlay() {
+    if (isLoading) return;
+    isLoading = true;
+    errorMsg = "";
+
+    try {
+      const params: Record<string, unknown> = {
+        mode: skirmishMode,
+        player_ships: skirmishPlayerShips,
+        enemy_ships: skirmishEnemyShips,
+        start_range_km: skirmishRange,
+        randomize_positions: true,
+      };
+      if (skirmishTimeLimit) params.time_limit_seconds = skirmishTimeLimit;
+
+      const resp = await wsClient.send("generate_skirmish", params) as Record<string, unknown>;
+
+      if (resp?.ok === false) {
+        errorMsg = (resp.error as string) ?? "Skirmish generation failed.";
+        return;
+      }
+
+      activeScenario = (resp?.scenario_name as string) ?? "Generated Skirmish";
+      _dispatchScenarioLoaded(resp);
+      await fetchAndRenderLobby();
+    } catch { errorMsg = "Error generating skirmish."; }
+    finally { isLoading = false; }
+  }
+
+  async function joinStation(shipId: string, stationName: string) {
+    errorMsg = "";
+    try {
+      const assignResp = await wsClient.send("assign_ship", { ship: shipId }) as { success?: boolean; message?: string };
+      if (!assignResp?.success) throw new Error(assignResp?.message ?? "assign failed");
+
+      const claimResp = await wsClient.send("claim_station", { station: stationName, ship: shipId }) as { success?: boolean; message?: string };
+      if (!claimResp?.success) throw new Error(claimResp?.message ?? "claim failed");
+
+      const detail = { assignedShip: shipId, station: stationName };
+      dispatch("scenario-loaded", detail);
+      document.dispatchEvent(new CustomEvent("scenario-loaded", { detail }));
+
+      await fetchAndRenderLobby();
+    } catch (e) {
+      errorMsg = `Failed to join station: ${e instanceof Error ? e.message : e}`;
+    }
+  }
+
+  function startMission() {
+    const detail = { started: true };
+    dispatch("scenario-loaded", detail);
+    document.dispatchEvent(new CustomEvent("scenario-loaded", { detail }));
+  }
+
+  function _dispatchScenarioLoaded(detail: Record<string, unknown>) {
+    dispatch("scenario-loaded", { ship_id: detail.ship_id as string | undefined });
+    document.dispatchEvent(new CustomEvent("scenario-loaded", { detail }));
+  }
+
+  // ── Post-mission ────────────────────────────────────────────────
+  /** Called externally to switch to post-mission screen */
+  export function showPostMission() { menuState = "post_mission"; }
+
+  function replayScenario() {
+    if (activeScenario) loadScenario(activeScenario);
+  }
+
+  function onNextMission() {
+    dispatch("next-mission", {});
+    document.dispatchEvent(new CustomEvent("next-mission", {}));
+  }
+</script>
+
+<div class="loader-root">
+  <!-- ── TITLE ─────────────────────────────────── -->
+  {#if menuState === "title"}
+    <div class="title-screen">
+      <div class="title-glow"></div>
+      <div class="title-content">
+        <h1 class="game-title">FLAXOS SPACESHIP SIM</h1>
+        <p class="game-subtitle">Hard Sci-Fi Tactical Bridge Simulator</p>
+        <div class="title-buttons">
+          <button class="btn btn-primary btn-large" on:click={goNewGame}>NEW GAME</button>
+          <button class="btn btn-accent btn-large" on:click={goQuickPlay}>QUICK PLAY</button>
+          <button class="btn btn-secondary btn-large" on:click={goJoinGame}>JOIN GAME</button>
+        </div>
+        <div class="title-version">v0.01</div>
+      </div>
+    </div>
+
+  <!-- ── MISSION SELECT ─────────────────────────── -->
+  {:else if menuState === "mission_select"}
+    <div class="screen">
+      <div class="screen-header">
+        <button class="btn btn-ghost" on:click={() => menuState = "title"}>← BACK</button>
+        <h2 class="section-title">SELECT MISSION</h2>
+      </div>
+
+      <div class="filter-bar">
+        {#each CATEGORIES as cat}
+          <button
+            class="filter-btn"
+            class:active={categoryFilter === cat}
+            on:click={() => categoryFilter = cat}
+          >
+            {cat === "all" ? "ALL" : (CATEGORY_LABELS[cat] ?? cat.toUpperCase())}
+          </button>
+        {/each}
+      </div>
+
+      {#if errorMsg}<div class="error-msg">{errorMsg}</div>{/if}
+
+      {#if filteredScenarios.length === 0}
+        <div class="empty-state">
+          {scenarios.length === 0 ? "No missions found. Check server connection." : "No missions in this category."}
+        </div>
+      {:else}
+        <div class="mission-grid">
+          {#each filteredScenarios as sc (sc.id)}
+            {@const diffColor = DIFFICULTY_COLORS[sc.difficulty ?? ""] ?? "#888"}
+            {@const isExpanded = expandedCard === sc.id}
+            <div
+              class="mission-card"
+              class:selected={selectedScenario === sc.id}
+              class:expanded={isExpanded}
+              on:click|stopPropagation={() => selectedScenario = sc.id}
+              role="button"
+              tabindex="0"
+              on:keydown={(e) => e.key === "Enter" && (selectedScenario = sc.id)}
+            >
+              <div class="card-header">
+                <span class="card-name">{sc.name ?? sc.id}</span>
+                <div class="card-tags">
+                  <span class="tag" style="--tag-color: {diffColor}">{(sc.difficulty ?? "unknown").toUpperCase()}</span>
+                  {#if sc.category}<span class="tag tag-cat">{CATEGORY_LABELS[sc.category] ?? sc.category.toUpperCase()}</span>{/if}
+                  {#if sc.player_count}<span class="tag tag-players">{sc.player_count}P</span>{/if}
+                </div>
+              </div>
+              <div class="card-desc">{sc.description ?? sc.mission_description ?? ""}</div>
+              {#if isExpanded && sc.briefing}
+                <div class="card-briefing">
+                  <div class="briefing-label">MISSION BRIEFING</div>
+                  <div class="briefing-text">{sc.briefing}</div>
+                </div>
+              {/if}
+              <div class="card-actions">
+                {#if sc.briefing}
+                  <button class="btn btn-ghost btn-sm" on:click|stopPropagation={() => expandedCard = isExpanded ? null : sc.id}>
+                    {isExpanded ? "HIDE" : "BRIEFING"}
+                  </button>
+                {/if}
+                <button
+                  class="btn btn-primary btn-sm"
+                  disabled={launching}
+                  on:click|stopPropagation={() => loadScenario(sc.id)}
+                >
+                  {launching && selectedScenario === sc.id ? "LOADING..." : "LAUNCH"}
+                </button>
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+  <!-- ── QUICK PLAY ─────────────────────────────── -->
+  {:else if menuState === "quick_play"}
+    <div class="screen">
+      <div class="screen-header">
+        <button class="btn btn-ghost" on:click={() => menuState = "title"}>← BACK</button>
+        <h2 class="section-title">QUICK PLAY</h2>
+      </div>
+
+      {#if errorMsg}<div class="error-msg">{errorMsg}</div>{/if}
+
+      <div class="qp-section">
+        <div class="qp-label">MODE</div>
+        <div class="filter-bar">
+          {#each SKIRMISH_MODES as m}
+            <button class="filter-btn" class:active={skirmishMode === m.id} title={m.desc} on:click={() => skirmishMode = m.id}>
+              {m.label}
+            </button>
+          {/each}
+        </div>
+      </div>
+
+      <!-- Player ships -->
+      <div class="qp-section">
+        <div class="qp-label">PLAYER SHIPS</div>
+        <div class="qp-ship-list">
+          {#each skirmishPlayerShips as s, i}
+            <div class="qp-ship-row">
+              <span class="ship-class-tag">{s.class.toUpperCase()}</span>
+              <button class="btn btn-ghost btn-xs" on:click={() => { skirmishPlayerShips.splice(i, 1); skirmishPlayerShips = [...skirmishPlayerShips]; }}>✕</button>
+            </div>
+          {/each}
+        </div>
+        <div class="qp-add-row">
+          <select class="qp-select" bind:value={skirmishNewPlayerClass}>
+            {#each SKIRMISH_SHIP_CLASSES as cls}<option value={cls}>{cls.toUpperCase()}</option>{/each}
+          </select>
+          <button class="btn btn-secondary btn-sm" on:click={() => { skirmishPlayerShips = [...skirmishPlayerShips, { class: skirmishNewPlayerClass }]; }}>ADD</button>
+        </div>
+      </div>
+
+      <!-- Enemy ships -->
+      <div class="qp-section">
+        <div class="qp-label">ENEMY SHIPS</div>
+        <div class="qp-ship-list">
+          {#each skirmishEnemyShips as s, i}
+            <div class="qp-ship-row">
+              <span class="ship-class-tag">{s.class.toUpperCase()}</span>
+              {#if (s.count ?? 1) > 1}<span class="count-tag">×{s.count}</span>{/if}
+              <button class="btn btn-ghost btn-xs" on:click={() => { skirmishEnemyShips.splice(i, 1); skirmishEnemyShips = [...skirmishEnemyShips]; }}>✕</button>
+            </div>
+          {/each}
+        </div>
+        <div class="qp-add-row">
+          <select class="qp-select" bind:value={skirmishNewEnemyClass}>
+            {#each SKIRMISH_SHIP_CLASSES as cls}<option value={cls}>{cls.toUpperCase()}</option>{/each}
+          </select>
+          <input class="qp-count" type="number" min="1" max="10" bind:value={skirmishNewEnemyCount} />
+          <button class="btn btn-secondary btn-sm" on:click={() => { skirmishEnemyShips = [...skirmishEnemyShips, { class: skirmishNewEnemyClass, count: skirmishNewEnemyCount }]; }}>ADD</button>
+        </div>
+      </div>
+
+      <!-- Range slider -->
+      <div class="qp-section">
+        <div class="qp-label">START RANGE: <span class="range-val">{skirmishRange} km</span></div>
+        <input type="range" class="qp-slider" min="10" max="200" step="5" bind:value={skirmishRange} />
+      </div>
+
+      <!-- Time limit -->
+      <div class="qp-section">
+        <div class="qp-label">TIME LIMIT <span class="qp-optional">(optional)</span></div>
+        <div class="qp-add-row">
+          <input class="qp-count" type="number" min="60" max="3600" step="30" placeholder="seconds" bind:value={skirmishTimeLimit} />
+          <button class="btn btn-ghost btn-sm" on:click={() => skirmishTimeLimit = null}>CLEAR</button>
+        </div>
+      </div>
+
+      <button class="btn btn-primary btn-large qp-launch" disabled={isLoading} on:click={generateAndPlay}>
+        {isLoading ? "GENERATING..." : "GENERATE & PLAY"}
+      </button>
+    </div>
+
+  <!-- ── LOBBY ──────────────────────────────────── -->
+  {:else if menuState === "lobby"}
+    <div class="screen">
+      <div class="screen-header">
+        <button class="btn btn-ghost" on:click={() => menuState = "title"}>← BACK</button>
+        <h2 class="section-title">FLEET LOBBY</h2>
+        <button class="btn btn-ghost btn-sm" on:click={fetchAndRenderLobby} disabled={isLoading}>
+          {isLoading ? "..." : "REFRESH"}
+        </button>
+      </div>
+
+      {#if activeScenario}
+        <div class="lobby-scenario">Mission: {activeScenario}</div>
+      {/if}
+      {#if errorMsg}<div class="error-msg">{errorMsg}</div>{/if}
+
+      {#if ships.length === 0}
+        <div class="empty-state">No active fleet. Load a mission first.</div>
+        <button class="btn btn-primary" on:click={goNewGame}>SELECT MISSION</button>
+      {:else}
+        <div class="ship-grid">
+          {#each ships as ship (ship.id)}
+            <div class="ship-card">
+              <div class="ship-card-header">
+                <span class="ship-name">{ship.name ?? ship.id}</span>
+                <span class="ship-class-badge">{ship.class ?? "?"}</span>
+                {#if ship.faction}<span class="ship-faction">{ship.faction.toUpperCase()}</span>{/if}
+              </div>
+              <div class="station-grid">
+                {#each (ship.stations ?? []) as st}
+                  {#if st.claimed}
+                    <div class="station-slot occupied" title={st.player ?? "Taken"}>
+                      <span class="st-name">{st.station}</span>
+                      <span class="st-status">{st.player ?? "TAKEN"}</span>
+                    </div>
+                  {:else}
+                    <button class="station-slot vacant" on:click={() => joinStation(ship.id, st.station)}>
+                      <span class="st-name">{st.station}</span>
+                      <span class="st-status">JOIN</span>
+                    </button>
+                  {/if}
+                {/each}
+              </div>
+            </div>
+          {/each}
+        </div>
+
+        {#if isCaptain}
+          <button class="btn btn-primary btn-large start-btn" on:click={startMission}>START MISSION</button>
+        {/if}
+      {/if}
+    </div>
+
+  <!-- ── POST MISSION ───────────────────────────── -->
+  {:else if menuState === "post_mission"}
+    <div class="post-mission screen">
+      <h2 class="section-title post-title">MISSION COMPLETE</h2>
+      <div class="post-buttons">
+        <button class="btn btn-primary btn-large" on:click={onNextMission}>NEXT MISSION</button>
+        <button class="btn btn-secondary btn-large" on:click={replayScenario}>REPLAY</button>
+        <button class="btn btn-ghost btn-large" on:click={() => menuState = "title"}>BACK TO MENU</button>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .loader-root {
+    width: 100%;
+    height: 100%;
+    overflow-y: auto;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-family: var(--font-sans);
+  }
+
+  /* ── Title ── */
+  .title-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 100%;
+    padding: var(--space-xl);
+    text-align: center;
+    position: relative;
+  }
+
+  .title-glow {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 400px;
+    height: 400px;
+    background: radial-gradient(circle, rgba(0, 170, 255, 0.07) 0%, transparent 70%);
+    pointer-events: none;
+  }
+
+  .title-content { position: relative; z-index: 1; }
+
+  .game-title {
+    font-family: var(--font-mono);
+    font-size: 2rem;
+    font-weight: 700;
+    letter-spacing: 6px;
+    color: var(--tier-accent, var(--hud-primary));
+    text-shadow: 0 0 20px rgba(68, 136, 255, 0.4);
+    margin: 0 0 var(--space-sm);
+    text-transform: uppercase;
+  }
+
+  .game-subtitle {
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
+    letter-spacing: 2px;
+    margin: 0 0 var(--space-xl);
+  }
+
+  .title-buttons {
+    display: flex;
+    gap: var(--space-md);
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .title-version {
+    margin-top: var(--space-lg);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--text-dim);
+  }
+
+  /* ── Screen wrapper ── */
+  .screen {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: var(--space-md);
+    min-height: 100%;
+  }
+
+  .screen-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    margin-bottom: var(--space-md);
+    border-bottom: 1px solid var(--border-subtle);
+    padding-bottom: var(--space-sm);
+  }
+
+  .section-title {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-lg);
+    font-weight: 700;
+    letter-spacing: 3px;
+    color: var(--text-primary);
+    text-transform: uppercase;
+    flex: 1;
+    margin: 0;
+  }
+
+  /* ── Filter bar ── */
+  .filter-bar {
+    display: flex;
+    gap: var(--space-xs);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-md);
+  }
+
+  .filter-btn {
+    padding: 4px 12px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    cursor: pointer;
+    letter-spacing: 0.5px;
+    transition: all var(--transition-fast);
+  }
+
+  .filter-btn.active {
+    background: var(--tier-accent, var(--hud-primary));
+    border-color: var(--tier-accent, var(--hud-primary));
+    color: #0a0a0f;
+    font-weight: 600;
+  }
+
+  .filter-btn:hover:not(.active) {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  /* ── Mission grid ── */
+  .mission-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .mission-card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    padding: var(--space-sm);
+    cursor: pointer;
+    transition: border-color var(--transition-fast);
+  }
+
+  .mission-card:hover { border-color: var(--border-active); }
+  .mission-card.selected { border-color: var(--tier-accent, var(--hud-primary)); }
+
+  .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--space-xs);
+    margin-bottom: var(--space-xs);
+  }
+
+  .card-name {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .card-tags { display: flex; gap: 4px; flex-wrap: wrap; }
+
+  .tag {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: rgba(var(--tier-accent-rgb, 68, 136, 255), 0.15);
+    color: var(--tag-color, var(--tier-accent, var(--hud-primary)));
+    border: 1px solid var(--tag-color, var(--tier-accent, var(--hud-primary)));
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    white-space: nowrap;
+  }
+
+  .tag-cat { color: var(--text-secondary); border-color: var(--border-default); background: transparent; }
+  .tag-players { color: var(--text-dim); border-color: var(--border-subtle); background: transparent; }
+
+  .card-desc {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    line-height: 1.4;
+    margin-bottom: var(--space-xs);
+  }
+
+  .card-briefing {
+    margin: var(--space-xs) 0;
+    padding: var(--space-sm);
+    background: var(--bg-input);
+    border-radius: var(--radius-sm);
+  }
+
+  .briefing-label {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: var(--space-xs);
+  }
+
+  .briefing-text {
+    font-size: var(--font-size-xs);
+    color: var(--text-primary);
+    line-height: 1.5;
+    white-space: pre-wrap;
+  }
+
+  .card-actions {
+    display: flex;
+    gap: var(--space-xs);
+    justify-content: flex-end;
+    margin-top: var(--space-xs);
+  }
+
+  /* ── Quick play ── */
+  .qp-section { margin-bottom: var(--space-md); }
+
+  .qp-label {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: var(--space-xs);
+  }
+
+  .qp-optional { color: var(--text-dim); font-weight: 400; }
+
+  .qp-slider {
+    width: 100%;
+    accent-color: var(--tier-accent, var(--hud-primary));
+  }
+
+  .range-val { color: var(--tier-accent, var(--hud-primary)); font-weight: 600; }
+
+  .qp-ship-list { display: flex; flex-direction: column; gap: 4px; margin-bottom: var(--space-xs); }
+
+  .qp-ship-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    padding: 4px 8px;
+    background: var(--bg-input);
+    border-radius: var(--radius-sm);
+  }
+
+  .ship-class-tag {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--text-primary);
+    flex: 1;
+  }
+
+  .count-tag {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  .qp-add-row { display: flex; gap: var(--space-xs); align-items: center; }
+
+  .qp-select {
+    flex: 1;
+    background: var(--bg-input);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    padding: 4px 8px;
+  }
+
+  .qp-count {
+    width: 60px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    padding: 4px 8px;
+    text-align: center;
+  }
+
+  .qp-launch { width: 100%; margin-top: var(--space-sm); }
+
+  /* ── Lobby ── */
+  .lobby-scenario {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--tier-accent, var(--hud-primary));
+    margin-bottom: var(--space-sm);
+    padding: var(--space-xs) var(--space-sm);
+    background: rgba(var(--tier-accent-rgb, 68, 136, 255), 0.1);
+    border-radius: var(--radius-sm);
+    border-left: 3px solid var(--tier-accent, var(--hud-primary));
+  }
+
+  .ship-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: var(--space-sm);
+    margin-bottom: var(--space-md);
+  }
+
+  .ship-card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    padding: var(--space-sm);
+  }
+
+  .ship-card-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    margin-bottom: var(--space-xs);
+    padding-bottom: var(--space-xs);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .ship-name {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    color: var(--text-primary);
+    flex: 1;
+  }
+
+  .ship-class-badge, .ship-faction {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: var(--bg-input);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+  }
+
+  .station-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 4px;
+  }
+
+  .station-slot {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 6px 4px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    font-family: var(--font-mono);
+    transition: all var(--transition-fast);
+  }
+
+  .station-slot.vacant {
+    cursor: pointer;
+    background: rgba(var(--tier-accent-rgb, 68, 136, 255), 0.08);
+    border-color: var(--tier-accent, var(--hud-primary));
+  }
+
+  .station-slot.vacant:hover {
+    background: rgba(var(--tier-accent-rgb, 68, 136, 255), 0.2);
+  }
+
+  .station-slot.occupied {
+    background: var(--bg-input);
+    opacity: 0.7;
+  }
+
+  .st-name {
+    font-size: 0.55rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .st-status {
+    font-size: 0.6rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-top: 2px;
+  }
+
+  .station-slot.vacant .st-status { color: var(--tier-accent, var(--hud-primary)); }
+
+  .start-btn { width: 100%; margin-top: var(--space-md); }
+
+  /* ── Post mission ── */
+  .post-mission {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+    text-align: center;
+  }
+
+  .post-title { margin-bottom: var(--space-xl); font-size: 1.5rem; letter-spacing: 6px; }
+
+  .post-buttons {
+    display: flex;
+    gap: var(--space-md);
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  /* ── Buttons ── */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-xs);
+    padding: 8px 20px;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    letter-spacing: 1px;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .btn-large { padding: 12px 32px; font-size: var(--font-size-sm); }
+  .btn-sm { padding: 4px 12px; font-size: 0.65rem; }
+  .btn-xs { padding: 2px 8px; font-size: 0.6rem; }
+
+  .btn-primary {
+    background: var(--tier-accent, var(--hud-primary));
+    border-color: var(--tier-accent, var(--hud-primary));
+    color: #0a0a0f;
+  }
+  .btn-primary:hover:not(:disabled) { filter: brightness(1.15); box-shadow: 0 0 12px rgba(var(--tier-accent-rgb, 68, 136, 255), 0.4); }
+
+  .btn-accent {
+    background: transparent;
+    border-color: var(--tier-accent, var(--hud-primary));
+    color: var(--tier-accent, var(--hud-primary));
+  }
+  .btn-accent:hover:not(:disabled) { background: rgba(var(--tier-accent-rgb, 68, 136, 255), 0.15); }
+
+  .btn-secondary {
+    background: var(--bg-input);
+    border-color: var(--border-active);
+    color: var(--text-primary);
+  }
+  .btn-secondary:hover:not(:disabled) { background: var(--bg-hover); }
+
+  .btn-ghost {
+    background: transparent;
+    border-color: transparent;
+    color: var(--text-secondary);
+  }
+  .btn-ghost:hover:not(:disabled) { color: var(--text-primary); background: var(--bg-hover); }
+
+  /* ── Misc ── */
+  .empty-state {
+    text-align: center;
+    padding: var(--space-xl);
+    color: var(--text-dim);
+    font-style: italic;
+    font-size: var(--font-size-sm);
+  }
+
+  .error-msg {
+    padding: var(--space-sm) var(--space-md);
+    background: rgba(255, 68, 68, 0.1);
+    border: 1px solid var(--status-critical);
+    border-radius: var(--radius-sm);
+    color: var(--status-critical);
+    font-size: var(--font-size-xs);
+    font-family: var(--font-mono);
+    margin-bottom: var(--space-sm);
+  }
+</style>

--- a/gui-svelte/src/components/ops/BoardingPanel.svelte
+++ b/gui-svelte/src/components/ops/BoardingPanel.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { getTacticalContacts } from "../tactical/tacticalData.js";
+  import {
+    asRecord,
+    formatPercent,
+    getBoardingTelemetry,
+    getOpsShip,
+    toNumber,
+    toStringValue,
+  } from "./opsData.js";
+
+  let status: Record<string, unknown> = {};
+  let selectedTarget = "";
+  let feedback = "";
+  let pollHandle: number | null = null;
+
+  $: ship = getOpsShip($gameState);
+  $: contacts = getTacticalContacts(ship);
+  $: telemetry = getBoardingTelemetry(ship);
+  $: boarding = Object.keys(status).length ? status : telemetry;
+  $: state = toStringValue(boarding.state, "idle");
+  $: targetId = toStringValue(boarding.target, selectedTarget);
+  $: progress = Math.max(0, Math.min(100, toNumber(boarding.progress) * 100));
+  $: resistance = asRecord(boarding.resistance) ?? {};
+  $: resistanceFactor = toNumber(resistance.total_factor, 1);
+
+  onMount(() => {
+    if (!selectedTarget && contacts.length) selectedTarget = contacts[0].id;
+    void refresh();
+    pollHandle = window.setInterval(() => void refresh(), 1500);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  async function refresh() {
+    try {
+      const response = await wsClient.sendShipCommand("boarding_status", {});
+      status = (asRecord(response) ?? {}) as Record<string, unknown>;
+    } catch {
+      status = {};
+    }
+  }
+
+  async function beginBoarding() {
+    if (!selectedTarget) return;
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("begin_boarding", { target_id: selectedTarget });
+      feedback = `Boarding started on ${selectedTarget}`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Boarding start failed";
+    }
+  }
+
+  async function cancelBoarding() {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("cancel_boarding", {});
+      feedback = "Boarding cancelled";
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Cancel failed";
+    }
+  }
+
+  function resistanceLabel(): string {
+    if (resistanceFactor <= 0.35) return "SEVERE";
+    if (resistanceFactor <= 0.6) return "HIGH";
+    if (resistanceFactor <= 0.85) return "MODERATE";
+    return "LIGHT";
+  }
+</script>
+
+<Panel title="Boarding" domain="power" priority="secondary" className="boarding-panel">
+  <div class="shell">
+    <section class="status-card">
+      <div class="head">
+        <span>Boarding State</span>
+        <strong>{state.toUpperCase()}</strong>
+      </div>
+      <div class="track">
+        <div class="fill" style={`width:${progress.toFixed(0)}%;`}></div>
+      </div>
+      <div class="meta">
+        <span>Progress {formatPercent(progress)}</span>
+        <span>{targetId || "NO TARGET"}</span>
+      </div>
+    </section>
+
+    <label class="selector">
+      <span>Target</span>
+      <select bind:value={selectedTarget}>
+        <option value="">Select target</option>
+        {#each contacts as contact}
+          <option value={contact.id}>{contact.id} · {contact.classification}</option>
+        {/each}
+      </select>
+    </label>
+
+    <div class="resistance-card">
+      <div class="head">
+        <span>Resistance</span>
+        <strong>{resistanceLabel()}</strong>
+      </div>
+      <div class="meta">
+        <span>Factor {resistanceFactor.toFixed(2)}</span>
+        <span>Weapons {toNumber(resistance.active_weapons, 0).toFixed(0)}</span>
+      </div>
+    </div>
+
+    <div class="actions">
+      <button type="button" disabled={!selectedTarget || state === "boarding"} on:click={beginBoarding}>BEGIN BOARDING</button>
+      <button class="secondary" type="button" disabled={state !== "boarding"} on:click={cancelBoarding}>CANCEL</button>
+    </div>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .status-card,
+  .resistance-card,
+  .feedback {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .head,
+  .meta,
+  .actions {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .selector {
+    display: grid;
+    gap: 6px;
+  }
+
+  .selector span,
+  .meta,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .track {
+    height: 10px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.35), var(--tier-accent));
+  }
+
+  select,
+  button {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  button.secondary {
+    color: var(--text-secondary);
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+</style>

--- a/gui-svelte/src/components/ops/CrewFatigueDisplay.svelte
+++ b/gui-svelte/src/components/ops/CrewFatigueDisplay.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { countRestingCrew, formatPercent, getCrewFatigueState, getOpsShip, readinessClass, toNumber } from "./opsData.js";
+
+  let feedback = "";
+
+  $: ship = getOpsShip($gameState);
+  $: fatigue = getCrewFatigueState(ship);
+  $: fatiguePercent = clampPercent(toNumber(fatigue.fatigue) * 100);
+  $: gLoad = toNumber(fatigue.g_load);
+  $: performance = clampPercent(toNumber(fatigue.performance, 1) * 100);
+  $: restingCrew = countRestingCrew(ship);
+  $: restOrdered = Boolean(fatigue.rest_ordered);
+
+  function clampPercent(value: number): number {
+    return Math.max(0, Math.min(100, value));
+  }
+
+  async function toggleRest(ordered: boolean) {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand(ordered ? "cancel_rest" : "crew_rest", {});
+      feedback = ordered ? "Rest order cancelled" : "Rest order sent";
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Crew rest command failed";
+    }
+  }
+</script>
+
+<Panel title="Crew Fatigue" domain="power" priority="secondary" className="crew-fatigue-display">
+  <div class="shell">
+    <div class="metric-card">
+      <div class="head">
+        <span>Fatigue</span>
+        <strong class={readinessClass(100 - fatiguePercent)}>{formatPercent(fatiguePercent)}</strong>
+      </div>
+      <div class="track">
+        <div class="fill {readinessClass(100 - fatiguePercent)}" style={`width:${fatiguePercent.toFixed(0)}%;`}></div>
+      </div>
+    </div>
+
+    <div class="stats-grid">
+      <div><span>G-Load</span><strong>{gLoad.toFixed(1)}g</strong></div>
+      <div><span>Performance</span><strong>{formatPercent(performance)}</strong></div>
+      <div><span>Resting Crew</span><strong>{restingCrew}</strong></div>
+      <div><span>Status</span><strong>{String(fatigue.status ?? "nominal").toUpperCase()}</strong></div>
+    </div>
+
+    <button type="button" class:active={restOrdered} on:click={() => toggleRest(restOrdered)}>
+      {restOrdered ? "CANCEL REST" : "ORDER CREW REST"}
+    </button>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .metric-card,
+  .feedback {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .head,
+  .stats-grid {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  span,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .track {
+    height: 12px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .fill {
+    height: 100%;
+  }
+
+  .fill.nominal {
+    background: rgba(0, 255, 136, 0.82);
+  }
+
+  .fill.warning {
+    background: rgba(255, 170, 0, 0.88);
+  }
+
+  .fill.critical {
+    background: rgba(255, 68, 68, 0.9);
+  }
+
+  button {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  button.active {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+</style>

--- a/gui-svelte/src/components/ops/CrewPanel.svelte
+++ b/gui-svelte/src/components/ops/CrewPanel.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { asRecord, getCrewRows, getOpsShip, skillShort, toStringValue } from "./opsData.js";
+
+  interface CrewCard {
+    crewId: string;
+    clientId: string;
+    name: string;
+    station: string;
+    fatigue: number;
+    stress: number;
+    injury: string;
+    skills: Record<string, number>;
+  }
+
+  let cards: CrewCard[] = [];
+  let canManageOfficers = false;
+  let feedback = "";
+  let pollHandle: number | null = null;
+
+  $: ship = getOpsShip($gameState);
+  $: rosterFallback = getCrewRows(ship);
+
+  onMount(() => {
+    detectCaptain();
+    void refresh();
+    pollHandle = window.setInterval(() => {
+      detectCaptain();
+      void refresh();
+    }, 5000);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  function detectCaptain() {
+    if (typeof document === "undefined") return;
+    const badge = document.querySelector(".claimed-badge");
+    canManageOfficers = (badge?.textContent ?? "").trim().toUpperCase() === "CAPTAIN";
+  }
+
+  async function refresh() {
+    try {
+      const response = await wsClient.sendShipCommand("crew_status", {});
+      const record = asRecord(response);
+      const source = Array.isArray(record?.crew) ? record.crew : [];
+      const stationMap = new Map(rosterFallback.map((row) => [row.crewId, row.station]));
+      cards = source
+        .map((item) => asRecord(item))
+        .filter((item): item is Record<string, unknown> => Boolean(item))
+        .map((item) => ({
+          crewId: toStringValue(item.crew_id),
+          clientId: toStringValue(item.client_id),
+          name: toStringValue(item.name, "Crew"),
+          station: stationMap.get(toStringValue(item.crew_id)) ?? toStringValue(item.station_assignment, "UNASSIGNED"),
+          fatigue: Number(item.fatigue ?? 0),
+          stress: Number(item.stress ?? 0),
+          injury: toStringValue(item.injury_state, "healthy"),
+          skills: (asRecord(item.skills) as Record<string, number> | null) ?? {},
+        }));
+    } catch {
+      cards = rosterFallback;
+    }
+  }
+
+  function topSkills(skills: Record<string, number>): Array<[string, number]> {
+    return Object.entries(skills)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3);
+  }
+
+  async function officerCommand(command: "promote_to_officer" | "demote_from_officer", card: CrewCard) {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand(command, { target_client: card.clientId || card.crewId });
+      feedback = `${command.replaceAll("_", " ")} sent`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Officer command failed";
+    }
+  }
+
+  async function restCrew(card: CrewCard) {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("crew_rest", { crew_id: card.crewId });
+      feedback = `Rest ordered for ${card.name}`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Rest order failed";
+    }
+  }
+</script>
+
+<Panel title="Crew Panel" domain="power" priority="secondary" className="crew-panel">
+  <div class="shell">
+    {#if cards.length === 0}
+      <div class="empty">Crew data unavailable.</div>
+    {:else}
+      {#each cards as card}
+        <div class="crew-card">
+          <div class="head">
+            <strong>{card.name}</strong>
+            <span>{card.station.toUpperCase()}</span>
+          </div>
+          <div class="status-row">
+            <span>Fatigue {Math.round(card.fatigue * 100)}%</span>
+            <span>Stress {Math.round(card.stress * 100)}%</span>
+            <span>{card.injury.toUpperCase()}</span>
+          </div>
+          <div class="skills">
+            {#each topSkills(card.skills) as [skill, level]}
+              <span>{skill.replaceAll("_", " ").toUpperCase()} {skillShort(level)}</span>
+            {/each}
+          </div>
+          <div class="actions">
+            <button type="button" on:click={() => restCrew(card)}>REST</button>
+            {#if canManageOfficers}
+              <button type="button" on:click={() => officerCommand("promote_to_officer", card)}>PROMOTE</button>
+              <button type="button" on:click={() => officerCommand("demote_from_officer", card)}>DEMOTE</button>
+            {/if}
+          </div>
+        </div>
+      {/each}
+    {/if}
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .crew-card,
+  .empty,
+  .feedback {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .head,
+  .status-row,
+  .actions {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .head span,
+  .status-row,
+  .skills span,
+  .empty,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .skills span {
+    padding: 2px 6px;
+    border-radius: 999px;
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  button {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+</style>

--- a/gui-svelte/src/components/ops/CrewRosterPanel.svelte
+++ b/gui-svelte/src/components/ops/CrewRosterPanel.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { getCrewRows, getOpsShip, skillLong } from "./opsData.js";
+
+  let selectedCrewId = "";
+
+  $: ship = getOpsShip($gameState);
+  $: rows = getCrewRows(ship);
+  $: selected = rows.find((row) => row.crewId === selectedCrewId) ?? null;
+
+  function skillSummary(skills: Record<string, number>): string {
+    return Object.entries(skills)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 2)
+      .map(([skill, level]) => `${skill.replaceAll("_", " ")} ${skillLong(level)}`)
+      .join(" · ");
+  }
+</script>
+
+<Panel title="Crew Roster" domain="power" priority="secondary" className="crew-roster-panel">
+  <div class="shell">
+    <div class="table">
+      {#if rows.length === 0}
+        <div class="empty">No crew roster loaded.</div>
+      {:else}
+        {#each rows as row}
+          <button type="button" class="row" on:click={() => selectedCrewId = row.crewId}>
+            <span>{row.name}</span>
+            <span>{row.station.toUpperCase()}</span>
+            <span>{row.injury.toUpperCase()}</span>
+            <span>{skillSummary(row.skills).toUpperCase()}</span>
+          </button>
+        {/each}
+      {/if}
+    </div>
+  </div>
+
+  {#if selected}
+    <div class="modal-backdrop">
+      <div class="modal">
+        <div class="modal-head">
+          <strong>{selected.name}</strong>
+          <button type="button" on:click={() => selectedCrewId = ""}>CLOSE</button>
+        </div>
+        <div class="detail-grid">
+          <div><span>Station</span><strong>{selected.station.toUpperCase()}</strong></div>
+          <div><span>Injury</span><strong>{selected.injury.toUpperCase()}</strong></div>
+          <div><span>Fatigue</span><strong>{Math.round(selected.fatigue * 100)}%</strong></div>
+          <div><span>Stress</span><strong>{Math.round(selected.stress * 100)}%</strong></div>
+        </div>
+        <div class="skill-list">
+          {#each Object.entries(selected.skills) as [skill, level]}
+            <div class="skill-row">
+              <span>{skill.replaceAll("_", " ").toUpperCase()}</span>
+              <strong>{skillLong(level)}</strong>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </div>
+  {/if}
+</Panel>
+
+<style>
+  .shell {
+    padding: var(--space-sm);
+  }
+
+  .table {
+    display: grid;
+    gap: 6px;
+  }
+
+  .row,
+  .empty {
+    display: grid;
+    gap: 6px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+    text-align: left;
+  }
+
+  .row span,
+  .empty,
+  .detail-grid span,
+  .skill-row span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .modal-backdrop {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: rgba(4, 5, 10, 0.76);
+  }
+
+  .modal {
+    display: grid;
+    gap: var(--space-sm);
+    width: min(420px, calc(100% - 24px));
+    padding: 14px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: var(--bg-panel);
+  }
+
+  .modal-head,
+  .skill-row {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .detail-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .skill-list {
+    display: grid;
+    gap: 6px;
+  }
+</style>

--- a/gui-svelte/src/components/ops/DroneControlPanel.svelte
+++ b/gui-svelte/src/components/ops/DroneControlPanel.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { asRecord, formatDistance, toNumber, toStringValue } from "./opsData.js";
+
+  interface DroneStatus {
+    capacity: number;
+    stored_count: number;
+    active_count: number;
+    stored_drones: Array<Record<string, unknown>>;
+    active_drones: Array<Record<string, unknown>>;
+  }
+
+  const LABELS: Record<string, string> = {
+    drone_sensor: "Sensor",
+    drone_combat: "Combat",
+    drone_decoy: "Decoy",
+  };
+
+  let status: DroneStatus = {
+    capacity: 0,
+    stored_count: 0,
+    active_count: 0,
+    stored_drones: [],
+    active_drones: [],
+  };
+
+  let feedback = "";
+  let pollHandle: number | null = null;
+
+  $: counts = Object.entries(
+    status.stored_drones.reduce<Record<string, number>>((acc, item) => {
+      const type = toStringValue(asRecord(item)?.drone_type, "unknown");
+      acc[type] = (acc[type] ?? 0) + 1;
+      return acc;
+    }, {}),
+  );
+
+  onMount(() => {
+    void refresh();
+    pollHandle = window.setInterval(() => void refresh(), 2000);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  async function refresh() {
+    try {
+      const response = await wsClient.sendShipCommand("drone_status", {});
+      const record = asRecord(response);
+      status = {
+        capacity: toNumber(record?.capacity, 0),
+        stored_count: toNumber(record?.stored_count, 0),
+        active_count: toNumber(record?.active_count, 0),
+        stored_drones: Array.isArray(record?.stored_drones) ? record?.stored_drones as Array<Record<string, unknown>> : [],
+        active_drones: Array.isArray(record?.active_drones) ? record?.active_drones as Array<Record<string, unknown>> : [],
+      };
+    } catch {
+      // best effort
+    }
+  }
+
+  async function launchDrone(droneType: string) {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("launch_drone", { drone_type: droneType });
+      feedback = `${LABELS[droneType] ?? droneType} drone launch requested`;
+      void refresh();
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Launch failed";
+    }
+  }
+
+  async function recallDrone(droneId: string) {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("recall_drone", { drone_id: droneId });
+      feedback = `Recall ordered for ${droneId}`;
+      void refresh();
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Recall failed";
+    }
+  }
+</script>
+
+<Panel title="Drone Control" domain="power" priority="secondary" className="drone-control-panel">
+  <div class="shell">
+    <section class="summary-card">
+      <div><span>Capacity</span><strong>{status.capacity}</strong></div>
+      <div><span>Stored</span><strong>{status.stored_count}</strong></div>
+      <div><span>Active</span><strong>{status.active_count}</strong></div>
+    </section>
+
+    <section class="stored-card">
+      <div class="section-title">Drone Bay</div>
+      {#if counts.length === 0}
+        <div class="empty">No drones in bay.</div>
+      {:else}
+        {#each counts as [droneType, count]}
+          <div class="stored-row">
+            <strong>{LABELS[droneType] ?? droneType}</strong>
+            <span>{count} ready</span>
+            <button type="button" disabled={count <= 0} on:click={() => launchDrone(droneType)}>LAUNCH</button>
+          </div>
+        {/each}
+      {/if}
+    </section>
+
+    <section class="active-card">
+      <div class="section-title">Active Drones</div>
+      {#if status.active_drones.length === 0}
+        <div class="empty">No deployed drones.</div>
+      {:else}
+        {#each status.active_drones as drone}
+          <div class="active-row">
+            <div class="active-meta">
+              <strong>{toStringValue(drone.label, toStringValue(drone.drone_id, "Drone"))}</strong>
+              <span>{toStringValue(drone.ai_role, "unknown").toUpperCase()}</span>
+            </div>
+            <div class="active-stats">
+              <span>Fuel {toNumber(drone.fuel_pct, 0).toFixed(0)}%</span>
+              <span>Hull {toNumber(drone.hull_pct, 0).toFixed(0)}%</span>
+              <span>{formatDistance(toNumber(drone.distance_m, 0))}</span>
+            </div>
+            <button type="button" on:click={() => recallDrone(toStringValue(drone.drone_id))}>RECALL</button>
+          </div>
+        {/each}
+      {/if}
+    </section>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .summary-card,
+  .stored-card,
+  .active-card,
+  .empty,
+  .feedback {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .summary-card {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .stored-row,
+  .active-row,
+  .active-meta,
+  .active-stats {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .active-row {
+    display: grid;
+    gap: 6px;
+  }
+
+  .section-title,
+  .summary-card span,
+  .stored-row span,
+  .active-stats,
+  .active-meta span,
+  .empty,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  button {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+</style>

--- a/gui-svelte/src/components/ops/OpsControlPanel.svelte
+++ b/gui-svelte/src/components/ops/OpsControlPanel.svelte
@@ -1,0 +1,349 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    POWER_CATEGORY_ORDER,
+    OPS_SYSTEM_PRIORITY_ORDER,
+    type PowerCategory,
+    ENGINEERING_SYSTEM_LABELS,
+    formatPercent,
+    formatDuration,
+    getFieldRepair,
+    getAutoOpsState,
+    getOpsProposals,
+    getOpsShip,
+    getOpsState,
+    getRepairTargets,
+    getRepairTeams,
+    getSystemPriority,
+    powerCategoryWeights,
+    toNumber,
+    toStringValue,
+    translatePowerCategoryWeights,
+  } from "./opsData.js";
+
+  let feedback = "";
+  let dirty = false;
+  let weights: Record<PowerCategory, number> = {
+    propulsion: 0.25,
+    weapons: 0.15,
+    sensors: 0.15,
+    comms: 0.05,
+    life_support: 0.05,
+  };
+
+  $: ship = getOpsShip($gameState);
+  $: ops = getOpsState(ship);
+  $: autoOps = getAutoOpsState(ship);
+  $: repairTeams = getRepairTeams(ship);
+  $: repairTargets = getRepairTargets(ship);
+  $: fieldRepair = getFieldRepair(ship);
+  $: proposals = getOpsProposals(ship);
+  $: cpuAssistTier = $tier === "cpu-assist";
+  $: manualTier = $tier === "manual";
+  $: autoOpsEnabled = Boolean(autoOps.enabled);
+  $: if (!dirty) weights = { ...powerCategoryWeights(ship) };
+
+  async function transmitPowerAllocation() {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("set_power_allocation", {
+        allocation: translatePowerCategoryWeights(weights),
+      });
+      dirty = false;
+      feedback = "Power allocation updated";
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Allocation update failed";
+    }
+  }
+
+  function adjustWeight(category: PowerCategory, value: number) {
+    dirty = true;
+    weights = { ...weights, [category]: Math.max(0, Math.min(1, value / 100)) };
+  }
+
+  async function dispatchRepair(subsystem: string, teamId = "") {
+    feedback = "";
+    try {
+      const params: Record<string, unknown> = { subsystem };
+      if (teamId) params.team = teamId;
+      await wsClient.sendShipCommand("dispatch_repair", params);
+      feedback = `Repair team dispatched to ${subsystem}`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Dispatch failed";
+    }
+  }
+
+  async function cancelRepair(subsystem: string) {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("cancel_repair", { subsystem });
+      feedback = `Repair cancelled for ${subsystem}`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Cancel failed";
+    }
+  }
+
+  async function setSystemPriority(subsystem: string, priority: number) {
+    try {
+      await wsClient.sendShipCommand("set_system_priority", { subsystem, priority });
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Priority update failed";
+    }
+  }
+
+  async function toggleAutoOps(enabled: boolean) {
+    try {
+      await wsClient.sendShipCommand(enabled ? "enable_auto_ops" : "disable_auto_ops", {});
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Auto-ops command failed";
+    }
+  }
+
+  async function approveProposal(proposalId: string) {
+    await wsClient.sendShipCommand("approve_ops", { proposal_id: proposalId });
+  }
+
+  async function denyProposal(proposalId: string) {
+    await wsClient.sendShipCommand("deny_ops", { proposal_id: proposalId });
+  }
+</script>
+
+<Panel title="Ops Control" domain="power" priority={cpuAssistTier ? "primary" : "secondary"} className="ops-control-panel">
+  <div class="shell">
+    <section class="auto-card">
+      <div class="row-head">
+        <span>Auto-Ops</span>
+        <strong>{autoOpsEnabled ? "ENABLED" : "DISABLED"}</strong>
+      </div>
+      <div class="toggle-row">
+        <button class:active={autoOpsEnabled} type="button" on:click={() => toggleAutoOps(true)}>ENABLE</button>
+        <button class:active={!autoOpsEnabled} type="button" on:click={() => toggleAutoOps(false)}>DISABLE</button>
+      </div>
+    </section>
+
+    {#if cpuAssistTier}
+      <section class="proposal-list">
+        {#if proposals.length === 0}
+          <div class="empty-card">No pending ops approvals.</div>
+        {:else}
+          {#each proposals as proposal}
+            <div class="proposal-card">
+              <div class="proposal-head">
+                <strong>{proposal.action.replaceAll("_", " ").toUpperCase()}</strong>
+                <span>{Math.round(proposal.confidence * 100)}%</span>
+              </div>
+              <div class="proposal-target">{proposal.target.toUpperCase()}</div>
+              <div class="proposal-reason">{proposal.reason}</div>
+              <div class="proposal-actions">
+                <button type="button" on:click={() => approveProposal(proposal.proposalId)}>APPROVE</button>
+                <button class="secondary" type="button" on:click={() => denyProposal(proposal.proposalId)}>DENY</button>
+              </div>
+            </div>
+          {/each}
+        {/if}
+      </section>
+    {:else}
+      <section class="power-card">
+        <div class="section-title">Power Allocation</div>
+        {#each POWER_CATEGORY_ORDER as category}
+          <div class="alloc-row">
+            <span>{category.replaceAll("_", " ").toUpperCase()}</span>
+            <input
+              type="range"
+              min="0"
+              max="100"
+              step="1"
+              value={Math.round((weights[category] ?? 0) * 100)}
+              on:input={(event) => adjustWeight(category, Number((event.currentTarget as HTMLInputElement).value))}
+              on:change={transmitPowerAllocation}
+            />
+            <strong>{formatPercent((weights[category] ?? 0) * 100)}</strong>
+          </div>
+        {/each}
+      </section>
+
+      <section class="teams-card">
+        <div class="section-title">Repair Teams</div>
+        {#each repairTeams as team}
+          <div class="team-row">
+            <strong>{toStringValue(team.team_id, "--")}</strong>
+            <span>{toStringValue(team.status, "idle").toUpperCase()}</span>
+            <span>{toStringValue(team.assigned_subsystem, "UNASSIGNED")}</span>
+            <span>{formatDuration(toNumber(team.transit_remaining, 0))}</span>
+          </div>
+        {/each}
+      </section>
+
+      <section class="dispatch-card">
+        <div class="section-title">Damage Dispatch</div>
+        {#if repairTargets.length === 0}
+          <div class="empty-card">No damaged systems awaiting repair.</div>
+        {:else}
+          {#each repairTargets as target}
+            <div class="target-card">
+              <div class="target-head">
+                <strong>{target.label.toUpperCase()}</strong>
+                <span>{formatPercent(target.damagePercent)}</span>
+              </div>
+              <div class="target-meta">
+                <span>{target.status.toUpperCase()}</span>
+                <span>{target.assignedTeam || "NO TEAM"}</span>
+              </div>
+              <div class="target-actions">
+                <button type="button" on:click={() => dispatchRepair(target.id)}>DISPATCH</button>
+                <button class="secondary" type="button" on:click={() => cancelRepair(target.id)}>CANCEL</button>
+              </div>
+            </div>
+          {/each}
+        {/if}
+      </section>
+
+      {#if manualTier}
+        <section class="priority-card">
+          <div class="section-title">System Priorities</div>
+          {#each OPS_SYSTEM_PRIORITY_ORDER as subsystem}
+            <div class="priority-row">
+              <span>{(ENGINEERING_SYSTEM_LABELS[subsystem] ?? subsystem).toUpperCase()}</span>
+              <input
+                type="range"
+                min="0"
+                max="10"
+                step="1"
+                value={getSystemPriority(ship, subsystem)}
+                on:change={(event) => setSystemPriority(subsystem, Number((event.currentTarget as HTMLInputElement).value))}
+              />
+              <strong>{getSystemPriority(ship, subsystem)}</strong>
+            </div>
+          {/each}
+        </section>
+      {/if}
+    {/if}
+
+    <section class="field-repair-card">
+      <div class="row-head">
+        <span>Spare Parts</span>
+        <strong>{formatPercent(toNumber(fieldRepair.spare_parts_percent, 0))}</strong>
+      </div>
+      <div class="track">
+        <div class="fill" style={`width:${toNumber(fieldRepair.spare_parts_percent, 0).toFixed(0)}%;`}></div>
+      </div>
+    </section>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .auto-card,
+  .power-card,
+  .teams-card,
+  .dispatch-card,
+  .priority-card,
+  .proposal-card,
+  .field-repair-card,
+  .empty-card {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .proposal-list {
+    display: grid;
+    gap: var(--space-sm);
+  }
+
+  .row-head,
+  .toggle-row,
+  .proposal-head,
+  .team-row,
+  .target-head,
+  .target-meta,
+  .priority-row,
+  .alloc-row,
+  .target-actions,
+  .proposal-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .alloc-row input,
+  .priority-row input {
+    flex: 1;
+  }
+
+  .section-title,
+  .row-head span,
+  .alloc-row span,
+  .team-row span,
+  .target-meta,
+  .proposal-target,
+  .proposal-reason,
+  .feedback,
+  .empty-card {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  button {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  button.active {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  button.secondary {
+    color: var(--text-secondary);
+  }
+
+  .track {
+    height: 10px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.35), var(--tier-accent));
+  }
+
+  .feedback {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    color: var(--status-info);
+    border: 1px solid rgba(68, 136, 255, 0.28);
+    background: rgba(68, 136, 255, 0.08);
+  }
+</style>

--- a/gui-svelte/src/components/ops/PowerProfileSelector.svelte
+++ b/gui-svelte/src/components/ops/PowerProfileSelector.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { asRecord, toStringValue } from "./opsData.js";
+
+  interface PowerProfileCard {
+    name: string;
+    description: string;
+  }
+
+  let profiles: PowerProfileCard[] = [];
+  let activeProfile = "";
+  let selectedProfile = "";
+  let feedback = "";
+  let pollHandle: number | null = null;
+
+  onMount(() => {
+    void refresh();
+    pollHandle = window.setInterval(() => void refresh(), 10000);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  async function refresh() {
+    try {
+      const response = await wsClient.sendShipCommand("get_power_profiles", {});
+      const record = asRecord(response);
+      const definitions = asRecord(record?.definitions) ?? {};
+      const source = Array.isArray(record?.profiles) ? record?.profiles : Object.keys(definitions);
+      activeProfile = toStringValue(record?.active_profile);
+      if (!selectedProfile) selectedProfile = activeProfile;
+      profiles = source.map((item) => {
+        const name = String(item);
+        const definition = asRecord(definitions[name]) ?? {};
+        return {
+          name,
+          description: toStringValue(definition.description, "Preset power routing profile"),
+        };
+      });
+    } catch {
+      // best effort
+    }
+  }
+
+  async function applyProfile(name: string) {
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("set_power_profile", { profile: name });
+      activeProfile = name;
+      selectedProfile = name;
+      feedback = `${name} applied`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Profile apply failed";
+    }
+  }
+</script>
+
+<Panel title="Power Profiles" domain="power" priority="secondary" className="power-profile-selector-panel">
+  <div class="shell">
+    {#if profiles.length === 0}
+      <div class="empty">No power profiles available.</div>
+    {:else}
+      {#each profiles as profile}
+        <button
+          type="button"
+          class:selected={profile.name === selectedProfile}
+          class:active={profile.name === activeProfile}
+          on:click={() => selectedProfile = profile.name}
+        >
+          <strong>{profile.name.toUpperCase()}</strong>
+          <span>{profile.description}</span>
+        </button>
+      {/each}
+      <button
+        class="apply"
+        type="button"
+        disabled={!selectedProfile || selectedProfile === activeProfile}
+        on:click={() => applyProfile(selectedProfile)}
+      >
+        APPLY PROFILE
+      </button>
+    {/if}
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  button,
+  .empty,
+  .feedback {
+    display: grid;
+    gap: 6px;
+    width: 100%;
+    text-align: left;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  button.selected {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+  }
+
+  button.active {
+    background: rgba(0, 255, 136, 0.08);
+    border-color: rgba(0, 255, 136, 0.35);
+  }
+
+  button.apply {
+    text-align: center;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  span,
+  .empty,
+  .feedback {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+</style>

--- a/gui-svelte/src/components/ops/ShipStatus.svelte
+++ b/gui-svelte/src/components/ops/ShipStatus.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import {
+    formatMass,
+    formatPercent,
+    formatSpeed,
+    getArmorIntegrity,
+    getArmorRows,
+    getHullPercent,
+    getOpsShip,
+    getReadiness,
+    readinessClass,
+    toNumber,
+  } from "./opsData.js";
+
+  $: ship = getOpsShip($gameState);
+  $: armorRows = getArmorRows(ship);
+  $: hullPercent = getHullPercent(ship);
+  $: armorPercent = getArmorIntegrity(ship);
+  $: readiness = getReadiness(ship);
+</script>
+
+<Panel title="Ship Status" domain="power" priority="primary" className="ship-status-panel">
+  <div class="stack">
+    <section class="hero-card">
+      <div class="hero-row">
+        <div>
+          <span class="label">Hull Integrity</span>
+          <strong>{formatPercent(hullPercent)}</strong>
+        </div>
+        <div>
+          <span class="label">Readiness</span>
+          <strong class={readinessClass(readiness.score)}>{readiness.label.toUpperCase()}</strong>
+        </div>
+      </div>
+      <div class="track">
+        <div class="fill {readinessClass(hullPercent)}" style={`width:${hullPercent.toFixed(0)}%;`}></div>
+      </div>
+    </section>
+
+    <section class="armor-grid">
+      {#each armorRows as row}
+        <div class="armor-card">
+          <div class="armor-head">
+            <span>{row.label}</span>
+            <strong class:critical={row.integrityPercent < 35}>{formatPercent(row.integrityPercent)}</strong>
+          </div>
+          <div class="track compact">
+            <div class="fill {readinessClass(row.integrityPercent)}" style={`width:${row.integrityPercent.toFixed(0)}%;`}></div>
+          </div>
+        </div>
+      {/each}
+    </section>
+
+    <section class="metrics">
+      <div><span>Armor Avg</span><strong>{formatPercent(armorPercent)}</strong></div>
+      <div><span>Mass</span><strong>{formatMass(toNumber(ship.mass))}</strong></div>
+      <div><span>Delta-V</span><strong>{formatSpeed(toNumber(ship.delta_v_remaining))}</strong></div>
+      <div><span>Crew</span><strong>{toNumber(ship.crew_complement, 0).toFixed(0)}</strong></div>
+    </section>
+  </div>
+</Panel>
+
+<style>
+  .stack {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .hero-card,
+  .armor-card {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent);
+  }
+
+  .hero-row,
+  .armor-head,
+  .metrics {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .armor-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .metrics {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .label,
+  .armor-head span,
+  .metrics span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  strong.nominal {
+    color: var(--status-nominal);
+  }
+
+  strong.warning {
+    color: var(--status-warning);
+  }
+
+  strong.critical {
+    color: var(--status-critical);
+  }
+
+  .track {
+    height: 12px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .track.compact {
+    height: 8px;
+  }
+
+  .fill {
+    height: 100%;
+  }
+
+  .fill.nominal {
+    background: rgba(0, 255, 136, 0.84);
+  }
+
+  .fill.warning {
+    background: rgba(255, 170, 0, 0.88);
+  }
+
+  .fill.critical {
+    background: rgba(255, 68, 68, 0.9);
+  }
+</style>

--- a/gui-svelte/src/components/ops/opsData.ts
+++ b/gui-svelte/src/components/ops/opsData.ts
@@ -1,0 +1,287 @@
+import type { JsonMap } from "../helm/helmData.js";
+import {
+  asRecord,
+  clamp,
+  extractShipState,
+  formatDistance,
+  formatDuration,
+  formatSpeed,
+  toNumber,
+  toStringValue,
+} from "../helm/helmData.js";
+import {
+  ENGINEERING_SYSTEM_LABELS,
+  POWER_CATEGORY_ORDER,
+  type PowerCategory,
+  getPowerCategoryWeights,
+  getSubsystemRows,
+  translateCategoryWeightsToBusAllocation,
+} from "../engineering/engineeringData.js";
+
+export interface ArmorSectionRow {
+  id: string;
+  label: string;
+  integrityPercent: number;
+  material: string;
+  stripped: boolean;
+}
+
+export interface OpsProposal {
+  proposalId: string;
+  action: string;
+  target: string;
+  reason: string;
+  confidence: number;
+}
+
+export interface CrewRow {
+  crewId: string;
+  clientId: string;
+  name: string;
+  station: string;
+  injury: string;
+  health: number;
+  fatigue: number;
+  stress: number;
+  skills: Record<string, number>;
+}
+
+export const OPS_SYSTEM_PRIORITY_ORDER = [
+  "life_support",
+  "reactor",
+  "sensors",
+  "rcs",
+  "propulsion",
+  "targeting",
+  "weapons",
+  "radiators",
+] as const;
+
+export function getOpsShip(gameState: JsonMap | null | undefined): JsonMap {
+  return extractShipState(gameState);
+}
+
+export function getOpsState(ship: JsonMap): JsonMap {
+  return asRecord(ship.ops) ?? {};
+}
+
+export function getAutoOpsState(ship: JsonMap): JsonMap {
+  return asRecord(ship.auto_ops) ?? {};
+}
+
+export function getCrewFatigueState(ship: JsonMap): JsonMap {
+  return asRecord(ship.crew_fatigue) ?? {};
+}
+
+export function getCrewProgressionState(ship: JsonMap): JsonMap {
+  return asRecord(ship.crew_progression) ?? {};
+}
+
+export function getBoardingTelemetry(ship: JsonMap): JsonMap {
+  return asRecord(ship.boarding) ?? {};
+}
+
+export function getDroneBayTelemetry(ship: JsonMap): JsonMap {
+  return asRecord(ship.drone_bay) ?? {};
+}
+
+export function getArmorRows(ship: JsonMap): ArmorSectionRow[] {
+  const sections = asRecord(asRecord(ship.armor_status)?.sections) ?? asRecord(ship.armor) ?? {};
+  const order = ["fore", "aft", "port", "starboard", "dorsal", "ventral"];
+  const labels: Record<string, string> = {
+    fore: "Fore",
+    aft: "Aft",
+    port: "Port",
+    starboard: "Starboard",
+    dorsal: "Dorsal",
+    ventral: "Ventral",
+  };
+
+  return order.map((id) => {
+    const row = asRecord(sections[id]) ?? {};
+    return {
+      id,
+      label: labels[id] ?? id,
+      integrityPercent: clamp(
+        toNumber(row.integrity_percent, toNumber(row.percent, toNumber(row.integrity, 100))),
+        0,
+        100,
+      ),
+      material: toStringValue(row.material, "unknown"),
+      stripped: Boolean(row.stripped),
+    };
+  });
+}
+
+export function getHullPercent(ship: JsonMap): number {
+  return clamp(toNumber(ship.hull_percent, 100), 0, 100);
+}
+
+export function getArmorIntegrity(ship: JsonMap): number {
+  return clamp(toNumber(asRecord(ship.armor_status)?.overall_integrity_percent, 100), 0, 100);
+}
+
+export function getReadiness(ship: JsonMap): { score: number; label: string } {
+  const hull = getHullPercent(ship);
+  const armor = getArmorIntegrity(ship);
+  const fatigue = getCrewFatigueState(ship);
+  const crewPerf = clamp(toNumber(fatigue.performance, 1) * 100, 0, 100);
+  const subsystemAverage = (() => {
+    const rows = getSubsystemRows(ship);
+    if (!rows.length) return 100;
+    return rows.reduce((sum, row) => sum + row.healthPercent, 0) / rows.length;
+  })();
+
+  const score = (hull + armor + crewPerf + subsystemAverage) / 4;
+  let label = "Mission Ready";
+  if (score < 35) label = "Critical";
+  else if (score < 60) label = "Compromised";
+  else if (score < 82) label = "Degraded";
+  return { score, label };
+}
+
+export function getRepairTeams(ship: JsonMap): JsonMap[] {
+  const rawTeams = getOpsState(ship).repair_teams;
+  const source = Array.isArray(rawTeams) ? (rawTeams as unknown[]) : [];
+  return source.map((item: unknown) => asRecord(item)).filter((item): item is JsonMap => Boolean(item));
+}
+
+export function getFieldRepair(ship: JsonMap): JsonMap {
+  return asRecord(getOpsState(ship).field_repair) ?? {};
+}
+
+export function getRepairTargets(ship: JsonMap): Array<{
+  id: string;
+  label: string;
+  healthPercent: number;
+  damagePercent: number;
+  assignedTeam: string;
+  status: string;
+}> {
+  const teamAssignments = new Map(
+    getRepairTeams(ship)
+      .filter((team) => toStringValue(team.assigned_subsystem))
+      .map((team) => [toStringValue(team.assigned_subsystem), toStringValue(team.team_id)]),
+  );
+
+  return getSubsystemRows(ship)
+    .filter((row) => row.damagePercent > 0.01)
+    .map((row) => ({
+      id: row.id,
+      label: row.label,
+      healthPercent: row.healthPercent,
+      damagePercent: row.damagePercent,
+      assignedTeam: teamAssignments.get(row.id) ?? "",
+      status: row.status,
+    }))
+    .sort((a, b) => b.damagePercent - a.damagePercent);
+}
+
+export function getOpsProposals(ship: JsonMap): OpsProposal[] {
+  const rawProposals = getAutoOpsState(ship).proposals;
+  const source = Array.isArray(rawProposals) ? (rawProposals as unknown[]) : [];
+  return source
+    .map((item: unknown) => asRecord(item))
+    .filter((item): item is JsonMap => Boolean(item))
+    .map((item: JsonMap) => ({
+      proposalId: toStringValue(item.proposal_id),
+      action: toStringValue(item.action, "proposal"),
+      target: toStringValue(item.target, "ship"),
+      reason: toStringValue(item.reason, "Awaiting approval"),
+      confidence: clamp(toNumber(item.confidence, 0), 0, 1),
+    }));
+}
+
+export function getCrewRows(ship: JsonMap): CrewRow[] {
+  const roster = Array.isArray(asRecord(getCrewProgressionState(ship))?.roster)
+    ? (asRecord(getCrewProgressionState(ship))?.roster as unknown[])
+    : [];
+
+  return roster
+    .map((item) => asRecord(item))
+    .filter((item): item is JsonMap => Boolean(item))
+    .map((item) => ({
+      crewId: toStringValue(item.crew_id),
+      clientId: toStringValue(item.client_id),
+      name: toStringValue(item.name, "Crew"),
+      station: toStringValue(item.station_assignment, "UNASSIGNED"),
+      injury: toStringValue(item.injury_state, "healthy"),
+      health: clamp(toNumber(item.health, 1), 0, 1),
+      fatigue: clamp(toNumber(item.fatigue, 0), 0, 1),
+      stress: clamp(toNumber(item.stress, 0), 0, 1),
+      skills: (asRecord(item.skills) as Record<string, number> | null) ?? {},
+    }));
+}
+
+export function countRestingCrew(ship: JsonMap): number {
+  const fatigue = getCrewFatigueState(ship);
+  if (!Boolean(fatigue.rest_ordered)) return 0;
+  const rows = getCrewRows(ship);
+  return rows.length;
+}
+
+export function getSystemPriority(ship: JsonMap, subsystem: string): number {
+  return toNumber(asRecord(getOpsState(ship).system_priorities)?.[subsystem], 0);
+}
+
+export function skillShort(level: number): string {
+  const map: Record<number, string> = {
+    1: "NOV",
+    2: "TRN",
+    3: "CMP",
+    4: "SKL",
+    5: "EXP",
+    6: "MST",
+  };
+  return map[level] ?? `${level}`;
+}
+
+export function skillLong(level: number): string {
+  const map: Record<number, string> = {
+    1: "NOVICE",
+    2: "TRAINEE",
+    3: "COMPETENT",
+    4: "SKILLED",
+    5: "EXPERT",
+    6: "MASTER",
+  };
+  return map[level] ?? `${level}`;
+}
+
+export function powerCategoryWeights(ship: JsonMap): Record<PowerCategory, number> {
+  return getPowerCategoryWeights(ship);
+}
+
+export function translatePowerCategoryWeights(weights: Record<PowerCategory, number>): Record<"primary" | "secondary" | "tertiary", number> {
+  return translateCategoryWeightsToBusAllocation(weights);
+}
+
+export function readinessClass(score: number): "critical" | "warning" | "nominal" {
+  if (score < 35) return "critical";
+  if (score < 60) return "warning";
+  return "nominal";
+}
+
+export function formatMass(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "--";
+  if (value >= 1000) return `${(value / 1000).toFixed(1)} kt`;
+  return `${value.toFixed(0)} t`;
+}
+
+export function formatPercent(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "--";
+  return `${Math.round(value)}%`;
+}
+
+export {
+  ENGINEERING_SYSTEM_LABELS,
+  POWER_CATEGORY_ORDER,
+  type PowerCategory,
+  asRecord,
+  clamp,
+  formatDistance,
+  formatDuration,
+  formatSpeed,
+  toNumber,
+  toStringValue,
+};

--- a/gui-svelte/src/components/science/ScienceAnalysisPanel.svelte
+++ b/gui-svelte/src/components/science/ScienceAnalysisPanel.svelte
@@ -1,0 +1,268 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { selectedScienceContactId } from "../../lib/stores/scienceUi.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    KNOWN_SHIP_CLASSES,
+    asRecord,
+    estimateMassFromContact,
+    findScienceContact,
+    formatDistance,
+    formatSquareMeters,
+    formatWatts,
+    getScienceContacts,
+    getScienceShip,
+    inferredThrustProfile,
+    recommendClassFromMass,
+    spectralBandsForContact,
+    toStringValue,
+  } from "./scienceData.js";
+
+  let analysisResult: Record<string, unknown> = {};
+  let spectralResult: Record<string, unknown> = {};
+  let feedback = "";
+  let massEstimateInput = "";
+  let selectedClass = "Unknown";
+  let lastContactId = "";
+
+  $: ship = getScienceShip($gameState);
+  $: contacts = getScienceContacts(ship);
+  $: if (!$selectedScienceContactId && contacts.length) selectedScienceContactId.set(contacts[0].id);
+  $: contact = findScienceContact(ship, $selectedScienceContactId);
+  $: if (contact && contact.id !== lastContactId) {
+    lastContactId = contact.id;
+    massEstimateInput = String(Math.round(estimateMassFromContact(contact)));
+    selectedClass = recommendClassFromMass(estimateMassFromContact(contact));
+    analysisResult = {};
+    spectralResult = {};
+  }
+  $: bands = spectralBandsForContact(contact, asRecord(spectralResult));
+  $: thrustProfile = inferredThrustProfile(contact, asRecord(spectralResult));
+  $: analysisRecord = asRecord(analysisResult) ?? {};
+  $: emissions = asRecord(analysisRecord.emissions) ?? {};
+  $: contactData = asRecord(analysisRecord.contact_data) ?? {};
+
+  async function analyze() {
+    if (!contact) return;
+    feedback = "";
+    try {
+      analysisResult = (await wsClient.sendShipCommand("analyze_contact", { contact_id: contact.id })) as Record<string, unknown>;
+      feedback = `Deep analysis complete for ${contact.id}`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Analysis failed";
+    }
+  }
+
+  async function spectral() {
+    if (!contact) return;
+    feedback = "";
+    try {
+      spectralResult = (await wsClient.sendShipCommand("spectral_analysis", { contact_id: contact.id })) as Record<string, unknown>;
+      feedback = `Spectral signature resolved for ${contact.id}`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Spectral scan failed";
+    }
+  }
+
+  async function classify() {
+    if (!contact) return;
+    await analyze();
+    feedback = `${contact.id} classified as ${selectedClass.toUpperCase()} at ${massEstimateInput || "--"} kg`;
+  }
+</script>
+
+<Panel title="Science Analysis" domain="sensor" priority="primary" className="science-analysis-panel">
+  <div class="shell">
+    <label class="field">
+      <span>Contact</span>
+      <select bind:value={$selectedScienceContactId}>
+        <option value="">Select contact</option>
+        {#each contacts as row}
+          <option value={row.id}>{row.id} · {row.classification}</option>
+        {/each}
+      </select>
+    </label>
+
+    <section class="band-card">
+      <div class="head">
+        <span>Spectral Signature</span>
+        <strong>{contact ? contact.id : "NO TRACK"}</strong>
+      </div>
+      <div class="bands">
+        {#each bands as band}
+          <div class="band-row">
+            <span>{band.label}</span>
+            <div class="track"><div class="fill" style={`width:${band.value.toFixed(1)}%;`}></div></div>
+            <strong>{Math.round(band.value)}%</strong>
+          </div>
+        {/each}
+      </div>
+    </section>
+
+    <section class="thrust-card">
+      <div class="head">
+        <span>Thrust Profile</span>
+        <strong>{thrustProfile.label.toUpperCase()}</strong>
+      </div>
+      <div class="meta">
+        <span>{thrustProfile.burnState.toUpperCase()}</span>
+        <span>{thrustProfile.thrustKn.toFixed(1)} kN</span>
+        <span>{contact ? formatDistance(contact.distance) : "--"}</span>
+      </div>
+    </section>
+
+    <div class="button-row">
+      <button type="button" disabled={!contact} on:click={analyze}>ANALYZE CONTACT</button>
+      <button type="button" disabled={!contact} on:click={spectral}>RUN SPECTRAL</button>
+    </div>
+
+    <section class="classification-card">
+      <div class="head">
+        <span>Classification</span>
+        <strong>{selectedClass.toUpperCase()}</strong>
+      </div>
+      <div class="grid">
+        <label class="field">
+          <span>Mass Estimate (kg)</span>
+          <input bind:value={massEstimateInput} inputmode="numeric" />
+        </label>
+        <label class="field">
+          <span>Ship Class</span>
+          <select bind:value={selectedClass}>
+            {#each KNOWN_SHIP_CLASSES as shipClass}
+              <option value={shipClass}>{shipClass.toUpperCase()}</option>
+            {/each}
+          </select>
+        </label>
+      </div>
+      <button type="button" disabled={!contact} on:click={classify}>CLASSIFY CONTACT</button>
+    </section>
+
+    <section class="readout-card">
+      <div class="head">
+        <span>Readout</span>
+        <strong>{toStringValue(analysisRecord.classification, contact?.classification ?? "--").toUpperCase()}</strong>
+      </div>
+      <div class="readout-grid">
+        <span>IR</span>
+        <strong>{formatWatts(Number(emissions.ir_watts ?? contact?.irWatts ?? 0))}</strong>
+        <span>RCS</span>
+        <strong>{formatSquareMeters(Number(emissions.rcs_m2 ?? contact?.rcsSquareMeters ?? 0))}</strong>
+        <span>Confidence</span>
+        <strong>{Math.round(Number(contactData.confidence ?? contact?.confidence ?? 0) * 100)}%</strong>
+        <span>Vector</span>
+        <strong>{toStringValue(analysisRecord.detection_method, contact?.detectionMethod ?? "--").toUpperCase()}</strong>
+      </div>
+    </section>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .band-card,
+  .thrust-card,
+  .classification-card,
+  .readout-card,
+  .feedback {
+    display: grid;
+    gap: 10px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .head,
+  .band-row,
+  .button-row,
+  .meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  .field {
+    display: grid;
+    gap: 6px;
+  }
+
+  .field span,
+  .meta,
+  .feedback,
+  .band-row span,
+  .readout-grid span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .grid,
+  .bands {
+    display: grid;
+    gap: 8px;
+  }
+
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  select,
+  input,
+  button {
+    width: 100%;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  .track {
+    flex: 1;
+    height: 8px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.22), var(--tier-accent));
+  }
+
+  .readout-grid {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 6px 12px;
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+
+  @media (max-width: 640px) {
+    .grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/gui-svelte/src/components/science/SensorAnalysisManual.svelte
+++ b/gui-svelte/src/components/science/SensorAnalysisManual.svelte
@@ -1,0 +1,223 @@
+<script lang="ts">
+  import { selectedScienceContactId } from "../../lib/stores/scienceUi.js";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    confidencePercent,
+    currentNoiseFloor,
+    findScienceContact,
+    formatDistance,
+    formatSquareMeters,
+    formatVectorShort,
+    formatWatts,
+    getScienceContacts,
+    getScienceShip,
+    probeRows,
+  } from "./scienceData.js";
+
+  interface HistoryRow {
+    timestamp: number;
+    contactId: string;
+    classification: string;
+    confidence: number;
+  }
+
+  let history: HistoryRow[] = [];
+  let lastHistoryKey = "";
+  let feedback = "";
+
+  $: ship = getScienceShip($gameState);
+  $: contacts = getScienceContacts(ship);
+  $: if (!$selectedScienceContactId && contacts.length) selectedScienceContactId.set(contacts[0].id);
+  $: contact = findScienceContact(ship, $selectedScienceContactId);
+  $: probes = probeRows(ship);
+  $: noiseFloor = currentNoiseFloor(ship);
+
+  $: if (contact) {
+    const key = `${contact.id}:${contact.classification}:${Math.round(contact.confidence * 100)}`;
+    if (key !== lastHistoryKey) {
+      lastHistoryKey = key;
+      history = [
+        {
+          timestamp: Date.now() / 1000,
+          contactId: contact.id,
+          classification: contact.classification,
+          confidence: confidencePercent(contact),
+        },
+        ...history,
+      ].slice(0, 8);
+    }
+  }
+
+  async function deployProbe() {
+    if (!contact) return;
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("deploy_probe", {
+        bearing: { azimuth: contact.bearing, elevation: 0 },
+      });
+      feedback = `Probe deployed toward ${contact.id}`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Probe deploy failed";
+    }
+  }
+
+  async function recallProbe() {
+    const activeProbe = probes.find((probe) => probe.active);
+    if (!activeProbe) return;
+    feedback = "";
+    try {
+      await wsClient.sendShipCommand("recall_probe", { probe_id: activeProbe.id });
+      feedback = `Probe ${String(activeProbe.id)} recalled`;
+    } catch (error) {
+      feedback = error instanceof Error ? error.message : "Probe recall failed";
+    }
+  }
+</script>
+
+<Panel title="Manual Sensor Analysis" domain="sensor" priority="secondary" className="sensor-analysis-manual">
+  <div class="shell">
+    <label class="field">
+      <span>Contact</span>
+      <select bind:value={$selectedScienceContactId}>
+        <option value="">Select contact</option>
+        {#each contacts as row}
+          <option value={row.id}>{row.id} · {row.classification}</option>
+        {/each}
+      </select>
+    </label>
+
+    <section class="data-card">
+      <div class="data-grid">
+        <span>IR Signature</span>
+        <strong>{formatWatts(contact?.irWatts ?? null)}</strong>
+        <span>Radar Cross Section</span>
+        <strong>{formatSquareMeters(contact?.rcsSquareMeters ?? null)}</strong>
+        <span>Noise Floor</span>
+        <strong>{formatWatts(noiseFloor)}</strong>
+        <span>Detection Confidence</span>
+        <strong>{Math.round(confidencePercent(contact))}%</strong>
+        <span>Range</span>
+        <strong>{formatDistance(contact?.distance ?? null)}</strong>
+        <span>Velocity Vector</span>
+        <strong>{contact ? formatVectorShort(contact.velocity) : "--"}</strong>
+      </div>
+    </section>
+
+    <section class="history-card">
+      <div class="head">
+        <span>Classification History</span>
+        <strong>{history.length}</strong>
+      </div>
+      {#if history.length === 0}
+        <div class="empty">No classification history.</div>
+      {:else}
+        <div class="history-table">
+          {#each history as row}
+            <div>{new Date(row.timestamp * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</div>
+            <div>{row.contactId}</div>
+            <div>{row.classification}</div>
+            <div>{Math.round(row.confidence)}%</div>
+          {/each}
+        </div>
+      {/if}
+    </section>
+
+    <section class="probe-card">
+      <div class="head">
+        <span>Probe Control</span>
+        <strong>{probes.length} active</strong>
+      </div>
+      <div class="button-row">
+        <button type="button" disabled={!contact} on:click={deployProbe}>DEPLOY PROBE</button>
+        <button type="button" disabled={!probes.find((probe) => probe.active)} on:click={recallProbe}>RECALL PROBE</button>
+      </div>
+    </section>
+
+    {#if feedback}
+      <div class="feedback">{feedback}</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .field,
+  .data-card,
+  .history-card,
+  .probe-card,
+  .feedback {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .field {
+    padding: 0;
+    border: none;
+    background: none;
+  }
+
+  .head,
+  .button-row {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .field span,
+  .head span,
+  .empty,
+  .feedback,
+  .history-table {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  select,
+  button {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  .data-grid,
+  .history-table {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 6px 12px;
+  }
+
+  .history-table {
+    grid-template-columns: 70px 1fr 1fr 56px;
+  }
+
+  .button-row button {
+    flex: 1;
+  }
+
+  .feedback {
+    color: var(--status-info);
+  }
+</style>

--- a/gui-svelte/src/components/science/scienceData.ts
+++ b/gui-svelte/src/components/science/scienceData.ts
@@ -1,0 +1,188 @@
+import type { JsonMap, Vec3 } from "../helm/helmData.js";
+import {
+  asRecord,
+  clamp,
+  extractShipState,
+  formatDistance,
+  formatSpeed,
+  magnitude,
+  toNumber,
+  toStringValue,
+  toVec3,
+} from "../helm/helmData.js";
+import { getTacticalContacts, type TacticalContact } from "../tactical/tacticalData.js";
+
+export interface ScienceContact extends TacticalContact {
+  signalSignature: number;
+  irWatts: number;
+  rcsSquareMeters: number;
+  lastUpdate: number;
+  detectionMethod: string;
+}
+
+export interface SpectralBand {
+  id: string;
+  label: string;
+  value: number;
+}
+
+export const KNOWN_SHIP_CLASSES = [
+  "Unknown",
+  "Corvette",
+  "Frigate",
+  "Destroyer",
+  "Cruiser",
+  "Carrier",
+  "Freighter",
+  "Transport",
+  "Gunboat",
+  "Station",
+] as const;
+
+function seeded01(seedText: string): number {
+  let hash = 0;
+  for (let i = 0; i < seedText.length; i += 1) {
+    hash = ((hash << 5) - hash + seedText.charCodeAt(i)) | 0;
+  }
+  return (Math.abs(hash) % 10_000) / 10_000;
+}
+
+export function getScienceShip(gameState: JsonMap | null | undefined): JsonMap {
+  return extractShipState(gameState);
+}
+
+export function getScienceState(ship: JsonMap): JsonMap {
+  return asRecord(ship.science) ?? {};
+}
+
+export function getScienceContacts(ship: JsonMap): ScienceContact[] {
+  const tactical = getTacticalContacts(ship);
+  const rawSensors = asRecord(ship.sensors) ?? {};
+  const rawContacts = Array.isArray(rawSensors.contacts) ? (rawSensors.contacts as unknown[]) : [];
+  const byId = new Map<string, JsonMap>();
+
+  rawContacts
+    .map((item) => asRecord(item))
+    .filter((item): item is JsonMap => Boolean(item))
+    .forEach((item) => {
+      byId.set(toStringValue(item.id), item);
+    });
+
+  return tactical.map((contact) => {
+    const raw = byId.get(contact.id) ?? {};
+    const signature = toNumber(raw.signature, contact.signalStrength || seeded01(contact.id) * 1_000_000);
+    const irWatts = signature > 0 ? signature : (0.25 + seeded01(`${contact.id}:ir`)) * 1_500_000;
+    const rcsSquareMeters = Math.max(1, toNumber(raw.rcs_m2, (0.15 + seeded01(`${contact.id}:rcs`)) * 220));
+
+    return {
+      ...contact,
+      signalSignature: signature,
+      irWatts,
+      rcsSquareMeters,
+      lastUpdate: toNumber(raw.last_update, 0),
+      detectionMethod: toStringValue(raw.detection_method, contact.detectionMethod),
+    };
+  });
+}
+
+export function findScienceContact(ship: JsonMap, contactId: string): ScienceContact | null {
+  return getScienceContacts(ship).find((contact) => contact.id === contactId) ?? null;
+}
+
+export function spectralBandsForContact(contact: ScienceContact | null, spectralResult: JsonMap | null = null): SpectralBand[] {
+  if (!contact) {
+    return [
+      { id: "infrared", label: "Infrared", value: 0 },
+      { id: "radar", label: "Radar", value: 0 },
+      { id: "plume", label: "Plume", value: 0 },
+      { id: "noise", label: "Noise", value: 0 },
+    ];
+  }
+
+  const spectralData = asRecord(spectralResult?.spectral_data) ?? {};
+  const ir = asRecord(spectralData.ir_signature) ?? {};
+  const rcs = asRecord(spectralData.rcs_data) ?? {};
+
+  const totalIr = toNumber(ir.total_ir, contact.irWatts);
+  const plume = toNumber(ir.plume_ir, totalIr * 0.45);
+  const radar = toNumber(rcs.effective_rcs, contact.rcsSquareMeters);
+  const noise = clamp((1 - contact.confidence) * 100, 3, 96);
+
+  const maxValue = Math.max(totalIr, plume, radar * 1000, noise, 1);
+  return [
+    { id: "infrared", label: "Infrared", value: clamp((totalIr / maxValue) * 100, 0, 100) },
+    { id: "radar", label: "Radar", value: clamp(((radar * 1000) / maxValue) * 100, 0, 100) },
+    { id: "plume", label: "Plume", value: clamp((plume / maxValue) * 100, 0, 100) },
+    { id: "noise", label: "Noise", value: noise },
+  ];
+}
+
+export function inferredThrustProfile(contact: ScienceContact | null, spectralResult: JsonMap | null = null): { label: string; thrustKn: number; burnState: string } {
+  if (!contact) return { label: "--", thrustKn: 0, burnState: "unknown" };
+
+  const spectralData = asRecord(spectralResult?.spectral_data) ?? {};
+  const drive = asRecord(spectralData.drive_inference) ?? {};
+  const label = toStringValue(drive.drive_type, contact.speed > 250 ? "epstein-like" : "ion-like");
+  const burnState = toStringValue(drive.burn_state, contact.speed > 180 ? "full" : "partial");
+  const thrustKn = toNumber(drive.estimated_thrust_kn, Math.max(8, contact.speed * 0.12));
+  return { label, thrustKn, burnState };
+}
+
+export function estimateMassFromContact(contact: ScienceContact | null): number {
+  if (!contact) return 0;
+  const accel = 2 + seeded01(`${contact.id}:accel`) * 32;
+  const thrust = Math.max(20_000, contact.irWatts * 0.08);
+  return Math.round(thrust / accel);
+}
+
+export function recommendClassFromMass(massKg: number): string {
+  if (massKg <= 10_000) return "Corvette";
+  if (massKg <= 45_000) return "Frigate";
+  if (massKg <= 120_000) return "Destroyer";
+  if (massKg <= 300_000) return "Cruiser";
+  return "Carrier";
+}
+
+export function probeRows(ship: JsonMap): JsonMap[] {
+  const sensors = asRecord(ship.sensors) ?? {};
+  const probes = Array.isArray(sensors.probes) ? sensors.probes : [];
+  return probes.map((item) => asRecord(item)).filter((item): item is JsonMap => Boolean(item));
+}
+
+export function currentNoiseFloor(ship: JsonMap): number {
+  const sensors = asRecord(ship.sensors) ?? {};
+  const ownEmissions = asRecord(sensors.own_emissions) ?? {};
+  return toNumber(sensors.noise_floor, Math.max(0.00000001, toNumber(ownEmissions.ir_signature, 0.0001) * 0.000001));
+}
+
+export function confidencePercent(contact: ScienceContact | null): number {
+  return contact ? clamp(contact.confidence * 100, 0, 100) : 0;
+}
+
+export function formatWatts(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "--";
+  if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(2)} MW`;
+  if (Math.abs(value) >= 1000) return `${(value / 1000).toFixed(1)} kW`;
+  return `${value.toFixed(1)} W`;
+}
+
+export function formatSquareMeters(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "--";
+  return `${value.toFixed(value >= 100 ? 0 : 1)} m²`;
+}
+
+export function formatVectorShort(vec: Vec3): string {
+  return `${vec.x.toFixed(0)}, ${vec.y.toFixed(0)}, ${vec.z.toFixed(0)}`;
+}
+
+export function pseudoAcceleration(contact: ScienceContact | null): number {
+  if (!contact) return 0;
+  return 2 + seeded01(`${contact.id}:acc`) * 30;
+}
+
+export function pseudoTargetMass(contact: ScienceContact | null): number {
+  if (!contact) return 80_000;
+  return Math.max(4_000, estimateMassFromContact(contact));
+}
+
+export { asRecord, formatDistance, formatSpeed, magnitude, toNumber, toStringValue, toVec3 };

--- a/gui-svelte/src/components/shared/EventLog.svelte
+++ b/gui-svelte/src/components/shared/EventLog.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { asRecord, toStringValue } from "../helm/helmData.js";
+
+  export let filter: string[] = [];
+  export let title = "Event Log";
+  export let priority: "primary" | "secondary" | "tertiary" = "secondary";
+  export let domain: "nav" | "sensor" | "weapons" | "power" | "comms" | "helm" | "" = "";
+
+  interface EventEntry {
+    type: string;
+    timestamp: number;
+    simTime: number;
+    shipId: string;
+    message: string;
+  }
+
+  let entries: EventEntry[] = [];
+  let pollHandle: number | null = null;
+
+  onMount(() => {
+    void refresh();
+    pollHandle = window.setInterval(() => void refresh(), 1200);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  function matches(type: string): boolean {
+    if (filter.length === 0) return true;
+    const lower = type.toLowerCase();
+    return filter.some((needle) => lower.includes(needle.toLowerCase()));
+  }
+
+  function formatEntry(raw: unknown): EventEntry | null {
+    const event = asRecord(raw);
+    if (!event) return null;
+    const payload = asRecord(event.data) ?? {};
+    const type = toStringValue(event.type, "event");
+    if (!matches(type)) return null;
+
+    return {
+      type,
+      timestamp: typeof event.timestamp === "number" ? event.timestamp : Date.now() / 1000,
+      simTime: typeof event.t === "number" ? event.t : 0,
+      shipId: toStringValue(event.ship_id),
+      message:
+        toStringValue(payload.message)
+        || toStringValue(payload.status)
+        || [payload.subsystem, payload.system, payload.target, payload.reactor].filter(Boolean).join(" ")
+        || type.replaceAll("_", " "),
+    };
+  }
+
+  async function refresh() {
+    try {
+      const response = await wsClient.send("get_events", { limit: 160 });
+      const record = asRecord(response);
+      const source = Array.isArray(record?.events) ? record.events : [];
+      entries = source
+        .map(formatEntry)
+        .filter((entry): entry is EventEntry => Boolean(entry))
+        .slice(-120)
+        .reverse();
+    } catch {
+      // best effort polling
+    }
+  }
+
+  function clock(ts: number): string {
+    return new Date(ts * 1000).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  }
+</script>
+
+<Panel {title} {priority} {domain} className="shared-event-log-panel">
+  <div class="shell">
+    {#if entries.length === 0}
+      <div class="empty">No matching events.</div>
+    {:else}
+      {#each entries as entry}
+        <div class="entry">
+          <div class="meta">
+            <span class="time">{clock(entry.timestamp)}</span>
+            <span class="type">{entry.type.replaceAll("_", " ").toUpperCase()}</span>
+          </div>
+          <div class="message">{entry.message}</div>
+        </div>
+      {/each}
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-xs);
+    padding: var(--space-sm);
+    max-height: 100%;
+  }
+
+  .entry {
+    display: grid;
+    gap: 4px;
+    padding: 8px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .meta {
+    display: flex;
+    gap: var(--space-sm);
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .time,
+  .type,
+  .empty {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  .time,
+  .type {
+    font-family: var(--font-mono);
+  }
+
+  .message {
+    color: var(--text-primary);
+    font-size: 0.8rem;
+  }
+</style>

--- a/gui-svelte/src/components/tactical/CombatLog.svelte
+++ b/gui-svelte/src/components/tactical/CombatLog.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+
+  type Filter = "all" | "railgun" | "torpedo" | "missile" | "pdc";
+
+  let filter: Filter = "all";
+  let entries: Array<Record<string, unknown>> = [];
+  let latestId = 0;
+  let pollHandle: number | null = null;
+
+  onMount(() => {
+    void poll();
+    pollHandle = window.setInterval(() => void poll(), 900);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  async function poll() {
+    try {
+      const params: Record<string, unknown> = { since_id: latestId, limit: 50 };
+      if (filter !== "all") params.weapon = filter;
+      const response = await wsClient.send("get_combat_log", params) as { entries?: Array<Record<string, unknown>>; latest_id?: number };
+      if (Array.isArray(response.entries) && response.entries.length > 0) {
+        entries = [...entries, ...response.entries].slice(-200);
+      }
+      latestId = response.latest_id ?? latestId;
+    } catch {
+      // polling best-effort
+    }
+  }
+
+  function headline(entry: Record<string, unknown>): string {
+    return String(entry.summary ?? entry.outcome ?? entry.event_type ?? entry.weapon ?? "event");
+  }
+
+  function detail(entry: Record<string, unknown>): string {
+    return [entry.cause, entry.effect, entry.outcome].filter(Boolean).join(" -> ") || String(entry.description ?? "");
+  }
+</script>
+
+<Panel title="Combat Log" domain="weapons" priority="secondary" className="combat-log-panel">
+  <div class="shell">
+    <div class="filters">
+      {#each ["all", "railgun", "torpedo", "missile", "pdc"] as item}
+        <button class:selected={filter === item} type="button" on:click={() => { filter = item as Filter; entries = []; latestId = 0; void poll(); }}>
+          {item.toUpperCase()}
+        </button>
+      {/each}
+    </div>
+
+    <div class="entry-list">
+      {#if entries.length === 0}
+        <div class="empty">No combat events yet.</div>
+      {:else}
+        {#each [...entries].reverse() as entry}
+          <div class="entry">
+            <strong>{headline(entry)}</strong>
+            <span>{detail(entry)}</span>
+          </div>
+        {/each}
+      {/if}
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell,
+  .entry-list {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .filters {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  .filters button.selected {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  .entry {
+    display: grid;
+    gap: 4px;
+    padding: 8px;
+    border-radius: var(--radius-sm);
+    border-left: 3px solid rgba(var(--tier-accent-rgb), 0.6);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .entry span,
+  .empty {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  strong {
+    font-family: var(--font-mono);
+  }
+</style>

--- a/gui-svelte/src/components/tactical/EccmControlPanel.svelte
+++ b/gui-svelte/src/components/tactical/EccmControlPanel.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { extractShipState, getECCMState, toStringValue } from "./tacticalData.js";
+
+  const commands = [
+    { label: "OFF", command: "eccm_off", active: (mode: string, multispectral: boolean) => mode === "off" && !multispectral },
+    { label: "FREQ HOP", command: "eccm_frequency_hop", active: (mode: string) => mode === "frequency_hop" },
+    { label: "BURN THROUGH", command: "eccm_burn_through", active: (mode: string) => mode === "burn_through" },
+    { label: "MULTISPECTRAL", command: "eccm_multispectral", active: (_mode: string, multispectral: boolean) => multispectral },
+  ];
+
+  $: ship = extractShipState($gameState);
+  $: eccm = getECCMState(ship);
+  $: mode = toStringValue(eccm.mode, "off");
+  $: multispectral = Boolean(eccm.multispectral_active);
+
+  async function send(command: string) {
+    await wsClient.sendShipCommand(command, {});
+  }
+</script>
+
+<Panel title="ECCM Control" domain="sensor" priority={mode !== "off" || multispectral ? "primary" : "secondary"} className="eccm-control-panel">
+  <div class="shell">
+    <div class="mode-grid">
+      {#each commands as item}
+        <button class:selected={item.active(mode, multispectral)} type="button" on:click={() => send(item.command)}>{item.label}</button>
+      {/each}
+    </div>
+
+    <div class="status-row">
+      <span>Status</span>
+      <strong>{eccm.status ?? "standby"}</strong>
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .mode-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .mode-grid button.selected {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  .status-row {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+  }
+</style>

--- a/gui-svelte/src/components/tactical/EcmControlPanel.svelte
+++ b/gui-svelte/src/components/tactical/EcmControlPanel.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { extractShipState, getECMState, toNumber } from "./tacticalData.js";
+
+  let emconLevel = "0";
+
+  $: ship = extractShipState($gameState);
+  $: ecm = getECMState(ship);
+  $: emconEnabled = Boolean(ecm.emcon_active);
+  $: emconLevel = emconEnabled ? "5" : "0";
+
+  async function toggleJammer() {
+    await wsClient.sendShipCommand(ecm.jammer_enabled ? "deactivate_jammer" : "activate_jammer", {});
+  }
+
+  async function deployChaff() {
+    await wsClient.sendShipCommand("deploy_chaff", {});
+  }
+
+  async function setEmcon(event: Event) {
+    emconLevel = (event.currentTarget as HTMLSelectElement).value;
+    await wsClient.sendShipCommand("set_emcon", { enabled: emconLevel !== "0" });
+  }
+</script>
+
+<Panel title="ECM Control" domain="sensor" priority={ecm.jammer_enabled || emconEnabled ? "primary" : "secondary"} className="ecm-control-panel">
+  <div class="shell">
+    <div class="status-grid">
+      <div class="card"><span>Jammer</span><strong>{ecm.jammer_enabled ? "ACTIVE" : "OFF"}</strong></div>
+      <div class="card"><span>Chaff</span><strong>{ecm.chaff_count ?? 0}</strong></div>
+      <div class="card"><span>EMCON</span><strong>{emconEnabled ? "ON" : "OFF"}</strong></div>
+      <div class="card"><span>Power</span><strong>{toNumber(ecm.jammer_power) / 1000} kW</strong></div>
+    </div>
+
+    <div class="actions">
+      <button on:click={toggleJammer}>{ecm.jammer_enabled ? "DEACTIVATE JAMMER" : "ACTIVATE JAMMER"}</button>
+      <button on:click={deployChaff}>DEPLOY CHAFF</button>
+    </div>
+
+    <label>
+      <span>EMCON level</span>
+      <select value={emconLevel} on:change={setEmcon}>
+        {#each [0, 1, 2, 3, 4, 5] as level}
+          <option value={String(level)}>{level}</option>
+        {/each}
+      </select>
+    </label>
+  </div>
+</Panel>
+
+<style>
+  .shell,
+  label {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .status-grid,
+  .actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .card {
+    display: grid;
+    gap: 4px;
+    padding: 8px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+  }
+
+  span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+  }
+</style>

--- a/gui-svelte/src/components/tactical/FireAuthorization.svelte
+++ b/gui-svelte/src/components/tactical/FireAuthorization.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
+  import {
+    extractShipState,
+    getAuthorizedWeapons,
+    getLauncherInventory,
+    getLockedTargetId,
+    getTacticalProposals,
+  } from "./tacticalData.js";
+
+  $: ship = extractShipState($gameState);
+  $: authorized = getAuthorizedWeapons(ship);
+  $: inventory = getLauncherInventory(ship);
+  $: proposals = getTacticalProposals(ship);
+  $: lockedTargetId = getLockedTargetId(ship);
+  $: activeTargetId = $selectedTacticalTargetId || lockedTargetId;
+  $: arcadeTier = $tier === "arcade";
+  $: cpuAssistTier = $tier === "cpu-assist";
+
+  async function fireNow(command: "fire_railgun" | "launch_torpedo" | "launch_missile") {
+    const params: Record<string, unknown> = {};
+    if (activeTargetId) params.target = activeTargetId;
+    if (command !== "fire_railgun") params.profile = "direct";
+    await wsClient.sendShipCommand(command, params);
+  }
+
+  async function toggleAuthorization(kind: "railgun" | "torpedo" | "missile") {
+    const enabled = authorized[kind];
+    await wsClient.sendShipCommand(enabled ? "deauthorize_weapon" : "authorize_weapon", {
+      weapon_type: kind,
+      profile: "direct",
+    });
+  }
+
+  async function approveProposal(proposalId: string) {
+    await wsClient.sendShipCommand("approve_tactical", { proposal_id: proposalId });
+  }
+
+  function ammoPercent(loaded: unknown, capacity: unknown): string {
+    const l = Number(loaded ?? 0);
+    const c = Number(capacity ?? 0);
+    if (!c) return "0%";
+    return `${Math.round((l / c) * 100)}%`;
+  }
+</script>
+
+<Panel title="Fire Authorization" domain="weapons" priority={arcadeTier || cpuAssistTier ? "primary" : "secondary"} className="fire-authorization-panel">
+  <div class="shell">
+    {#if arcadeTier}
+      <div class="arcade-grid">
+        <button class="arcade-btn railgun" on:click={() => fireNow("fire_railgun")}>
+          <span>RAILGUN</span>
+        </button>
+        <button class="arcade-btn torpedo" on:click={() => fireNow("launch_torpedo")}>
+          <span>TORPEDO</span>
+          <strong>{ammoPercent(inventory.torpedoes.loaded, inventory.torpedoes.capacity)}</strong>
+        </button>
+        <button class="arcade-btn missile" on:click={() => fireNow("launch_missile")}>
+          <span>MISSILE</span>
+          <strong>{ammoPercent(inventory.missiles.loaded, inventory.missiles.capacity)}</strong>
+        </button>
+      </div>
+    {:else if cpuAssistTier}
+      <div class="auth-grid">
+        {#each ["railgun", "torpedo", "missile"] as weapon}
+          <button class:selected={authorized[weapon]} type="button" on:click={() => toggleAuthorization(weapon as "railgun" | "torpedo" | "missile")}>
+            <span>{weapon.toUpperCase()}</span>
+            <strong>{authorized[weapon] ? "AUTHORIZED" : "HOLD"}</strong>
+          </button>
+        {/each}
+      </div>
+
+      <div class="proposal-list">
+        {#if proposals.length === 0}
+          <div class="empty">No pending tactical approvals.</div>
+        {:else}
+          {#each proposals as proposal}
+            <div class="proposal-card">
+              <strong>{proposal.action ?? "proposal"}</strong>
+              <span>{proposal.target ?? "--"} · {proposal.confidence ? `${Math.round(Number(proposal.confidence) * 100)}%` : "pending"}</span>
+              <span>{proposal.reason ?? "Awaiting approval"}</span>
+              <button on:click={() => approveProposal(String(proposal.proposal_id ?? ""))}>APPROVE</button>
+            </div>
+          {/each}
+        {/if}
+      </div>
+    {:else}
+      <div class="manual-note">RAW and MANUAL tiers use explicit weapon panels below.</div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell,
+  .proposal-list {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .arcade-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .arcade-btn,
+  .auth-grid button,
+  .proposal-card {
+    display: grid;
+    gap: 6px;
+    padding: 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+  }
+
+  .arcade-btn span,
+  .manual-note,
+  .proposal-card span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .arcade-btn strong,
+  .auth-grid strong,
+  .proposal-card strong {
+    font-family: var(--font-mono);
+  }
+
+  .auth-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .auth-grid button.selected {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  .proposal-card,
+  .manual-note {
+    background: rgba(255, 255, 255, 0.02);
+  }
+</style>

--- a/gui-svelte/src/components/tactical/FiringSolutionDisplay.svelte
+++ b/gui-svelte/src/components/tactical/FiringSolutionDisplay.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    asRecord,
+    extractShipState,
+    getBestWeaponSolution,
+    getSolutionFactors,
+    getTargetingSummary,
+    toNumber,
+  } from "./tacticalData.js";
+
+  let liveSolution: Record<string, unknown> = {};
+  let pollHandle: number | null = null;
+
+  $: ship = extractShipState($gameState);
+  $: targeting = getTargetingSummary(ship);
+  $: fallbackSolution = getBestWeaponSolution(ship);
+  $: solution = Object.keys(liveSolution).length ? liveSolution : fallbackSolution;
+  $: factors = getSolutionFactors(asRecord(solution) ?? {});
+  $: overall = toNumber(solution.confidence, targeting.lockQuality);
+  $: overallClass = overall >= 0.75 ? "good" : overall >= 0.45 ? "warn" : "bad";
+  $: arcadeTier = $tier === "arcade";
+
+  onMount(() => {
+    void refresh();
+    pollHandle = window.setInterval(() => void refresh(), 2500);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  async function refresh() {
+    if (!targeting.lockedTarget) {
+      liveSolution = {};
+      return;
+    }
+    try {
+      liveSolution = asRecord(await wsClient.sendShipCommand("get_target_solution", {})) ?? {};
+    } catch {
+      liveSolution = {};
+    }
+  }
+</script>
+
+<Panel title="Firing Solution" domain="weapons" priority={overall >= 0.7 ? "primary" : "secondary"} className="firing-solution-panel">
+  <div class="shell">
+    <div class="overall">
+      <span>Overall confidence</span>
+      <strong class={overallClass}>{Math.round(overall * 100)}%</strong>
+    </div>
+
+    <div class="track">
+      <div class="fill {overallClass}" style={`width: ${Math.round(overall * 100)}%;`}></div>
+    </div>
+
+    {#if !arcadeTier}
+      <div class="factor-list">
+        {#each factors as factor}
+          <div class="factor-row">
+            <span>{factor.label}</span>
+            <div class="factor-track"><div class="factor-fill" style={`width: ${Math.round(factor.value * 100)}%;`}></div></div>
+            <strong>{Math.round(factor.value * 100)}%</strong>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell,
+  .factor-list {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .overall,
+  .factor-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(70px, auto);
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .factor-row {
+    grid-template-columns: 90px minmax(0, 1fr) 52px;
+  }
+
+  span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    text-align: right;
+  }
+
+  .track,
+  .factor-track {
+    height: 10px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: var(--bg-input);
+  }
+
+  .fill,
+  .factor-fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.25), var(--tier-accent));
+  }
+
+  .good { color: var(--status-nominal); }
+  .warn { color: #ffd84d; }
+  .bad { color: var(--status-critical); }
+
+  .fill.good { background: rgba(0, 255, 136, 0.85); }
+  .fill.warn { background: rgba(255, 216, 77, 0.85); }
+  .fill.bad { background: rgba(255, 68, 68, 0.85); }
+</style>

--- a/gui-svelte/src/components/tactical/LauncherControl.svelte
+++ b/gui-svelte/src/components/tactical/LauncherControl.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { selectedLauncherType, selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
+  import { extractShipState, getLockedTargetId, getTacticalContacts } from "./tacticalData.js";
+
+  const profiles = ["direct", "evasive", "terminal_pop", "bracket"];
+  const salvoOptions = [1, 2, 4];
+
+  let salvoSize = 1;
+  let profile = "direct";
+  let guidanceMode = "guided";
+  let warheadType = "fragmentation";
+  let selectedTarget = "";
+
+  $: ship = extractShipState($gameState);
+  $: contacts = getTacticalContacts(ship);
+  $: lockedTargetId = getLockedTargetId(ship);
+  $: selectedTarget = $selectedTacticalTargetId || lockedTargetId;
+
+  async function fire() {
+    const command = $selectedLauncherType === "torpedo" ? "launch_torpedo" : "launch_missile";
+    await wsClient.sendShipCommand(command, {
+      target: selectedTarget || undefined,
+      profile,
+      salvo_size: salvoSize,
+      guidance_mode: guidanceMode,
+      warhead_type: warheadType,
+    });
+  }
+
+  async function program() {
+    await wsClient.sendShipCommand("program_munition", {
+      munition_type: $selectedLauncherType,
+      flight_profile: profile,
+      guidance_mode: guidanceMode,
+      warhead_type: warheadType,
+      salvo_size: salvoSize,
+      target: selectedTarget || undefined,
+    });
+  }
+
+  function onTargetChange(event: Event) {
+    const value = (event.currentTarget as HTMLSelectElement).value;
+    selectedTarget = value;
+    selectedTacticalTargetId.set(value);
+  }
+</script>
+
+<Panel title="Launcher Control" domain="weapons" priority="secondary" className="launcher-control-panel">
+  <div class="shell">
+    <div class="toggle-row">
+      <button class:selected={$selectedLauncherType === "torpedo"} type="button" on:click={() => selectedLauncherType.set("torpedo")}>TORPEDO</button>
+      <button class:selected={$selectedLauncherType === "missile"} type="button" on:click={() => selectedLauncherType.set("missile")}>MISSILE</button>
+    </div>
+
+    <div class="option-grid">
+      <label>
+        <span>Target</span>
+        <select value={selectedTarget} on:change={onTargetChange}>
+          <option value="">Locked target</option>
+          {#each contacts as contact}
+            <option value={contact.id}>{contact.id} · {contact.classification}</option>
+          {/each}
+        </select>
+      </label>
+      <label>
+        <span>Salvo</span>
+        <select bind:value={salvoSize}>
+          {#each salvoOptions as option}
+            <option value={option}>{option}</option>
+          {/each}
+        </select>
+      </label>
+      <label>
+        <span>Profile</span>
+        <select bind:value={profile}>
+          {#each profiles as option}
+            <option value={option}>{option}</option>
+          {/each}
+        </select>
+      </label>
+    </div>
+
+    <div class="option-grid">
+      <label><span>Guidance</span><input bind:value={guidanceMode} /></label>
+      <label><span>Warhead</span><input bind:value={warheadType} /></label>
+    </div>
+
+    <div class="actions">
+      <button on:click={program}>PROGRAM</button>
+      <button on:click={fire}>FIRE</button>
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .toggle-row,
+  .actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .toggle-row button.selected {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  .option-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .option-grid:last-of-type {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  label {
+    display: grid;
+    gap: 6px;
+  }
+
+  span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+</style>

--- a/gui-svelte/src/components/tactical/MultiTrackPanel.svelte
+++ b/gui-svelte/src/components/tactical/MultiTrackPanel.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
+  import { extractShipState, getMultiTrackState, getPdcMounts, getTacticalContacts, getWeaponMounts, toStringValue } from "./tacticalData.js";
+
+  let assignWeapon = "";
+
+  $: ship = extractShipState($gameState);
+  $: contacts = getTacticalContacts(ship);
+  $: multiTrack = getMultiTrackState(ship);
+  $: pdcMounts = getPdcMounts(ship);
+  $: weaponMounts = getWeaponMounts(ship);
+
+  async function addTrack() {
+    if (!$selectedTacticalTargetId) return;
+    await wsClient.sendShipCommand("add_track", { contact_id: $selectedTacticalTargetId });
+  }
+
+  async function removeTrack(contactId: string) {
+    await wsClient.sendShipCommand("remove_track", { contact_id: contactId });
+  }
+
+  async function assignPdc(contactId: string, mountId: string) {
+    if (!mountId) return;
+    await wsClient.sendShipCommand("assign_pdc_target", { mount_id: mountId, contact_id: contactId });
+  }
+
+  async function splitFire(contactId: string, mountId: string) {
+    if (!mountId) return;
+    await wsClient.sendShipCommand("split_fire", { mount_id: mountId, contact_id: contactId });
+  }
+
+  async function clearAssignments() {
+    await wsClient.sendShipCommand("clear_assignments", {});
+  }
+</script>
+
+<Panel title="Multi-Track" domain="weapons" priority="secondary" className="multi-track-panel">
+  <div class="shell">
+    <div class="toolbar">
+      <button disabled={!$selectedTacticalTargetId} on:click={addTrack}>ADD TRACK</button>
+      <button disabled={multiTrack.trackCount === 0} on:click={clearAssignments}>CLEAR ASSIGNMENTS</button>
+    </div>
+
+    {#if multiTrack.trackCount === 0}
+      <div class="empty">No multi-target tracks assigned.</div>
+    {:else}
+      {#each multiTrack.tracks as track}
+        <div class="track-card">
+          <div class="header">
+            <strong>{toStringValue(track.contact_id)}</strong>
+            <span>Priority {track.priority ?? 0} · Q {Math.round(Number(track.quality_modifier ?? 0) * 100)}%</span>
+          </div>
+          <div class="assignments">
+            <label>
+              <span>PDC</span>
+              <select on:change={(event) => assignPdc(String(track.contact_id), (event.currentTarget as HTMLSelectElement).value)}>
+                <option value="">Assign</option>
+                {#each pdcMounts as mount}
+                  <option value={mount.id}>{mount.id}</option>
+                {/each}
+              </select>
+            </label>
+            <label>
+              <span>Weapon</span>
+              <select bind:value={assignWeapon} on:change={(event) => splitFire(String(track.contact_id), (event.currentTarget as HTMLSelectElement).value)}>
+                <option value="">Split-fire</option>
+                {#each weaponMounts as mount}
+                  <option value={mount.id}>{mount.id}</option>
+                {/each}
+              </select>
+            </label>
+          </div>
+          <button on:click={() => removeTrack(String(track.contact_id))}>REMOVE</button>
+        </div>
+      {/each}
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .toolbar,
+  .assignments {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .track-card {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+  }
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  label {
+    display: grid;
+    gap: 6px;
+  }
+
+  span,
+  .empty {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  strong {
+    font-family: var(--font-mono);
+  }
+</style>

--- a/gui-svelte/src/components/tactical/PdcControl.svelte
+++ b/gui-svelte/src/components/tactical/PdcControl.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
+  import { extractShipState, getCombatState, getThreatList, toStringValue } from "./tacticalData.js";
+
+  const modes = [
+    { label: "AUTO", value: "auto" },
+    { label: "MANUAL", value: "manual" },
+    { label: "PRIORITY", value: "priority" },
+    { label: "HOLD", value: "hold_fire" },
+  ];
+
+  $: ship = extractShipState($gameState);
+  $: combat = getCombatState(ship);
+  $: threats = getThreatList(ship);
+  $: mode = toStringValue(combat.pdc_mode, "auto");
+  $: priorityTarget = $selectedTacticalTargetId;
+
+  async function setMode(next: string) {
+    await wsClient.sendShipCommand("set_pdc_mode", { mode: next });
+  }
+
+  async function applyPriority(event: Event) {
+    const targetId = (event.currentTarget as HTMLSelectElement).value;
+    if (!targetId) return;
+    await wsClient.sendShipCommand("set_pdc_priority", {
+      torpedo_ids: [targetId],
+      target_id: targetId,
+    });
+  }
+</script>
+
+<Panel title="PDC Control" domain="weapons" priority="secondary" className="pdc-control-panel">
+  <div class="shell">
+    <div class="mode-grid">
+      {#each modes as item}
+        <button class:selected={mode === item.value} type="button" on:click={() => setMode(item.value)}>{item.label}</button>
+      {/each}
+    </div>
+
+    <label>
+      <span>Priority target</span>
+      <select value={priorityTarget} on:change={applyPriority}>
+        <option value="">Select track</option>
+        {#each threats as threat}
+          <option value={threat.id}>{threat.id} · {threat.classification}</option>
+        {/each}
+      </select>
+    </label>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .mode-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  .mode-grid button.selected {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  label {
+    display: grid;
+    gap: 6px;
+  }
+
+  span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+</style>

--- a/gui-svelte/src/components/tactical/RailgunControl.svelte
+++ b/gui-svelte/src/components/tactical/RailgunControl.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
+  import { extractShipState, getLockedTargetId, getRailgunMounts } from "./tacticalData.js";
+
+  $: ship = extractShipState($gameState);
+  $: mounts = getRailgunMounts(ship);
+  $: targetId = $selectedTacticalTargetId || getLockedTargetId(ship);
+  $: arcadeTier = $tier === "arcade";
+
+  async function fireMount(mountId: string) {
+    await wsClient.sendShipCommand("fire_railgun", {
+      mount_id: mountId,
+      target: targetId || undefined,
+    });
+  }
+</script>
+
+<Panel title="Railgun Control" domain="weapons" priority="secondary" className="railgun-control-panel">
+  <div class="shell">
+    {#if mounts.length === 0}
+      <div class="empty">No railgun mounts installed.</div>
+    {:else}
+      {#each mounts as mount}
+        <div class="mount-row">
+          <div class="meta">
+            <strong>{mount.id}</strong>
+            <span>{mount.ammo} slugs · {mount.ready ? "READY" : mount.status.toUpperCase()}</span>
+          </div>
+          <div class="track">
+            <div class="fill" class:arcade={arcadeTier} style={`width: ${Math.round(mount.charge * 100)}%;`}></div>
+          </div>
+          <button disabled={!mount.ready || mount.ammo <= 0} on:click={() => fireMount(mount.id)}>FIRE</button>
+        </div>
+      {/each}
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .mount-row {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+  }
+
+  .meta {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  .meta span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  .track {
+    height: 10px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+  }
+
+  .fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.25), var(--tier-accent));
+  }
+
+  .fill.arcade {
+    animation: pulse 1.2s ease-in-out infinite;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 0.75; }
+    50% { opacity: 1; }
+  }
+</style>

--- a/gui-svelte/src/components/tactical/SensorContacts.svelte
+++ b/gui-svelte/src/components/tactical/SensorContacts.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { tier } from "../../lib/stores/tier.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
+  import {
+    extractShipState,
+    formatBearing,
+    formatContactSummary,
+    formatContactVector,
+    getLockedTargetId,
+    getSensorState,
+    getTacticalContacts,
+    toNumber,
+  } from "./tacticalData.js";
+
+  export let passive = false;
+
+  let busy = false;
+
+  $: ship = extractShipState($gameState);
+  $: contacts = getTacticalContacts(ship);
+  $: sensors = getSensorState(ship);
+  $: lockedTargetId = getLockedTargetId(ship);
+  $: arcadeTier = $tier === "arcade";
+  $: cpuAssistTier = $tier === "cpu-assist";
+  $: manualTier = $tier === "manual";
+  $: cooldown = toNumber(sensors.ping_cooldown_remaining);
+  $: canPing = !passive && Boolean(sensors.can_ping ?? true) && cooldown <= 0;
+
+  async function pingSensors() {
+    if (!canPing) return;
+    busy = true;
+    try {
+      await wsClient.sendShipCommand("ping_sensors", {});
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function lockContact(contactId: string) {
+    selectedTacticalTargetId.set(contactId);
+    if (passive) return;
+    await wsClient.sendShipCommand("lock_target", { contact_id: contactId });
+  }
+</script>
+
+<Panel title={passive ? "Passive Contacts" : "Sensor Contacts"} domain="sensor" priority={$tier === "manual" ? "primary" : "secondary"} className="sensor-contacts-panel">
+  <div class="shell">
+    {#if !passive}
+      <div class="toolbar">
+        <button disabled={!canPing || busy} on:click={pingSensors}>
+          {cooldown > 0 ? `PING ${cooldown.toFixed(1)}s` : "PING SENSORS"}
+        </button>
+        <div class="summary">{contacts.length} contacts</div>
+      </div>
+    {/if}
+
+    <div class="list">
+      {#if contacts.length === 0}
+        <div class="empty">No contacts resolved.</div>
+      {:else}
+        {#each contacts as contact}
+          <button
+            class="contact-row"
+            class:selected={contact.id === $selectedTacticalTargetId || contact.id === lockedTargetId}
+            class:passive={passive}
+            type="button"
+            disabled={passive}
+            on:click={() => lockContact(contact.id)}
+          >
+            <div class="topline">
+              <strong>{contact.id}</strong>
+              <span class="threat {contact.threatLevel}">{contact.threatLevel.toUpperCase()}</span>
+            </div>
+
+            {#if cpuAssistTier}
+              <div class="primary-line">{contact.classification || "Unknown"} · {Math.round(contact.threatScore * 100)} threat</div>
+            {:else}
+              <div class="primary-line">{contact.classification || "Unknown"} · {formatContactSummary(contact)}</div>
+            {/if}
+
+            {#if !arcadeTier && !cpuAssistTier}
+              <div class="detail-line">
+                <span>Bearing {formatBearing(contact.bearing)}</span>
+                <span>Closure {contact.closureRate >= 0 ? "+" : ""}{contact.closureRate.toFixed(0)} m/s</span>
+              </div>
+            {/if}
+
+            {#if manualTier}
+              <div class="detail-line">
+                <span>Signal {contact.signalStrength.toFixed(2)}</span>
+                <span>V {formatContactVector(contact)}</span>
+              </div>
+            {/if}
+
+            <div class="confidence-track" aria-label="Contact confidence">
+              <div class="confidence-fill {contact.threatLevel}" style={`width: ${(contact.confidence * 100).toFixed(0)}%;`}></div>
+            </div>
+          </button>
+        {/each}
+      {/if}
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell,
+  .list {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .toolbar,
+  .topline,
+  .detail-line {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .summary,
+  .primary-line,
+  .detail-line,
+  .empty {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  .contact-row {
+    display: grid;
+    gap: 6px;
+    width: 100%;
+    text-align: left;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .contact-row.selected {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+  }
+
+  .contact-row.passive {
+    cursor: default;
+  }
+
+  .contact-row strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .threat {
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.08em;
+  }
+
+  .threat.green,
+  .confidence-fill.green {
+    color: var(--status-nominal);
+    background: rgba(0, 255, 136, 0.85);
+  }
+
+  .threat.yellow,
+  .confidence-fill.yellow {
+    color: #ffd84d;
+    background: rgba(255, 216, 77, 0.85);
+  }
+
+  .threat.orange,
+  .confidence-fill.orange {
+    color: #ff9d47;
+    background: rgba(255, 157, 71, 0.9);
+  }
+
+  .threat.red,
+  .confidence-fill.red {
+    color: var(--status-critical);
+    background: rgba(255, 68, 68, 0.9);
+  }
+
+  .confidence-track {
+    height: 8px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .confidence-fill {
+    height: 100%;
+  }
+</style>

--- a/gui-svelte/src/components/tactical/SubsystemSelector.svelte
+++ b/gui-svelte/src/components/tactical/SubsystemSelector.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { extractShipState, getTargetingSummary } from "./tacticalData.js";
+
+  const options = [
+    { label: "NONE", value: "none" },
+    { label: "HULL", value: "hull" },
+    { label: "DRIVE", value: "drive" },
+    { label: "REACTOR", value: "reactor" },
+    { label: "COMMS", value: "comms" },
+    { label: "SENSORS", value: "sensors" },
+    { label: "WEAPONS", value: "weapons" },
+  ];
+
+  let draft = "none";
+
+  $: ship = extractShipState($gameState);
+  $: targeting = getTargetingSummary(ship);
+  $: draft = targeting.subsystem || "none";
+
+  async function updateSubsystem(event: Event) {
+    draft = (event.currentTarget as HTMLSelectElement).value;
+    await wsClient.sendShipCommand("set_target_subsystem", { target_subsystem: draft });
+  }
+</script>
+
+<Panel title="Subsystem Targeting" domain="weapons" priority="secondary" className="subsystem-selector-panel">
+  <div class="shell">
+    <label>
+      <span>Target Subsystem</span>
+      <select value={draft} on:change={updateSubsystem}>
+        {#each options as option}
+          <option value={option.value}>{option.label}</option>
+        {/each}
+      </select>
+    </label>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    padding: var(--space-sm);
+  }
+
+  label {
+    display: grid;
+    gap: 6px;
+  }
+
+  span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+</style>

--- a/gui-svelte/src/components/tactical/TacticalMap.svelte
+++ b/gui-svelte/src/components/tactical/TacticalMap.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
+  import { extractShipState, getTacticalContacts, getWeaponMounts, type TacticalContact } from "./tacticalData.js";
+
+  let canvas: HTMLCanvasElement | null = null;
+  let dragging = false;
+  let lastX = 0;
+  let lastY = 0;
+  let offsetX = 0;
+  let offsetY = 0;
+  let zoom = 0.0015;
+
+  $: ship = extractShipState($gameState);
+  $: contacts = getTacticalContacts(ship);
+  $: mounts = getWeaponMounts(ship);
+  $: maxRange = mounts.reduce((max, mount) => Math.max(max, mount.range), 50_000);
+
+  onMount(() => {
+    if (!canvas) return undefined;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return undefined;
+    let raf = 0;
+
+    const draw = () => {
+      if (!canvas) return;
+      const width = canvas.width;
+      const height = canvas.height;
+      const cx = width / 2 + offsetX;
+      const cy = height / 2 + offsetY;
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = "#081019";
+      ctx.fillRect(0, 0, width, height);
+
+      ctx.strokeStyle = "rgba(255,255,255,0.08)";
+      ctx.beginPath();
+      ctx.moveTo(cx, 0);
+      ctx.lineTo(cx, height);
+      ctx.moveTo(0, cy);
+      ctx.lineTo(width, cy);
+      ctx.stroke();
+
+      [maxRange * 0.3, maxRange * 0.6, maxRange].forEach((range, index) => {
+        ctx.beginPath();
+        ctx.strokeStyle = `rgba(0, 170, 255, ${0.1 + index * 0.06})`;
+        ctx.arc(cx, cy, range * zoom, 0, Math.PI * 2);
+        ctx.stroke();
+      });
+
+      contacts.forEach((contact) => {
+        const x = cx + contact.position.x * zoom;
+        const y = cy - contact.position.y * zoom;
+        ctx.strokeStyle = "rgba(255,255,255,0.16)";
+        ctx.beginPath();
+        ctx.moveTo(cx, cy);
+        ctx.lineTo(x, y);
+        ctx.stroke();
+
+        if (contact.confidence < 0.95) {
+          ctx.strokeStyle = "rgba(255, 216, 77, 0.3)";
+          ctx.beginPath();
+          ctx.ellipse(x, y, 12 + (1 - contact.confidence) * 18, 8 + (1 - contact.confidence) * 12, 0, 0, Math.PI * 2);
+          ctx.stroke();
+        }
+
+        ctx.fillStyle = contact.id === $selectedTacticalTargetId ? "#00ffaa" : "#74b9ff";
+        ctx.beginPath();
+        ctx.arc(x, y, 4 + contact.threatScore * 4, 0, Math.PI * 2);
+        ctx.fill();
+
+        ctx.fillStyle = "rgba(255,255,255,0.9)";
+        ctx.font = "11px JetBrains Mono";
+        ctx.fillText(`${contact.id} ${contact.classification ?? ""}`, x + 8, y - 8);
+      });
+
+      raf = requestAnimationFrame(draw);
+    };
+
+    raf = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(raf);
+  });
+
+  async function lockNearest(event: MouseEvent) {
+    if (!canvas || contacts.length === 0) return;
+    const rect = canvas.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) * canvas.width) / rect.width;
+    const y = ((event.clientY - rect.top) * canvas.height) / rect.height;
+    const cx = canvas.width / 2 + offsetX;
+    const cy = canvas.height / 2 + offsetY;
+    let best: TacticalContact | null = null;
+    let bestDistance = Number.POSITIVE_INFINITY;
+
+    for (const contact of contacts) {
+      const dotX = cx + contact.position.x * zoom;
+      const dotY = cy - contact.position.y * zoom;
+      const distance = Math.hypot(dotX - x, dotY - y);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = contact;
+      }
+    }
+
+    if (!best || bestDistance > 28) return;
+    selectedTacticalTargetId.set(best.id);
+    await wsClient.sendShipCommand("lock_target", { contact_id: best.id });
+  }
+
+  function startDrag(event: MouseEvent) {
+    dragging = true;
+    lastX = event.clientX;
+    lastY = event.clientY;
+  }
+
+  function onMove(event: MouseEvent) {
+    if (!dragging) return;
+    offsetX += event.clientX - lastX;
+    offsetY += event.clientY - lastY;
+    lastX = event.clientX;
+    lastY = event.clientY;
+  }
+
+  function endDrag() {
+    dragging = false;
+  }
+
+  function onWheel(event: WheelEvent) {
+    event.preventDefault();
+    zoom = Math.min(0.01, Math.max(0.0002, zoom * (event.deltaY > 0 ? 0.88 : 1.12)));
+  }
+</script>
+
+<Panel title="Tactical Map" domain="sensor" priority="primary" className="tactical-map-panel">
+  <div class="shell">
+    <canvas
+      bind:this={canvas}
+      width="520"
+      height="360"
+      on:click={lockNearest}
+      on:mousedown={startDrag}
+      on:mousemove={onMove}
+      on:mouseup={endDrag}
+      on:mouseleave={endDrag}
+      on:wheel={onWheel}
+    ></canvas>
+    <div class="caption">Drag to pan. Scroll to zoom. Click a contact to lock.</div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: 8px;
+    padding: var(--space-sm);
+  }
+
+  canvas {
+    width: 100%;
+    height: auto;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: #081019;
+    cursor: crosshair;
+  }
+
+  .caption {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+</style>

--- a/gui-svelte/src/components/tactical/TargetAssessment.svelte
+++ b/gui-svelte/src/components/tactical/TargetAssessment.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { extractShipState, getLockedTargetId, getAssessmentSummary, asRecord } from "./tacticalData.js";
+
+  let assessment: Record<string, unknown> | null = null;
+  let pollHandle: number | null = null;
+
+  $: ship = extractShipState($gameState);
+  $: lockedTargetId = getLockedTargetId(ship);
+  $: summary = getAssessmentSummary(assessment);
+
+  onMount(() => {
+    void refresh();
+    pollHandle = window.setInterval(() => void refresh(), 3000);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  async function refresh() {
+    if (!lockedTargetId) {
+      assessment = null;
+      return;
+    }
+    try {
+      assessment = asRecord(await wsClient.sendShipCommand("assess_damage", {}));
+    } catch {
+      assessment = null;
+    }
+  }
+</script>
+
+<Panel title="Target Assessment" domain="sensor" priority="secondary" className="target-assessment-panel">
+  <div class="shell">
+    <div class="hull-bar">
+      <span>Estimated hull</span>
+      <strong>{Math.round(summary.hull * 100)}%</strong>
+    </div>
+    <div class="track"><div class="fill" style={`width: ${Math.round(summary.hull * 100)}%;`}></div></div>
+
+    <div class="subsystems">
+      {#if summary.subsystems.length === 0}
+        <div class="empty">No target damage estimate available.</div>
+      {:else}
+        {#each summary.subsystems as subsystem}
+          <div class="subsystem-row">
+            <strong>{String(subsystem.name).toUpperCase()}</strong>
+            <span>{subsystem.health != null && Number(subsystem.health) >= 0 ? `${Math.round(Number(subsystem.health) * 100)}%` : "--"}</span>
+            <span>{String(subsystem.status ?? "unknown").toUpperCase()}</span>
+          </div>
+        {/each}
+      {/if}
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell,
+  .subsystems {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .hull-bar,
+  .subsystem-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .hull-bar {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .track {
+    height: 10px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--bg-input);
+  }
+
+  .fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.25), var(--tier-accent));
+  }
+
+  span,
+  .empty {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  strong {
+    font-family: var(--font-mono);
+  }
+</style>

--- a/gui-svelte/src/components/tactical/TargetingDisplay.svelte
+++ b/gui-svelte/src/components/tactical/TargetingDisplay.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
+  import {
+    asRecord,
+    extractShipState,
+    formatDistance,
+    formatDuration,
+    getLockedTargetId,
+    getTargetingSummary,
+    toNumber,
+    toStringValue,
+  } from "./tacticalData.js";
+
+  const stages = ["Acquisition", "Weapons Lock", "Solution", "Ready to Fire"];
+
+  let solution: Record<string, unknown> = {};
+  let pollHandle: number | null = null;
+
+  $: ship = extractShipState($gameState);
+  $: targeting = getTargetingSummary(ship);
+  $: lockedTargetId = getLockedTargetId(ship);
+  $: targetId = $selectedTacticalTargetId || lockedTargetId;
+  $: solutionQuality = Math.max(targeting.lockQuality, toNumber(solution.lock_quality, 0));
+  $: progressWidth = `${Math.round(solutionQuality * 100)}%`;
+
+  onMount(() => {
+    void refreshSolution();
+    pollHandle = window.setInterval(() => void refreshSolution(), 2500);
+    return () => {
+      if (pollHandle != null) window.clearInterval(pollHandle);
+    };
+  });
+
+  async function refreshSolution() {
+    if (!targetId) {
+      solution = {};
+      return;
+    }
+
+    try {
+      const response = await wsClient.sendShipCommand("get_target_solution", {});
+      solution = asRecord(response) ?? {};
+    } catch {
+      solution = {};
+    }
+  }
+
+  async function designateTarget() {
+    if (!targetId) return;
+    await wsClient.sendShipCommand("designate_target", { contact_id: targetId });
+    await refreshSolution();
+  }
+
+  async function unlockTarget() {
+    await wsClient.sendShipCommand("unlock_target", {});
+    solution = {};
+  }
+</script>
+
+<Panel title="Targeting Display" domain="weapons" priority={targeting.lockState === "locked" ? "primary" : "secondary"} className="targeting-display-panel">
+  <div class="shell">
+    <div class="header">
+      <div>
+        <div class="label">Target</div>
+        <strong>{targetId || "NO TARGET"}</strong>
+      </div>
+      <div class="badge">{Math.round(solutionQuality * 100)}%</div>
+    </div>
+
+    <div class="pipeline">
+      {#each stages as stage, index}
+        <div class="stage" class:active={index < targeting.stage} class:current={index === Math.max(0, targeting.stage - 1)}>
+          <span>{stage}</span>
+        </div>
+      {/each}
+    </div>
+
+    <div class="confidence-track">
+      <div class="confidence-fill" style={`width: ${progressWidth};`}></div>
+    </div>
+
+    <div class="metrics">
+      <div class="metric"><span>Lock state</span><strong>{targeting.lockState.toUpperCase()}</strong></div>
+      <div class="metric"><span>Range</span><strong>{formatDistance(toNumber(solution.range, NaN))}</strong></div>
+      <div class="metric"><span>ETA</span><strong>{formatDuration(toNumber(solution.time_to_cpa, toNumber(solution.time_of_flight, NaN)))}</strong></div>
+      <div class="metric"><span>Subsystem</span><strong>{toStringValue(solution.target_subsystem, targeting.subsystem).toUpperCase()}</strong></div>
+    </div>
+
+    <div class="actions">
+      <button disabled={!targetId} on:click={designateTarget}>DESIGNATE</button>
+      <button disabled={!lockedTargetId} on:click={unlockTarget}>UNLOCK</button>
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .header,
+  .actions {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  .label,
+  .metric span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  strong,
+  .badge {
+    font-family: var(--font-mono);
+  }
+
+  .badge {
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(var(--tier-accent-rgb), 0.4);
+  }
+
+  .pipeline {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  .stage {
+    padding: 8px;
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.025);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .stage.active {
+    border-color: rgba(var(--tier-accent-rgb), 0.35);
+    background: rgba(var(--tier-accent-rgb), 0.1);
+  }
+
+  .stage.current {
+    box-shadow: inset 0 0 0 1px rgba(var(--tier-accent-rgb), 0.35);
+  }
+
+  .stage span {
+    font-size: 0.72rem;
+  }
+
+  .confidence-track {
+    height: 10px;
+    border-radius: 999px;
+    background: var(--bg-input);
+    overflow: hidden;
+  }
+
+  .confidence-fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.3), var(--tier-accent));
+  }
+
+  .metrics {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .metric {
+    display: grid;
+    gap: 4px;
+    padding: 8px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+  }
+</style>

--- a/gui-svelte/src/components/tactical/ThreatBoard.svelte
+++ b/gui-svelte/src/components/tactical/ThreatBoard.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
+  import { extractShipState, formatDistance, getThreatList } from "./tacticalData.js";
+
+  $: ship = extractShipState($gameState);
+  $: threats = getThreatList(ship).slice(0, 8);
+
+  async function lockThreat(contactId: string) {
+    selectedTacticalTargetId.set(contactId);
+    await wsClient.sendShipCommand("lock_target", { contact_id: contactId });
+  }
+</script>
+
+<Panel title="Threat Board" domain="weapons" priority="secondary" className="threat-board-panel">
+  <div class="shell">
+    {#if threats.length === 0}
+      <div class="empty">Threat queue clear.</div>
+    {:else}
+      {#each threats as threat, index}
+        <button class="threat-row {threat.threatLevel}" class:selected={threat.id === $selectedTacticalTargetId} type="button" on:click={() => lockThreat(threat.id)}>
+          <span class="index">{index + 1}</span>
+          <div class="body">
+            <strong>{threat.id}</strong>
+            <span>{threat.classification || "Unknown"} · {formatDistance(threat.distance)}</span>
+          </div>
+          <span class="score">{Math.round(threat.threatScore * 100)}</span>
+        </button>
+      {/each}
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-xs);
+    padding: var(--space-sm);
+  }
+
+  .threat-row {
+    display: grid;
+    grid-template-columns: 28px minmax(0, 1fr) auto;
+    gap: var(--space-sm);
+    align-items: center;
+    padding: 10px;
+    text-align: left;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .threat-row.selected {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+  }
+
+  .threat-row.red { border-color: rgba(255, 68, 68, 0.45); }
+  .threat-row.orange { border-color: rgba(255, 157, 71, 0.45); }
+  .threat-row.yellow { border-color: rgba(255, 216, 77, 0.35); }
+  .threat-row.green { border-color: rgba(0, 255, 136, 0.28); }
+
+  .index,
+  .score,
+  .empty,
+  .body span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  .index,
+  .score,
+  strong {
+    font-family: var(--font-mono);
+  }
+
+  .body {
+    display: grid;
+    gap: 4px;
+  }
+</style>

--- a/gui-svelte/src/components/tactical/WeaponsStatus.svelte
+++ b/gui-svelte/src/components/tactical/WeaponsStatus.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { extractShipState, getLauncherInventory, getRailgunMounts } from "./tacticalData.js";
+
+  $: ship = extractShipState($gameState);
+  $: inventory = getLauncherInventory(ship);
+  $: railguns = getRailgunMounts(ship);
+  $: averageCharge = railguns.length
+    ? railguns.reduce((sum, mount) => sum + mount.charge, 0) / railguns.length
+    : 0;
+</script>
+
+<Panel title="Weapons Status" domain="weapons" priority="secondary" className="weapons-status-panel">
+  <div class="shell">
+    <div class="stat-grid">
+      <div class="card"><span>Railgun mounts</span><strong>{railguns.length}</strong></div>
+      <div class="card"><span>Rail charge</span><strong>{Math.round(averageCharge * 100)}%</strong></div>
+      <div class="card"><span>Torpedoes</span><strong>{inventory.torpedoes.loaded ?? 0}/{inventory.torpedoes.capacity ?? 0}</strong></div>
+      <div class="card"><span>Missiles</span><strong>{inventory.missiles.loaded ?? 0}/{inventory.missiles.capacity ?? 0}</strong></div>
+    </div>
+
+    {#if railguns.length > 0}
+      <div class="mount-list">
+        {#each railguns as mount}
+          <div class="mount-row">
+            <strong>{mount.id}</strong>
+            <span>{Math.round(mount.charge * 100)}% charged</span>
+            <span>{mount.ammo} slugs</span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell,
+  .mount-list {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .stat-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .card,
+  .mount-row {
+    display: grid;
+    gap: 4px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.025);
+  }
+
+  .card span,
+  .mount-row span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+  }
+
+  strong {
+    font-family: var(--font-mono);
+  }
+</style>

--- a/gui-svelte/src/components/tactical/tacticalData.ts
+++ b/gui-svelte/src/components/tactical/tacticalData.ts
@@ -1,0 +1,378 @@
+import type { JsonMap, Vec3 } from "../helm/helmData.js";
+import {
+  asRecord,
+  clamp,
+  extractShipState,
+  formatDistance,
+  formatDuration,
+  formatSpeed,
+  formatVector,
+  getSystem,
+  magnitude,
+  normalizeAngle,
+  signed,
+  toNumber,
+  toStringValue,
+  toVec3,
+} from "../helm/helmData.js";
+
+export type ThreatLevel = "green" | "yellow" | "orange" | "red";
+
+export interface TacticalContact {
+  id: string;
+  name: string;
+  classification: string;
+  faction: string;
+  diplomaticState: string;
+  distance: number;
+  bearing: number;
+  confidence: number;
+  threatScore: number;
+  threatLevel: ThreatLevel;
+  position: Vec3;
+  velocity: Vec3;
+  closureRate: number;
+  speed: number;
+  contactState: string;
+  detectionMethod: string;
+  signalStrength: number;
+}
+
+export interface WeaponMountState {
+  id: string;
+  type: string;
+  weaponType: "railgun" | "pdc" | "torpedo" | "missile" | "other";
+  ammo: number;
+  ready: boolean;
+  charge: number;
+  cooldown: number;
+  status: string;
+  range: number;
+}
+
+const ZERO_VEC: Vec3 = { x: 0, y: 0, z: 0 };
+
+function textIncludes(source: string, values: string[]): boolean {
+  const lower = source.toLowerCase();
+  return values.some((value) => lower.includes(value));
+}
+
+function deriveBearing(position: Vec3): number {
+  const radians = Math.atan2(position.x, position.y);
+  return normalizeAngle((radians * 180) / Math.PI);
+}
+
+function parseBearing(value: unknown, position: Vec3): number {
+  if (typeof value === "number" && Number.isFinite(value)) return normalizeAngle(value);
+  const rec = asRecord(value);
+  if (rec) {
+    const vec = toVec3(rec, position);
+    return deriveBearing(vec);
+  }
+  return deriveBearing(position);
+}
+
+function computeThreatScore(contact: TacticalContact): number {
+  const classText = `${contact.classification} ${contact.name}`.toLowerCase();
+  let base = 0.2;
+
+  if (textIncludes(classText, ["torpedo", "missile"])) base += 0.55;
+  else if (textIncludes(classText, ["battleship", "cruiser", "carrier"])) base += 0.45;
+  else if (textIncludes(classText, ["frigate", "destroyer", "corvette", "gunship"])) base += 0.32;
+  else if (textIncludes(classText, ["drone", "shuttle", "probe"])) base += 0.1;
+
+  const closing = Math.max(0, contact.closureRate);
+  const approachBonus = clamp(closing / 2000, 0, 0.25);
+  const distanceBonus = 0.28 * (1 - clamp(contact.distance / 250_000, 0, 1));
+  const hostileBonus = textIncludes(contact.diplomaticState, ["hostile", "enemy"]) ? 0.15 : 0;
+  const confidenceBonus = contact.confidence * 0.12;
+
+  return clamp(base + approachBonus + distanceBonus + hostileBonus + confidenceBonus, 0, 1);
+}
+
+function scoreToThreatLevel(score: number): ThreatLevel {
+  if (score >= 0.78) return "red";
+  if (score >= 0.58) return "orange";
+  if (score >= 0.35) return "yellow";
+  return "green";
+}
+
+function normalizeContact(item: JsonMap): TacticalContact {
+  const position = toVec3(item.position);
+  const velocity = toVec3(item.velocity);
+  const distance = toNumber(item.distance, magnitude(position));
+  const speed = magnitude(velocity);
+  const bearing = parseBearing(item.bearing, position);
+  const closureRate = distance > 0
+    ? -((position.x * velocity.x) + (position.y * velocity.y) + (position.z * velocity.z)) / distance
+    : 0;
+
+  const contact: TacticalContact = {
+    id: toStringValue(item.id, "unknown"),
+    name: toStringValue(item.name) || toStringValue(item.classification) || toStringValue(item.id, "Unknown"),
+    classification: toStringValue(item.classification, "Unknown"),
+    faction: toStringValue(item.faction, "unknown"),
+    diplomaticState: toStringValue(item.diplomatic_state, "unknown"),
+    distance,
+    bearing,
+    confidence: clamp(toNumber(item.confidence, 0), 0, 1),
+    threatScore: 0,
+    threatLevel: "green",
+    position,
+    velocity,
+    closureRate,
+    speed,
+    contactState: toStringValue(item.contact_state, "confirmed"),
+    detectionMethod: toStringValue(item.detection_method, "passive"),
+    signalStrength: toNumber(item.signal_strength, toNumber(item.signature_strength, toNumber(item.confidence, 0))),
+  };
+
+  contact.threatScore = computeThreatScore(contact);
+  contact.threatLevel = scoreToThreatLevel(contact.threatScore);
+  return contact;
+}
+
+export function getShip(gameState: JsonMap | null | undefined): JsonMap {
+  return extractShipState(gameState);
+}
+
+export function getSensorState(ship: JsonMap): JsonMap {
+  return asRecord(ship.sensors) ?? getSystem(ship, "sensors");
+}
+
+export function getTargetingState(ship: JsonMap): JsonMap {
+  return asRecord(ship.targeting) ?? getSystem(ship, "targeting");
+}
+
+export function getCombatState(ship: JsonMap): JsonMap {
+  return asRecord(ship.weapons) ?? asRecord(ship.combat) ?? getSystem(ship, "combat");
+}
+
+export function getECMState(ship: JsonMap): JsonMap {
+  return asRecord(ship.ecm) ?? getSystem(ship, "ecm");
+}
+
+export function getECCMState(ship: JsonMap): JsonMap {
+  const sensors = getSensorState(ship);
+  return asRecord(ship.eccm) ?? asRecord(sensors.eccm) ?? {};
+}
+
+export function getAutoTacticalState(ship: JsonMap): JsonMap {
+  return asRecord(ship.auto_tactical) ?? getSystem(ship, "auto_tactical");
+}
+
+export function getTacticalContacts(ship: JsonMap): TacticalContact[] {
+  const sensors = getSensorState(ship);
+  const contacts = Array.isArray(sensors.contacts) ? sensors.contacts : [];
+  return contacts
+    .map((item) => asRecord(item))
+    .filter((item): item is JsonMap => Boolean(item))
+    .map(normalizeContact)
+    .sort((a, b) => {
+      if (b.threatScore !== a.threatScore) return b.threatScore - a.threatScore;
+      return a.distance - b.distance;
+    });
+}
+
+export function findTacticalContact(ship: JsonMap, contactId: string): TacticalContact | null {
+  return getTacticalContacts(ship).find((contact) => contact.id === contactId) ?? null;
+}
+
+export function getThreatList(ship: JsonMap): TacticalContact[] {
+  return getTacticalContacts(ship).filter((contact) => contact.confidence > 0.1);
+}
+
+export function getLockedTargetId(ship: JsonMap): string {
+  const targeting = getTargetingState(ship);
+  return toStringValue(targeting.locked_target);
+}
+
+export function getLockStage(targeting: JsonMap): number {
+  const state = toStringValue(targeting.lock_state, "idle");
+  if (state === "locked") return 4;
+  if (state === "tracking") return 3;
+  if (state === "acquiring") return 2;
+  if (state === "designated") return 1;
+  return 0;
+}
+
+export function getWeaponMounts(ship: JsonMap): WeaponMountState[] {
+  const combat = getCombatState(ship);
+  const source = asRecord(combat.truth_weapons) ?? asRecord(combat.weapons) ?? {};
+
+  return Object.entries(source)
+    .map(([id, raw]) => {
+      const item = asRecord(raw);
+      if (!item) return null;
+      const typeString = toStringValue(item.type, id).toLowerCase();
+      let weaponType: WeaponMountState["weaponType"] = "other";
+      if (id.startsWith("railgun") || typeString.includes("railgun")) weaponType = "railgun";
+      else if (id.startsWith("pdc") || typeString.includes("pdc")) weaponType = "pdc";
+      else if (typeString.includes("torpedo")) weaponType = "torpedo";
+      else if (typeString.includes("missile")) weaponType = "missile";
+
+      return {
+        id,
+        type: toStringValue(item.type, id),
+        weaponType,
+        ammo: toNumber(item.ammo),
+        ready: Boolean(item.ready),
+        charge: clamp(toNumber(item.charge_fraction, toNumber(item.charge, 0)), 0, 1),
+        cooldown: toNumber(item.cooldown_remaining, toNumber(item.cooldown)),
+        status: toStringValue(item.status, item.ready ? "ready" : "standby"),
+        range: toNumber(item.range, toNumber(item.max_range)),
+      };
+    })
+    .filter((item): item is WeaponMountState => Boolean(item));
+}
+
+export function getRailgunMounts(ship: JsonMap): WeaponMountState[] {
+  return getWeaponMounts(ship).filter((mount) => mount.weaponType === "railgun");
+}
+
+export function getPdcMounts(ship: JsonMap): WeaponMountState[] {
+  return getWeaponMounts(ship).filter((mount) => mount.weaponType === "pdc");
+}
+
+export function getLauncherInventory(ship: JsonMap): { torpedoes: JsonMap; missiles: JsonMap } {
+  const combat = getCombatState(ship);
+  return {
+    torpedoes: asRecord(combat.torpedoes) ?? {},
+    missiles: asRecord(combat.missiles) ?? {},
+  };
+}
+
+export function getBestWeaponSolution(ship: JsonMap): JsonMap {
+  const targeting = getTargetingState(ship);
+  const solutions = asRecord(targeting.solutions) ?? {};
+  const ranked = Object.entries(solutions)
+    .map(([id, raw]) => ({ id, data: asRecord(raw) }))
+    .filter((row): row is { id: string; data: JsonMap } => Boolean(row.data))
+    .sort((a, b) => toNumber(b.data.confidence) - toNumber(a.data.confidence));
+
+  return ranked[0]?.data ?? {};
+}
+
+export function getSolutionFactors(solution: JsonMap): Array<{ label: string; value: number }> {
+  const factors = asRecord(solution.confidence_factors);
+  if (factors) {
+    return [
+      { label: "Range", value: clamp(toNumber(factors.range, 0), 0, 1) },
+      { label: "Closure", value: clamp(toNumber(factors.closure_rate, toNumber(factors.closure, 0)), 0, 1) },
+      { label: "Motion", value: clamp(toNumber(factors.target_motion, 0), 0, 1) },
+      { label: "Track", value: clamp(toNumber(factors.track_quality, 0), 0, 1) },
+      { label: "Age", value: clamp(toNumber(factors.solution_age, 0), 0, 1) },
+    ];
+  }
+
+  return [
+    { label: "Range", value: clamp(1 - toNumber(solution.range) / 200_000, 0, 1) },
+    { label: "Closure", value: clamp(1 - Math.abs(toNumber(solution.range_rate)) / 2500, 0, 1) },
+    { label: "Motion", value: clamp(toNumber(solution.hit_probability, toNumber(solution.confidence)), 0, 1) },
+    { label: "Track", value: clamp(toNumber(solution.lock_quality, toNumber(solution.track_quality)), 0, 1) },
+    { label: "Age", value: clamp(1 - toNumber(solution.solution_age) / 12, 0, 1) },
+  ];
+}
+
+export function getTargetingSummary(ship: JsonMap): {
+  lockedTarget: string;
+  lockState: string;
+  lockQuality: number;
+  stage: number;
+  correlation: number;
+  trackQuality: number;
+  lockProgress: number;
+  subsystem: string;
+} {
+  const targeting = getTargetingState(ship);
+  return {
+    lockedTarget: toStringValue(targeting.locked_target),
+    lockState: toStringValue(targeting.lock_state, "idle"),
+    lockQuality: clamp(toNumber(targeting.lock_quality), 0, 1),
+    stage: getLockStage(targeting),
+    correlation: clamp(toNumber(targeting.correlation_progress), 0, 1),
+    trackQuality: clamp(toNumber(targeting.track_quality), 0, 1),
+    lockProgress: clamp(toNumber(targeting.lock_progress), 0, 1),
+    subsystem: toStringValue(targeting.target_subsystem, "none"),
+  };
+}
+
+export function getMultiTrackState(ship: JsonMap): {
+  trackCount: number;
+  tracks: JsonMap[];
+  primaryTarget: string;
+  pdcAssignments: JsonMap;
+  splitFireAssignments: JsonMap;
+} {
+  const targeting = getTargetingState(ship);
+  const state = asRecord(targeting.multi_track) ?? {};
+  return {
+    trackCount: toNumber(state.track_count),
+    tracks: Array.isArray(state.tracks) ? state.tracks.map((item) => asRecord(item)).filter((item): item is JsonMap => Boolean(item)) : [],
+    primaryTarget: toStringValue(state.primary_target),
+    pdcAssignments: asRecord(state.pdc_assignments) ?? {},
+    splitFireAssignments: asRecord(state.split_fire_assignments) ?? {},
+  };
+}
+
+export function getAuthorizedWeapons(ship: JsonMap): Record<string, boolean> {
+  const combat = getCombatState(ship);
+  const autoFire = asRecord(combat.auto_fire) ?? {};
+  const authorized = asRecord(autoFire.authorized) ?? {};
+  return {
+    railgun: Boolean(authorized.railgun),
+    torpedo: Boolean(authorized.torpedo),
+    missile: Boolean(authorized.missile),
+  };
+}
+
+export function getTacticalProposals(ship: JsonMap): JsonMap[] {
+  const autoTactical = getAutoTacticalState(ship);
+  return Array.isArray(autoTactical.proposals)
+    ? autoTactical.proposals.map((proposal) => asRecord(proposal)).filter((proposal): proposal is JsonMap => Boolean(proposal))
+    : [];
+}
+
+export function formatBearing(value: number): string {
+  return `${signed(normalizeAngle(value), 0)}°`;
+}
+
+export function formatContactVector(contact: TacticalContact): string {
+  return formatVector(contact.velocity);
+}
+
+export function formatContactSummary(contact: TacticalContact): string {
+  return `${formatDistance(contact.distance)} · ${formatSpeed(contact.speed)}`;
+}
+
+export function summarizeSolution(solution: JsonMap): string {
+  const eta = formatDuration(toNumber(solution.time_of_flight, toNumber(solution.eta)));
+  const range = formatDistance(toNumber(solution.range));
+  return `${range} · TOF ${eta}`;
+}
+
+export function getAssessmentSummary(assessment: JsonMap | null): { hull: number; subsystems: JsonMap[] } {
+  const record = assessment ?? {};
+  const subsystems = asRecord(record.subsystems) ?? {};
+  const rows = Object.entries(subsystems)
+    .map(([name, raw]) => {
+      const item = asRecord(raw);
+      if (!item) return null;
+      return {
+        name,
+        health: toNumber(item.health, -1),
+        status: toStringValue(item.status, "unknown"),
+        confidence: toStringValue(item.confidence, "none"),
+      };
+    })
+    .filter((row): row is { name: string; health: number; status: string; confidence: string } => Boolean(row));
+
+  const numeric = rows
+    .map((row) => toNumber(row.health, -1))
+    .filter((value) => value >= 0);
+  const hull = numeric.length ? numeric.reduce((sum, value) => sum + value, 0) / numeric.length : 0;
+  return { hull, subsystems: rows as unknown as JsonMap[] };
+}
+
+export { formatDistance, formatDuration, formatSpeed, formatVector, magnitude, toNumber, toStringValue, asRecord };
+export { extractShipState };

--- a/gui-svelte/src/lib/stores/commsUi.ts
+++ b/gui-svelte/src/lib/stores/commsUi.ts
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export const selectedCommsTargetId = writable<string>("");

--- a/gui-svelte/src/lib/stores/helmUi.ts
+++ b/gui-svelte/src/lib/stores/helmUi.ts
@@ -1,0 +1,9 @@
+import { writable } from "svelte/store";
+
+const _selectedHelmTargetId = writable<string>("");
+
+export const selectedHelmTargetId = {
+  subscribe: _selectedHelmTargetId.subscribe,
+  set: (value: string) => _selectedHelmTargetId.set(value),
+  clear: () => _selectedHelmTargetId.set(""),
+};

--- a/gui-svelte/src/lib/stores/scienceUi.ts
+++ b/gui-svelte/src/lib/stores/scienceUi.ts
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export const selectedScienceContactId = writable<string>("");

--- a/gui-svelte/src/lib/stores/tacticalUi.ts
+++ b/gui-svelte/src/lib/stores/tacticalUi.ts
@@ -1,0 +1,4 @@
+import { writable } from "svelte/store";
+
+export const selectedTacticalTargetId = writable("");
+export const selectedLauncherType = writable<"torpedo" | "missile">("torpedo");

--- a/gui-svelte/src/views/CommsView.svelte
+++ b/gui-svelte/src/views/CommsView.svelte
@@ -1,46 +1,88 @@
 <script lang="ts">
-  const VIEW_NAME = "Comms";
+  import { tier } from "../lib/stores/tier.js";
+
+  import CommsControlPanel from "../components/comms/CommsControlPanel.svelte";
+  import CommsChoicePanel from "../components/comms/CommsChoicePanel.svelte";
+  import StationChat from "../components/comms/StationChat.svelte";
+  import HailFrequencyGame from "../components/games/HailFrequencyGame.svelte";
+  import SensorContacts from "../components/tactical/SensorContacts.svelte";
+
+  $: arcadeTier = $tier === "arcade";
+  $: cpuAssistTier = $tier === "cpu-assist";
 </script>
 
-<div class="view-root">
-  <div class="stub-content">
-    <div class="stub-title">{VIEW_NAME}</div>
-    <div class="stub-hint">Implementation in progress — Prompt 3+</div>
-  </div>
+<div class="comms-root" class:arcade={arcadeTier} class:cpu={cpuAssistTier}>
+  <section class="group radio">
+    <div class="group-title">Radio</div>
+    <CommsControlPanel />
+    {#if arcadeTier}
+      <HailFrequencyGame />
+    {/if}
+  </section>
+
+  <section class="group incoming">
+    <div class="group-title">Incoming</div>
+    <CommsChoicePanel />
+  </section>
+
+  <section class="group situation">
+    <div class="group-title">Situation</div>
+    <StationChat />
+    <SensorContacts passive />
+  </section>
 </div>
 
 <style>
-  .view-root {
+  .comms-root {
     width: 100%;
     height: 100%;
     display: grid;
-    grid-template-columns: repeat(12, 1fr);
+    grid-template-columns: minmax(340px, 1.15fr) minmax(320px, 1fr) minmax(340px, 1.05fr);
     gap: var(--space-xs);
     padding: var(--space-xs);
     overflow: hidden;
   }
-  .stub-content {
-    grid-column: 1 / -1;
+
+  .group {
+    min-height: 0;
+    overflow: auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    gap: var(--space-sm);
+    gap: var(--space-xs);
+    padding-right: 2px;
   }
-  .stub-title {
+
+  .group-title {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    padding: 6px 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.12), transparent 60%), var(--bg-panel);
     font-family: var(--font-mono);
-    font-size: 1.4rem;
-    font-weight: 700;
-    letter-spacing: 4px;
-    color: var(--tier-accent, var(--hud-primary));
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    opacity: 0.6;
-  }
-  .stub-hint {
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
     color: var(--text-secondary);
-    letter-spacing: 1px;
+  }
+
+  @media (max-width: 1180px) {
+    .comms-root {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-auto-rows: minmax(0, 1fr);
+    }
+  }
+
+  @media (max-width: 760px) {
+    .comms-root {
+      grid-template-columns: 1fr;
+      height: auto;
+      overflow: auto;
+    }
+
+    .group {
+      overflow: visible;
+    }
   }
 </style>

--- a/gui-svelte/src/views/EngineeringView.svelte
+++ b/gui-svelte/src/views/EngineeringView.svelte
@@ -1,46 +1,134 @@
 <script lang="ts">
-  const VIEW_NAME = "Engineering";
+  import { tier } from "../lib/stores/tier.js";
+
+  import ThermalDisplay from "../components/engineering/ThermalDisplay.svelte";
+  import EngineeringControlPanel from "../components/engineering/EngineeringControlPanel.svelte";
+  import SubsystemStatus from "../components/engineering/SubsystemStatus.svelte";
+  import PowerDrawDisplay from "../components/engineering/PowerDrawDisplay.svelte";
+  import PowerAllocationPanel from "../components/engineering/PowerAllocationPanel.svelte";
+  import SystemToggles from "../components/engineering/SystemToggles.svelte";
+
+  import EventLog from "../components/shared/EventLog.svelte";
+  import ReactorBalanceGame from "../components/games/ReactorBalanceGame.svelte";
+  import RadiatorDeployGame from "../components/games/RadiatorDeployGame.svelte";
+
+  $: manualTier = $tier === "manual";
+  $: rawTier = $tier === "raw";
+  $: arcadeTier = $tier === "arcade";
+  $: cpuAssistTier = $tier === "cpu-assist";
+
+  const ENGINEERING_EVENT_FILTER = [
+    "reactor",
+    "drive",
+    "radiator",
+    "vent",
+    "thermal",
+    "power",
+    "subsystem",
+    "repair",
+    "cascade",
+    "engineering_proposal",
+  ];
 </script>
 
-<div class="view-root">
-  <div class="stub-content">
-    <div class="stub-title">{VIEW_NAME}</div>
-    <div class="stub-hint">Implementation in progress — Prompt 3+</div>
-  </div>
+<div class="engineering-root" class:arcade={arcadeTier} class:manual={manualTier} class:cpu={cpuAssistTier}>
+  <section class="column thermal">
+    <div class="column-title">Thermal &amp; Drive</div>
+    <ThermalDisplay />
+    {#if arcadeTier}
+      <ReactorBalanceGame />
+      <RadiatorDeployGame />
+    {/if}
+    <EngineeringControlPanel />
+  </section>
+
+  <section class="column power">
+    <div class="column-title">Power</div>
+    <PowerDrawDisplay />
+    <PowerAllocationPanel />
+  </section>
+
+  <section class="column systems">
+    <div class="column-title">Systems</div>
+    <SubsystemStatus />
+    <SystemToggles />
+  </section>
+
+  <section class="column monitoring">
+    <div class="column-title">Monitoring</div>
+    <EventLog title="Engineering Log" domain="power" filter={ENGINEERING_EVENT_FILTER} priority={cpuAssistTier ? "primary" : "secondary"} />
+  </section>
 </div>
 
 <style>
-  .view-root {
+  .engineering-root {
     width: 100%;
     height: 100%;
     display: grid;
-    grid-template-columns: repeat(12, 1fr);
+    grid-template-columns: minmax(340px, 1.2fr) minmax(290px, 1fr) minmax(280px, 0.95fr) minmax(280px, 0.95fr);
     gap: var(--space-xs);
     padding: var(--space-xs);
     overflow: hidden;
   }
-  .stub-content {
-    grid-column: 1 / -1;
+
+  .engineering-root.arcade {
+    grid-template-columns: minmax(360px, 1.35fr) minmax(260px, 0.9fr) minmax(250px, 0.85fr) minmax(250px, 0.85fr);
+  }
+
+  .engineering-root.cpu {
+    grid-template-columns: minmax(360px, 1.25fr) minmax(280px, 0.95fr) minmax(260px, 0.9fr) minmax(280px, 0.95fr);
+  }
+
+  .engineering-root.manual {
+    grid-template-columns: minmax(360px, 1.25fr) minmax(320px, 1fr) minmax(280px, 0.95fr) minmax(280px, 0.95fr);
+  }
+
+  .column {
+    min-height: 0;
+    overflow: auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    gap: var(--space-sm);
+    gap: var(--space-xs);
+    padding-right: 2px;
   }
-  .stub-title {
+
+  .column-title {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    padding: 6px 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.12), transparent 60%), var(--bg-panel);
     font-family: var(--font-mono);
-    font-size: 1.4rem;
-    font-weight: 700;
-    letter-spacing: 4px;
-    color: var(--tier-accent, var(--hud-primary));
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    opacity: 0.6;
-  }
-  .stub-hint {
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
     color: var(--text-secondary);
-    letter-spacing: 1px;
+  }
+
+  @media (max-width: 1420px) {
+    .engineering-root,
+    .engineering-root.arcade,
+    .engineering-root.cpu,
+    .engineering-root.manual {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-auto-rows: minmax(0, 1fr);
+    }
+  }
+
+  @media (max-width: 860px) {
+    .engineering-root,
+    .engineering-root.arcade,
+    .engineering-root.cpu,
+    .engineering-root.manual {
+      grid-template-columns: 1fr;
+      height: auto;
+      overflow: auto;
+    }
+
+    .column {
+      overflow: visible;
+    }
   }
 </style>

--- a/gui-svelte/src/views/FleetView.svelte
+++ b/gui-svelte/src/views/FleetView.svelte
@@ -1,46 +1,95 @@
 <script lang="ts">
-  const VIEW_NAME = "Fleet";
+  import { tier } from "../lib/stores/tier.js";
+
+  import FleetTacticalDisplay from "../components/fleet/FleetTacticalDisplay.svelte";
+  import FleetRoster from "../components/fleet/FleetRoster.svelte";
+  import FormationControl from "../components/fleet/FormationControl.svelte";
+  import FleetOrders from "../components/fleet/FleetOrders.svelte";
+  import FleetFireControl from "../components/fleet/FleetFireControl.svelte";
+  import SharedContacts from "../components/fleet/SharedContacts.svelte";
+  import FleetFormationGame from "../components/games/FleetFormationGame.svelte";
+
+  $: arcadeTier = $tier === "arcade";
 </script>
 
-<div class="view-root">
-  <div class="stub-content">
-    <div class="stub-title">{VIEW_NAME}</div>
-    <div class="stub-hint">Implementation in progress — Prompt 3+</div>
-  </div>
+<div class="fleet-root" class:arcade={arcadeTier}>
+  <section class="group tactical">
+    <div class="group-title">Tactical</div>
+    <FleetTacticalDisplay />
+    <FleetRoster />
+  </section>
+
+  <section class="group formation">
+    <div class="group-title">Formation</div>
+    <FormationControl />
+    {#if arcadeTier}
+      <FleetFormationGame />
+    {/if}
+  </section>
+
+  <section class="group orders">
+    <div class="group-title">Orders</div>
+    <FleetOrders />
+    <SharedContacts />
+  </section>
+
+  <section class="group fire">
+    <div class="group-title">Fire Control</div>
+    <FleetFireControl />
+  </section>
 </div>
 
 <style>
-  .view-root {
+  .fleet-root {
     width: 100%;
     height: 100%;
     display: grid;
-    grid-template-columns: repeat(12, 1fr);
+    grid-template-columns: minmax(360px, 1.3fr) minmax(280px, 0.95fr) minmax(320px, 1fr) minmax(260px, 0.85fr);
     gap: var(--space-xs);
     padding: var(--space-xs);
     overflow: hidden;
   }
-  .stub-content {
-    grid-column: 1 / -1;
+
+  .group {
+    min-height: 0;
+    overflow: auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    gap: var(--space-sm);
+    gap: var(--space-xs);
+    padding-right: 2px;
   }
-  .stub-title {
+
+  .group-title {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    padding: 6px 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.12), transparent 60%), var(--bg-panel);
     font-family: var(--font-mono);
-    font-size: 1.4rem;
-    font-weight: 700;
-    letter-spacing: 4px;
-    color: var(--tier-accent, var(--hud-primary));
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    opacity: 0.6;
-  }
-  .stub-hint {
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
     color: var(--text-secondary);
-    letter-spacing: 1px;
+  }
+
+  @media (max-width: 1320px) {
+    .fleet-root {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-auto-rows: minmax(0, 1fr);
+    }
+  }
+
+  @media (max-width: 820px) {
+    .fleet-root {
+      grid-template-columns: 1fr;
+      height: auto;
+      overflow: auto;
+    }
+
+    .group {
+      overflow: visible;
+    }
   }
 </style>

--- a/gui-svelte/src/views/HelmView.svelte
+++ b/gui-svelte/src/views/HelmView.svelte
@@ -1,46 +1,170 @@
 <script lang="ts">
-  const VIEW_NAME = "Helm";
+  import { tier } from "../lib/stores/tier.js";
+
+  import HelmWorkflowStrip from "../components/helm/HelmWorkflowStrip.svelte";
+  import FlightDataPanel from "../components/helm/FlightDataPanel.svelte";
+  import AutopilotStatus from "../components/helm/AutopilotStatus.svelte";
+  import FlightComputerPanel from "../components/helm/FlightComputerPanel.svelte";
+  import ManualFlightPanel from "../components/helm/ManualFlightPanel.svelte";
+  import RcsControls from "../components/helm/RcsControls.svelte";
+  import RcsThrusterDisplay from "../components/helm/RcsThrusterDisplay.svelte";
+  import HelmQueuePanel from "../components/helm/HelmQueuePanel.svelte";
+  import DockingPanel from "../components/helm/DockingPanel.svelte";
+  import ManeuverPlanner from "../components/helm/ManeuverPlanner.svelte";
+  import HelmBalanceGame from "../components/games/HelmBalanceGame.svelte";
+
+  $: manualTier = $tier === "manual";
+  $: rawTier = $tier === "raw";
+  $: arcadeTier = $tier === "arcade";
+  $: cpuAssistTier = $tier === "cpu-assist";
 </script>
 
-<div class="view-root">
-  <div class="stub-content">
-    <div class="stub-title">{VIEW_NAME}</div>
-    <div class="stub-hint">Implementation in progress — Prompt 3+</div>
+<div class="helm-root" class:manual={manualTier} class:arcade={arcadeTier} class:cpu={cpuAssistTier}>
+  <div class="workflow-slot">
+    <HelmWorkflowStrip />
   </div>
+
+  <section class="column awareness">
+    <div class="column-title">Awareness</div>
+    <FlightDataPanel />
+    {#if arcadeTier}
+      <HelmBalanceGame />
+    {/if}
+    <RcsThrusterDisplay />
+    {#if rawTier}
+      <ManeuverPlanner />
+    {/if}
+  </section>
+
+  <section class="column command">
+    <div class="column-title">Command</div>
+
+    {#if manualTier}
+      <div class="prominent">
+        <ManualFlightPanel />
+      </div>
+      <ManeuverPlanner />
+    {:else if arcadeTier}
+      <div class="prominent">
+        <FlightComputerPanel />
+      </div>
+      <ManualFlightPanel />
+      <RcsControls />
+    {:else if cpuAssistTier}
+      <FlightComputerPanel />
+    {:else}
+      <FlightComputerPanel />
+      <ManualFlightPanel />
+      <RcsControls />
+      <ManeuverPlanner />
+    {/if}
+  </section>
+
+  <section class="column status">
+    <div class="column-title">Status</div>
+
+    {#if cpuAssistTier}
+      <div class="prominent">
+        <AutopilotStatus />
+      </div>
+    {:else}
+      <AutopilotStatus />
+    {/if}
+
+    <HelmQueuePanel />
+    <DockingPanel />
+  </section>
 </div>
 
 <style>
-  .view-root {
+  .helm-root {
     width: 100%;
     height: 100%;
     display: grid;
-    grid-template-columns: repeat(12, 1fr);
+    grid-template-columns: minmax(270px, 0.9fr) minmax(340px, 1.2fr) minmax(270px, 0.95fr);
+    grid-template-rows: auto minmax(0, 1fr);
     gap: var(--space-xs);
     padding: var(--space-xs);
     overflow: hidden;
   }
-  .stub-content {
+
+  .helm-root.manual {
+    grid-template-columns: minmax(250px, 0.8fr) minmax(420px, 1.45fr) minmax(250px, 0.85fr);
+  }
+
+  .helm-root.cpu {
+    grid-template-columns: minmax(260px, 0.9fr) minmax(320px, 1fr) minmax(340px, 1.2fr);
+  }
+
+  .workflow-slot {
     grid-column: 1 / -1;
+    min-width: 0;
+  }
+
+  .column {
+    min-height: 0;
+    overflow: auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    gap: var(--space-sm);
+    gap: var(--space-xs);
+    padding-right: 2px;
   }
-  .stub-title {
+
+  .column-title {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    padding: 6px 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.12), transparent 60%), var(--bg-panel);
     font-family: var(--font-mono);
-    font-size: 1.4rem;
-    font-weight: 700;
-    letter-spacing: 4px;
-    color: var(--tier-accent, var(--hud-primary));
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    opacity: 0.6;
-  }
-  .stub-hint {
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
     color: var(--text-secondary);
-    letter-spacing: 1px;
+  }
+
+  .prominent {
+    flex: 1 0 auto;
+  }
+
+  .prominent :global(.panel) {
+    height: 100%;
+  }
+
+  @media (max-width: 1180px) {
+    .helm-root,
+    .helm-root.manual,
+    .helm-root.cpu {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-rows: auto auto minmax(0, 1fr);
+    }
+
+    .awareness {
+      grid-column: 1;
+    }
+
+    .command {
+      grid-column: 2;
+    }
+
+    .status {
+      grid-column: 1 / -1;
+    }
+  }
+
+  @media (max-width: 780px) {
+    .helm-root,
+    .helm-root.manual,
+    .helm-root.cpu {
+      grid-template-columns: 1fr;
+      grid-template-rows: auto;
+      overflow: auto;
+    }
+
+    .column {
+      overflow: visible;
+    }
   }
 </style>

--- a/gui-svelte/src/views/MissionView.svelte
+++ b/gui-svelte/src/views/MissionView.svelte
@@ -1,46 +1,261 @@
 <script lang="ts">
-  const VIEW_NAME = "Mission";
+  import { onMount, onDestroy } from "svelte";
+  import { wsClient } from "../lib/ws/wsClient.js";
+  import Panel from "../components/layout/Panel.svelte";
+  import ScenarioLoader from "../components/mission/ScenarioLoader.svelte";
+  import MissionObjectives from "../components/mission/MissionObjectives.svelte";
+  import CampaignHub from "../components/mission/CampaignHub.svelte";
+  import CommandPrompt from "../components/mission/CommandPrompt.svelte";
+
+  // Game state: "lobby" | "playing" | "ended"
+  type GamePhase = "lobby" | "playing" | "ended";
+  let phase: GamePhase = "lobby";
+
+  // Reference to ScenarioLoader so we can call showPostMission()
+  let loaderRef: ScenarioLoader | undefined;
+
+  // Which in-game panel is active
+  let activePanel: "objectives" | "campaign" | "console" = "objectives";
+
+  // ── Event wiring ─────────────────────────────────────────────────
+  function onScenarioLoaded(e: Event) {
+    const detail = (e as CustomEvent<Record<string, unknown>>).detail;
+    // station claim or started flag → transition to playing
+    if (detail?.station || detail?.started || detail?.assignedShip) {
+      phase = "playing";
+    } else if (detail?.ship_id || detail?.scenario) {
+      // scenario loaded but not yet in lobby-to-playing transition — stay in lobby
+      // (ScenarioLoader transitions to lobby screen internally)
+    }
+  }
+
+  function onMissionEnd(e: Event) {
+    const detail = (e as CustomEvent<{ status?: string }>).detail;
+    if (detail?.status === "success" || detail?.status === "failure") {
+      phase = "ended";
+      loaderRef?.showPostMission();
+    }
+  }
+
+  function onNextMission() {
+    phase = "lobby";
+    // ScenarioLoader will handle the state internally
+  }
+
+  let missionEndHandler: ((e: Event) => void) | null = null;
+  let scenarioLoadedHandler: ((e: Event) => void) | null = null;
+  let nextMissionHandler: ((e: Event) => void) | null = null;
+  let missionPollGen = 0;
+
+  async function pollForMissionEnd(gen: number) {
+    if (gen !== missionPollGen || phase !== "playing") return;
+    try {
+      const resp = await wsClient.send("get_mission", {}) as { ok?: boolean; mission?: { mission_status?: string; status?: string } };
+      if (gen !== missionPollGen) return;
+      const status = resp?.mission?.mission_status ?? resp?.mission?.status;
+      if (status === "success" || status === "failure") {
+        phase = "ended";
+        loaderRef?.showPostMission();
+        return; // stop polling
+      }
+    } catch { /* skip */ }
+    if (gen === missionPollGen) setTimeout(() => pollForMissionEnd(gen), 3000);
+  }
+
+  $: if (phase === "playing") {
+    missionPollGen++;
+    pollForMissionEnd(missionPollGen);
+  } else {
+    missionPollGen++; // cancel any running poll
+  }
+
+  onMount(() => {
+    scenarioLoadedHandler = onScenarioLoaded;
+    document.addEventListener("scenario-loaded", scenarioLoadedHandler);
+
+    missionEndHandler = onMissionEnd;
+    document.addEventListener("mission_complete", missionEndHandler);
+
+    nextMissionHandler = () => onNextMission();
+    document.addEventListener("next-mission", nextMissionHandler);
+  });
+
+  onDestroy(() => {
+    missionPollGen++;
+    if (scenarioLoadedHandler) document.removeEventListener("scenario-loaded", scenarioLoadedHandler);
+    if (missionEndHandler) document.removeEventListener("mission_complete", missionEndHandler);
+    if (nextMissionHandler) document.removeEventListener("next-mission", nextMissionHandler);
+  });
 </script>
 
-<div class="view-root">
-  <div class="stub-content">
-    <div class="stub-title">{VIEW_NAME}</div>
-    <div class="stub-hint">Implementation in progress — Prompt 3+</div>
-  </div>
+<div class="mission-view">
+  {#if phase === "lobby" || phase === "ended"}
+    <!-- ── Full-screen scenario loader ── -->
+    <div class="loader-fullscreen">
+      <ScenarioLoader
+        bind:this={loaderRef}
+        on:scenario-loaded={(e) => onScenarioLoaded(e)}
+        on:next-mission={() => onNextMission()}
+      />
+    </div>
+
+  {:else if phase === "playing"}
+    <!-- ── In-mission layout ── -->
+    <div class="playing-layout">
+      <!-- Left: compact scenario loader (collapsed) -->
+      <div class="loader-sidebar">
+        <Panel title="Mission Select" domain="nav" priority="tertiary" collapsible={true}>
+          <div class="loader-collapsed-wrap">
+            <ScenarioLoader
+              bind:this={loaderRef}
+              on:scenario-loaded={(e) => onScenarioLoaded(e)}
+              on:next-mission={() => onNextMission()}
+            />
+          </div>
+        </Panel>
+      </div>
+
+      <!-- Right: in-mission panels -->
+      <div class="mission-panels">
+        <!-- Panel tabs -->
+        <div class="panel-tabs" role="tablist">
+          <button
+            class="tab-btn"
+            class:active={activePanel === "objectives"}
+            role="tab"
+            aria-selected={activePanel === "objectives"}
+            on:click={() => activePanel = "objectives"}
+          >OBJECTIVES</button>
+          <button
+            class="tab-btn"
+            class:active={activePanel === "campaign"}
+            role="tab"
+            aria-selected={activePanel === "campaign"}
+            on:click={() => activePanel = "campaign"}
+          >CAMPAIGN</button>
+          <button
+            class="tab-btn"
+            class:active={activePanel === "console"}
+            role="tab"
+            aria-selected={activePanel === "console"}
+            on:click={() => activePanel = "console"}
+          >CONSOLE</button>
+        </div>
+
+        <div class="panel-body">
+          {#if activePanel === "objectives"}
+            <Panel title="Mission Objectives" domain="nav" priority="primary" collapsible={false}>
+              <MissionObjectives />
+            </Panel>
+          {:else if activePanel === "campaign"}
+            <Panel title="Campaign" domain="comms" priority="secondary" collapsible={false}>
+              <CampaignHub />
+            </Panel>
+          {:else if activePanel === "console"}
+            <Panel title="Command Console" domain="" priority="tertiary" collapsible={false}>
+              <CommandPrompt />
+            </Panel>
+          {/if}
+        </div>
+      </div>
+    </div>
+  {/if}
 </div>
 
 <style>
-  .view-root {
+  .mission-view {
     width: 100%;
     height: 100%;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ── Full-screen loader (lobby / ended) ── */
+  .loader-fullscreen {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  /* ── Playing layout ── */
+  .playing-layout {
     display: grid;
-    grid-template-columns: repeat(12, 1fr);
+    grid-template-columns: 340px 1fr;
     gap: var(--space-xs);
+    height: 100%;
     padding: var(--space-xs);
     overflow: hidden;
   }
-  .stub-content {
-    grid-column: 1 / -1;
+
+  .loader-sidebar {
+    overflow-y: auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    gap: var(--space-sm);
+    gap: var(--space-xs);
   }
-  .stub-title {
-    font-family: var(--font-mono);
-    font-size: 1.4rem;
-    font-weight: 700;
-    letter-spacing: 4px;
-    color: var(--tier-accent, var(--hud-primary));
-    text-transform: uppercase;
-    opacity: 0.6;
+
+  .loader-collapsed-wrap {
+    max-height: 300px;
+    overflow-y: auto;
   }
-  .stub-hint {
+
+  .mission-panels {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    overflow: hidden;
+  }
+
+  /* ── Tabs ── */
+  .panel-tabs {
+    display: flex;
+    gap: 2px;
+    background: var(--bg-void);
+    padding: 2px;
+    border-radius: var(--radius-sm);
+    flex-shrink: 0;
+  }
+
+  .tab-btn {
+    flex: 1;
+    padding: 5px 12px;
+    background: transparent;
+    border: none;
+    border-radius: calc(var(--radius-sm) - 1px);
+    color: var(--text-secondary);
     font-family: var(--font-mono);
     font-size: var(--font-size-xs);
-    color: var(--text-secondary);
-    letter-spacing: 1px;
+    font-weight: 600;
+    cursor: pointer;
+    letter-spacing: 0.5px;
+    transition: all var(--transition-fast);
+    text-transform: uppercase;
+  }
+
+  .tab-btn.active {
+    background: var(--tier-accent, var(--hud-primary));
+    color: #0a0a0f;
+  }
+
+  .tab-btn:hover:not(.active) {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  /* ── Panel body ── */
+  .panel-body {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .panel-body :global(.panel) {
+    flex: 1;
+    min-height: 0;
+  }
+
+  .panel-body :global(.panel-body) {
+    overflow-y: auto;
   }
 </style>

--- a/gui-svelte/src/views/OpsView.svelte
+++ b/gui-svelte/src/views/OpsView.svelte
@@ -1,46 +1,131 @@
 <script lang="ts">
-  const VIEW_NAME = "Ops";
+  import { tier } from "../lib/stores/tier.js";
+
+  import ShipStatus from "../components/ops/ShipStatus.svelte";
+  import OpsControlPanel from "../components/ops/OpsControlPanel.svelte";
+  import PowerProfileSelector from "../components/ops/PowerProfileSelector.svelte";
+  import CrewPanel from "../components/ops/CrewPanel.svelte";
+  import CrewRosterPanel from "../components/ops/CrewRosterPanel.svelte";
+  import CrewFatigueDisplay from "../components/ops/CrewFatigueDisplay.svelte";
+  import BoardingPanel from "../components/ops/BoardingPanel.svelte";
+  import DroneControlPanel from "../components/ops/DroneControlPanel.svelte";
+
+  import SubsystemStatus from "../components/engineering/SubsystemStatus.svelte";
+  import DamageControlGame from "../components/games/DamageControlGame.svelte";
+
+  $: manualTier = $tier === "manual";
+  $: rawTier = $tier === "raw";
+  $: arcadeTier = $tier === "arcade";
+  $: cpuAssistTier = $tier === "cpu-assist";
 </script>
 
-<div class="view-root">
-  <div class="stub-content">
-    <div class="stub-title">{VIEW_NAME}</div>
-    <div class="stub-hint">Implementation in progress — Prompt 3+</div>
-  </div>
+<div class="ops-root" class:arcade={arcadeTier} class:manual={manualTier} class:cpu={cpuAssistTier}>
+  <section class="group damage">
+    <div class="group-title">Damage Control</div>
+    <ShipStatus />
+    <SubsystemStatus />
+    {#if arcadeTier}
+      <DamageControlGame />
+    {/if}
+    <OpsControlPanel />
+  </section>
+
+  <section class="group power">
+    <div class="group-title">Power</div>
+    <PowerProfileSelector />
+  </section>
+
+  <section class="group crew">
+    <div class="group-title">Crew</div>
+    <CrewFatigueDisplay />
+    <CrewPanel />
+    {#if manualTier || rawTier}
+      <CrewRosterPanel />
+    {/if}
+  </section>
+
+  <section class="group boarding">
+    <div class="group-title">Boarding</div>
+    <BoardingPanel />
+  </section>
+
+  <section class="group drones">
+    <div class="group-title">Drones</div>
+    <DroneControlPanel />
+  </section>
 </div>
 
 <style>
-  .view-root {
+  .ops-root {
     width: 100%;
     height: 100%;
     display: grid;
-    grid-template-columns: repeat(12, 1fr);
+    grid-template-columns: minmax(320px, 1.2fr) minmax(260px, 0.85fr) minmax(300px, 1.05fr) minmax(260px, 0.9fr) minmax(260px, 0.9fr);
     gap: var(--space-xs);
     padding: var(--space-xs);
     overflow: hidden;
   }
-  .stub-content {
-    grid-column: 1 / -1;
+
+  .ops-root.arcade {
+    grid-template-columns: minmax(340px, 1.3fr) minmax(240px, 0.8fr) minmax(280px, 1fr) minmax(250px, 0.85fr) minmax(250px, 0.85fr);
+  }
+
+  .ops-root.cpu {
+    grid-template-columns: minmax(330px, 1.2fr) minmax(250px, 0.85fr) minmax(300px, 1fr) minmax(250px, 0.85fr) minmax(250px, 0.85fr);
+  }
+
+  .group {
+    min-height: 0;
+    overflow: auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    gap: var(--space-sm);
+    gap: var(--space-xs);
+    padding-right: 2px;
   }
-  .stub-title {
+
+  .group-title {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    padding: 6px 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.12), transparent 60%), var(--bg-panel);
     font-family: var(--font-mono);
-    font-size: 1.4rem;
-    font-weight: 700;
-    letter-spacing: 4px;
-    color: var(--tier-accent, var(--hud-primary));
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    opacity: 0.6;
-  }
-  .stub-hint {
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
     color: var(--text-secondary);
-    letter-spacing: 1px;
+  }
+
+  @media (max-width: 1500px) {
+    .ops-root,
+    .ops-root.arcade,
+    .ops-root.cpu {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-auto-rows: minmax(0, 1fr);
+    }
+  }
+
+  @media (max-width: 1080px) {
+    .ops-root,
+    .ops-root.arcade,
+    .ops-root.cpu {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      height: auto;
+      overflow: auto;
+    }
+
+    .group {
+      overflow: visible;
+    }
+  }
+
+  @media (max-width: 760px) {
+    .ops-root,
+    .ops-root.arcade,
+    .ops-root.cpu {
+      grid-template-columns: 1fr;
+    }
   }
 </style>

--- a/gui-svelte/src/views/ScienceView.svelte
+++ b/gui-svelte/src/views/ScienceView.svelte
@@ -1,46 +1,83 @@
 <script lang="ts">
-  const VIEW_NAME = "Science";
+  import { tier } from "../lib/stores/tier.js";
+
+  import SensorContacts from "../components/tactical/SensorContacts.svelte";
+  import ScienceAnalysisPanel from "../components/science/ScienceAnalysisPanel.svelte";
+  import SensorAnalysisManual from "../components/science/SensorAnalysisManual.svelte";
+  import SpectralAnalysisGame from "../components/games/SpectralAnalysisGame.svelte";
+  import MassEstimationGame from "../components/games/MassEstimationGame.svelte";
+
+  $: manualTier = $tier === "manual";
+  $: rawTier = $tier === "raw";
+  $: arcadeTier = $tier === "arcade";
 </script>
 
-<div class="view-root">
-  <div class="stub-content">
-    <div class="stub-title">{VIEW_NAME}</div>
-    <div class="stub-hint">Implementation in progress — Prompt 3+</div>
-  </div>
+<div class="science-root" class:arcade={arcadeTier}>
+  <section class="group sensors">
+    <div class="group-title">Sensors</div>
+    <SensorContacts passive />
+    {#if manualTier || rawTier}
+      <SensorAnalysisManual />
+    {:else if arcadeTier}
+      <SpectralAnalysisGame />
+      <MassEstimationGame />
+    {/if}
+  </section>
+
+  <section class="group analysis">
+    <div class="group-title">Analysis</div>
+    <ScienceAnalysisPanel />
+    {#if arcadeTier}
+      <SpectralAnalysisGame />
+      <MassEstimationGame />
+    {/if}
+  </section>
 </div>
 
 <style>
-  .view-root {
+  .science-root {
     width: 100%;
     height: 100%;
     display: grid;
-    grid-template-columns: repeat(12, 1fr);
+    grid-template-columns: minmax(340px, 1fr) minmax(360px, 1.1fr);
     gap: var(--space-xs);
     padding: var(--space-xs);
     overflow: hidden;
   }
-  .stub-content {
-    grid-column: 1 / -1;
+
+  .group {
+    min-height: 0;
+    overflow: auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    gap: var(--space-sm);
+    gap: var(--space-xs);
+    padding-right: 2px;
   }
-  .stub-title {
+
+  .group-title {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    padding: 6px 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.12), transparent 60%), var(--bg-panel);
     font-family: var(--font-mono);
-    font-size: 1.4rem;
-    font-weight: 700;
-    letter-spacing: 4px;
-    color: var(--tier-accent, var(--hud-primary));
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    opacity: 0.6;
-  }
-  .stub-hint {
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
     color: var(--text-secondary);
-    letter-spacing: 1px;
+  }
+
+  @media (max-width: 960px) {
+    .science-root {
+      grid-template-columns: 1fr;
+      height: auto;
+      overflow: auto;
+    }
+
+    .group {
+      overflow: visible;
+    }
   }
 </style>

--- a/gui-svelte/src/views/TacticalView.svelte
+++ b/gui-svelte/src/views/TacticalView.svelte
@@ -1,46 +1,169 @@
 <script lang="ts">
-  const VIEW_NAME = "Tactical";
+  import { tier } from "../lib/stores/tier.js";
+
+  import SensorContacts from "../components/tactical/SensorContacts.svelte";
+  import TacticalMap from "../components/tactical/TacticalMap.svelte";
+  import TargetingDisplay from "../components/tactical/TargetingDisplay.svelte";
+  import FiringSolutionDisplay from "../components/tactical/FiringSolutionDisplay.svelte";
+  import SubsystemSelector from "../components/tactical/SubsystemSelector.svelte";
+  import ThreatBoard from "../components/tactical/ThreatBoard.svelte";
+  import WeaponsStatus from "../components/tactical/WeaponsStatus.svelte";
+  import FireAuthorization from "../components/tactical/FireAuthorization.svelte";
+  import RailgunControl from "../components/tactical/RailgunControl.svelte";
+  import PdcControl from "../components/tactical/PdcControl.svelte";
+  import LauncherControl from "../components/tactical/LauncherControl.svelte";
+  import EcmControlPanel from "../components/tactical/EcmControlPanel.svelte";
+  import EccmControlPanel from "../components/tactical/EccmControlPanel.svelte";
+  import MultiTrackPanel from "../components/tactical/MultiTrackPanel.svelte";
+  import CombatLog from "../components/tactical/CombatLog.svelte";
+  import TargetAssessment from "../components/tactical/TargetAssessment.svelte";
+
+  import SensorSweepGame from "../components/games/SensorSweepGame.svelte";
+  import TargetingLockGame from "../components/games/TargetingLockGame.svelte";
+  import WeaponsChargeGame from "../components/games/WeaponsChargeGame.svelte";
+  import PdcThreatGame from "../components/games/PdcThreatGame.svelte";
+  import EcmFrequencyGame from "../components/games/EcmFrequencyGame.svelte";
+  import MunitionConfigGame from "../components/games/MunitionConfigGame.svelte";
+  import MunitionProgrammingPanel from "../components/games/MunitionProgrammingPanel.svelte";
+
+  $: manualTier = $tier === "manual";
+  $: rawTier = $tier === "raw";
+  $: arcadeTier = $tier === "arcade";
+  $: cpuAssistTier = $tier === "cpu-assist";
 </script>
 
-<div class="view-root">
-  <div class="stub-content">
-    <div class="stub-title">{VIEW_NAME}</div>
-    <div class="stub-hint">Implementation in progress — Prompt 3+</div>
-  </div>
+<div class="tactical-root" class:arcade={arcadeTier} class:manual={manualTier} class:cpu={cpuAssistTier}>
+  <section class="group detect">
+    <div class="group-title">Detect</div>
+    <TacticalMap />
+    <SensorContacts />
+    {#if arcadeTier}
+      <SensorSweepGame />
+    {/if}
+  </section>
+
+  <section class="group decide">
+    <div class="group-title">Decide</div>
+    <TargetingDisplay />
+    <FiringSolutionDisplay />
+    <SubsystemSelector />
+    <MultiTrackPanel />
+    {#if arcadeTier}
+      <TargetingLockGame />
+    {/if}
+  </section>
+
+  <section class="group destroy">
+    <div class="group-title">Destroy</div>
+    <FireAuthorization />
+    {#if arcadeTier}
+      <WeaponsChargeGame />
+      <MunitionConfigGame />
+      <PdcThreatGame />
+    {:else if cpuAssistTier}
+      <LauncherControl />
+    {:else}
+      <RailgunControl />
+      <PdcControl />
+      <LauncherControl />
+      {#if manualTier}
+        <MunitionProgrammingPanel />
+      {/if}
+    {/if}
+  </section>
+
+  <section class="group awareness">
+    <div class="group-title">Awareness</div>
+    <ThreatBoard />
+    <WeaponsStatus />
+    <TargetAssessment />
+    <EcmControlPanel />
+    <EccmControlPanel />
+    {#if arcadeTier}
+      <EcmFrequencyGame />
+    {/if}
+  </section>
+
+  <section class="group aftermath">
+    <div class="group-title">After-Action</div>
+    <CombatLog />
+    {#if cpuAssistTier}
+      <SensorContacts passive />
+    {/if}
+  </section>
 </div>
 
 <style>
-  .view-root {
+  .tactical-root {
     width: 100%;
     height: 100%;
     display: grid;
-    grid-template-columns: repeat(12, 1fr);
+    grid-template-columns: minmax(320px, 1.25fr) minmax(260px, 0.95fr) minmax(280px, 1fr) minmax(250px, 0.9fr) minmax(260px, 0.95fr);
     gap: var(--space-xs);
     padding: var(--space-xs);
     overflow: hidden;
   }
-  .stub-content {
-    grid-column: 1 / -1;
+
+  .tactical-root.arcade {
+    grid-template-columns: minmax(300px, 1.15fr) minmax(250px, 0.9fr) minmax(300px, 1.05fr) minmax(240px, 0.85fr) minmax(240px, 0.85fr);
+  }
+
+  .tactical-root.cpu {
+    grid-template-columns: minmax(300px, 1.1fr) minmax(280px, 0.95fr) minmax(320px, 1.1fr) minmax(260px, 0.9fr) minmax(260px, 0.9fr);
+  }
+
+  .group {
+    min-height: 0;
+    overflow: auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    gap: var(--space-sm);
+    gap: var(--space-xs);
+    padding-right: 2px;
   }
-  .stub-title {
+
+  .group-title {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    padding: 6px 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.12), transparent 60%), var(--bg-panel);
     font-family: var(--font-mono);
-    font-size: 1.4rem;
-    font-weight: 700;
-    letter-spacing: 4px;
-    color: var(--tier-accent, var(--hud-primary));
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    opacity: 0.6;
-  }
-  .stub-hint {
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
     color: var(--text-secondary);
-    letter-spacing: 1px;
+  }
+
+  @media (max-width: 1500px) {
+    .tactical-root,
+    .tactical-root.arcade,
+    .tactical-root.cpu {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-auto-rows: minmax(0, 1fr);
+    }
+  }
+
+  @media (max-width: 1080px) {
+    .tactical-root,
+    .tactical-root.arcade,
+    .tactical-root.cpu {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      height: auto;
+      overflow: auto;
+    }
+
+    .group {
+      overflow: visible;
+    }
+  }
+
+  @media (max-width: 760px) {
+    .tactical-root,
+    .tactical-root.arcade,
+    .tactical-root.cpu {
+      grid-template-columns: 1fr;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary

- **Helm** (Prompt 3): FlightDataPanel, FlightComputerPanel, AutopilotStatus, ManualFlightPanel, RcsControls, RcsThrusterDisplay, HelmQueuePanel, DockingPanel, ManeuverPlanner, HelmWorkflowStrip; HelmBalanceGame arcade mini-game; full HelmView with 3-col tier-adaptive layout
- **Tactical** (Prompt 4): SensorContacts, TacticalMap (canvas), TargetingDisplay, FiringSolutionDisplay, SubsystemSelector, ThreatBoard, WeaponsStatus, FireAuthorization, RailgunControl, PdcControl, LauncherControl, EcmControlPanel, EccmControlPanel, MultiTrackPanel, CombatLog, TargetAssessment; 7 arcade mini-games; TacticalView
- **Engineering** (Prompt 5): ThermalDisplay, EngineeringControlPanel, SubsystemStatus, PowerDrawDisplay, PowerAllocationPanel, SystemToggles; ReactorBalanceGame + RadiatorDeployGame; EngineeringView
- **Ops** (Prompt 6): ShipStatus, OpsControlPanel, PowerProfileSelector, CrewPanel, CrewRosterPanel, CrewFatigueDisplay, BoardingPanel, DroneControlPanel; DamageControlGame; OpsView
- **Comms / Science / Fleet** (Prompt 7): Full Comms station with choice panel + chat + hail game; Science with spectral analysis + mini-games; Fleet with canvas tactical display + formation control + fire control; CommsView / ScienceView / FleetView
- **Mission** (Prompt 8): ScenarioLoader 5-state machine (TITLE → MISSION_SELECT → QUICK_PLAY → LOBBY → POST_MISSION), MissionObjectives with polling + completion display, CampaignHub, CommandPrompt with history + autocomplete; MissionView with lobby/playing/ended phase switching

## Test plan

- [ ] `python tools/start_gui_stack.py --ui svelte --no-browser` starts without error
- [ ] Open `http://localhost:3100` — Mission view shows Title screen
- [ ] NEW GAME → mission list loads → LAUNCH → transitions to Lobby
- [ ] JOIN GAME → Lobby with ship/station grid shown
- [ ] Switch to Helm view — FlightDataPanel and FlightComputerPanel render
- [ ] Tier switch (ARCADE → MANUAL) changes Helm layout
- [ ] Switch to Tactical — SensorContacts, TacticalMap canvas, weapon controls visible
- [ ] Switch to Engineering — thermal bars, power sliders render
- [ ] Switch to Comms — CommsChoicePanel, StationChat visible
- [ ] Switch to Fleet — canvas tactical display, formation buttons
- [ ] `svelte-check`: 0 errors | `vite build`: ✓ 302 modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)