### PR TITLE
[codex] Resume station UAT with ship wiring and command fixes

### DIFF
--- a/docs/STATION_UAT_WIRING_CHECKLIST.md
+++ b/docs/STATION_UAT_WIRING_CHECKLIST.md
@@ -1,0 +1,157 @@
+# Station UAT Wiring Checklist
+
+This checklist is for resuming UI UAT after station refactors. It is focused on
+deterministic bridge wiring, not balance tuning.
+
+Use it to answer three questions in order:
+
+1. Did the scenario load the correct ship with the correct systems?
+2. Did the client bind to the active player ship and station?
+3. Did the command produce the expected telemetry change?
+
+## Preflight
+
+1. Start the stack in station mode.
+   `python3 tools/start_gui_stack.py --server station`
+2. Open the Svelte GUI.
+3. Open browser devtools and run:
+   `_flaxosDebugState()`
+
+Expected before starting a mission:
+- `ws.isConnected` is `true`
+- `activeShipId` is `null`
+- `blockedCommandTotal` is `0`
+
+## Fast Headless Smoke
+
+Run this before UI UAT:
+
+```bash
+python3 tools/check_station_wiring.py
+```
+
+Expected:
+- `PASS loadout`
+- `PASS manual`
+- `PASS auto`
+- `PASS overall`
+
+If this fails, stop and fix backend/scenario wiring first. UI UAT will not be trustworthy.
+
+## Tutorial 01: Helm Manual + Rendezvous
+
+Scenario:
+- `01_tutorial_intercept.yaml`
+
+Purpose:
+- validate mission load
+- validate active ship binding
+- validate manual thrust
+- validate lock + rendezvous autopilot
+- validate docking flow
+
+Steps:
+1. Load `Tutorial: Intercept and Dock`.
+2. Run `_flaxosDebugState()`.
+3. Confirm:
+   - `activeShipId === "player"`
+   - `shipStateId === "player"`
+   - `blockedCommandTotal === 0`
+4. Switch to Helm.
+5. Use `Ping Sensors`.
+6. Lock the station contact.
+7. In `Flight Computer`, click `RENDEZVOUS`.
+8. Watch `FlightDataPanel` and `AutopilotStatus`.
+9. When inside 5 km, use `DockingPanel` to request docking.
+
+Expected:
+- No generic `Command rejected` message
+- `AutopilotStatus` shows an active program and phase
+- Speed increases above `100 m/s` within roughly 10-15 seconds
+- Range to target trends downward
+- Docking request succeeds inside range/velocity limits
+
+Manual override check:
+1. Disengage autopilot.
+2. In `ManualFlightPanel`, set throttle to `25%`.
+3. Wait 3-5 seconds.
+
+Expected:
+- Velocity magnitude increases
+- No blocked ship commands in `_flaxosDebugState().ws.blockedCommands`
+
+## Tutorial 07: Close Docking Sanity
+
+Scenario:
+- `07_docking_test.yaml`
+
+Purpose:
+- short-range docking validation without a long approach burn
+
+Steps:
+1. Load the scenario.
+2. Confirm `_flaxosDebugState()` still reports the correct ship.
+3. Request docking from the docking panel.
+
+Expected:
+- Docking state transitions: `free -> approaching -> docked`
+
+## Tutorial 02: Tactical Basic Fire
+
+Scenario:
+- `02_combat_destroy.yaml`
+
+Purpose:
+- validate contact lock
+- validate tactical fire controls
+- validate combat telemetry and log feedback
+
+Steps:
+1. Load the scenario.
+2. Ping sensors.
+3. Lock the hostile contact.
+4. Fire one railgun shot.
+5. If available, launch one missile or torpedo.
+
+Expected:
+- Lock quality and solution update in tactical panels
+- Fire buttons send commands without rejection
+- Combat log records the shot/event chain
+
+## MANUAL Tier Pass
+
+Run these in `manual` tier:
+- Tutorial 01: manual throttle, pitch/yaw/roll, then rendezvous
+- Tutorial 02: lock target, fire individual weapons, review combat log
+- Tutorial 07: docking request and undock
+
+Expected:
+- keyboard/manual controls change telemetry
+- per-panel commands change the correct subsystem state
+- no hidden auto-assist is required for success
+
+## RAW Tier Pass
+
+Run these in `raw` tier:
+- Tutorial 01: inspect vectors, heading, delta-v, queue, and exact autopilot data
+- Tutorial 02: inspect firing factors, lock pipeline, subsystem targeting
+- Engineering/Ops: verify exact power and repair telemetry values appear
+
+Expected:
+- raw numeric views update continuously
+- no panel is display-only unless intended by tier rules
+
+## Failure Triage
+
+If a panel appears wired but nothing happens:
+
+1. Check `_flaxosDebugState()`.
+   - `activeShipId` missing means the GUI is not bound to a ship.
+   - `blockedCommandTotal > 0` means ship commands were sent before the active ship was set.
+2. Check the panel feedback text.
+   - The UI should now surface server rejection reasons instead of only `Command rejected`.
+3. Run:
+   `python3 tools/check_station_wiring.py`
+4. If headless passes but GUI fails, the issue is client binding or view wiring.
+5. If headless fails, the issue is scenario/backend command flow.
+

--- a/gui-svelte/src/components/fleet/FleetRoster.svelte
+++ b/gui-svelte/src/components/fleet/FleetRoster.svelte
@@ -52,7 +52,7 @@
     try {
       await wsClient.sendShipCommand("fleet_add_ship", {
         fleet_id: fleetId,
-        target_ship: shipToAdd.trim(),
+        ship: shipToAdd.trim(),
       });
       shipToAdd = "";
       feedback = "Ship added to fleet";

--- a/gui-svelte/src/components/helm/FlightComputerPanel.svelte
+++ b/gui-svelte/src/components/helm/FlightComputerPanel.svelte
@@ -99,6 +99,23 @@
     return sorted[0];
   }
 
+  function describeCommandFailure(resp: {
+    message?: string;
+    error?: string;
+    reason?: string;
+    response?: { message?: string; error?: string; reason?: string };
+  } | null | undefined): string {
+    return String(
+      resp?.message
+      ?? resp?.error
+      ?? resp?.reason
+      ?? resp?.response?.message
+      ?? resp?.response?.error
+      ?? resp?.response?.reason
+      ?? "Command rejected"
+    );
+  }
+
   async function refreshSolutions() {
     if (!canSolve) {
       navSolutions = [];
@@ -124,23 +141,37 @@
     feedback = "";
 
     try {
+      type CmdResp = {
+        ok?: boolean;
+        message?: string;
+        error?: string;
+        reason?: string;
+        response?: { ok?: boolean; message?: string; error?: string; reason?: string };
+      };
+      let resp: CmdResp;
+
       if (program === "hold") {
-        await wsClient.sendShipCommand("autopilot", { enable: true, program: "hold" });
-        feedback = "Hold position engaged";
+        resp = await wsClient.sendShipCommand("autopilot", { enable: true, program: "hold" }) as CmdResp;
       } else {
         if (!activeTargetId) {
           feedback = "Select a target first";
           return;
         }
-
-        await wsClient.sendShipCommand("autopilot", {
+        resp = await wsClient.sendShipCommand("autopilot", {
           enable: true,
           program,
           target: activeTargetId,
           profile,
-        });
-        feedback = `${program.toUpperCase()} engaged`;
+        }) as CmdResp;
       }
+
+      // Surface server-side rejections (returned as resolved { ok: false } not thrown)
+      const serverOk = resp?.ok !== false && resp?.response?.ok !== false;
+      if (!serverOk) {
+        feedback = `Error: ${describeCommandFailure(resp)}`;
+        return;
+      }
+      feedback = program === "hold" ? "Hold position engaged" : `${program.toUpperCase()} engaged`;
     } catch (error) {
       feedback = error instanceof Error ? error.message : "Flight computer command failed";
     } finally {

--- a/gui-svelte/src/components/mission/ScenarioLoader.svelte
+++ b/gui-svelte/src/components/mission/ScenarioLoader.svelte
@@ -36,6 +36,17 @@
 
   interface SkirmishShip { class: string; count?: number; }
 
+  type CommandEnvelope = {
+    ok?: boolean;
+    success?: boolean;
+    message?: string;
+    error?: string;
+    reason?: string;
+    response?: Record<string, unknown>;
+    data?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+
   // ── State ─────────────────────────────────────────────────────────
   let menuState: MenuState = "title";
   let scenarios: Scenario[] = [];
@@ -73,6 +84,29 @@
     tutorial: "TUTORIAL", combat: "COMBAT", stealth: "STEALTH", fleet: "FLEET", campaign: "CAMPAIGN",
   };
   const CATEGORIES = ["all", "tutorial", "combat", "stealth", "fleet", "campaign"];
+
+  function commandSucceeded(resp: CommandEnvelope | null | undefined): boolean {
+    if (!resp) return false;
+    return resp.ok !== false && resp.success !== false;
+  }
+
+  function unwrapCommandData<T extends Record<string, unknown>>(resp: CommandEnvelope | null | undefined): T {
+    const response = resp?.response;
+    if (response && typeof response === "object" && !Array.isArray(response)) {
+      return response as T;
+    }
+
+    const data = resp?.data;
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      return data as T;
+    }
+
+    return (resp ?? {}) as T;
+  }
+
+  function commandError(resp: CommandEnvelope | null | undefined, fallback: string): string {
+    return String(resp?.message ?? resp?.error ?? resp?.reason ?? fallback);
+  }
 
   // ── Derived ───────────────────────────────────────────────────────
   $: filteredScenarios = [...scenarios]
@@ -136,19 +170,22 @@
         try { await wsClient.connect(); } catch { /* continue */ }
       }
 
-      const shipsResp = await wsClient.send("list_ships", {}) as { success?: boolean; data?: { ships: LobbyShip[] } };
-      ships = (shipsResp?.success && shipsResp?.data?.ships) ? shipsResp.data.ships : [];
+      const shipsResp = await wsClient.send("list_ships", {}) as CommandEnvelope;
+      const shipsData = unwrapCommandData<{ ships?: LobbyShip[] }>(shipsResp);
+      ships = commandSucceeded(shipsResp) && Array.isArray(shipsData.ships) ? shipsData.ships : [];
 
-      const statusResp = await wsClient.send("my_status", {}) as { success?: boolean; data?: { station?: string } };
-      isCaptain = !!(statusResp?.success && statusResp?.data?.station === "captain");
+      const statusResp = await wsClient.send("my_status", {}) as CommandEnvelope;
+      const statusData = unwrapCommandData<{ station?: string }>(statusResp);
+      isCaptain = commandSucceeded(statusResp) && statusData.station === "captain";
 
       const stateResp = await wsClient.send("get_state", {}) as { active_scenario?: string };
       activeScenario = stateResp?.active_scenario ?? null;
 
       await Promise.all(ships.map(async (ship) => {
         try {
-          const sResp = await wsClient.send("station_status", { ship: ship.id }) as { success?: boolean; data?: { stations: ShipStation[] } };
-          ship.stations = sResp?.success ? (sResp.data?.stations ?? []) : [];
+          const sResp = await wsClient.send("station_status", { ship: ship.id }) as CommandEnvelope;
+          const stationData = unwrapCommandData<{ stations?: ShipStation[] }>(sResp);
+          ship.stations = commandSucceeded(sResp) ? (stationData.stations ?? []) : [];
         } catch { ship.stations = []; }
       }));
       ships = [...ships]; // trigger reactivity
@@ -175,10 +212,10 @@
         try { await wsClient.connect(); } catch { /* continue */ }
       }
 
-      const resp = await wsClient.send("load_scenario", { scenario: scenarioId }) as Record<string, unknown>;
+      const resp = await wsClient.send("load_scenario", { scenario: scenarioId }) as CommandEnvelope;
 
-      if (resp?.ok === false) {
-        errorMsg = (resp.error as string) ?? "Failed to load scenario.";
+      if (!commandSucceeded(resp)) {
+        errorMsg = commandError(resp, "Failed to load scenario.");
         return;
       }
 
@@ -210,10 +247,10 @@
       };
       if (skirmishTimeLimit) params.time_limit_seconds = skirmishTimeLimit;
 
-      const resp = await wsClient.send("generate_skirmish", params) as Record<string, unknown>;
+      const resp = await wsClient.send("generate_skirmish", params) as CommandEnvelope;
 
-      if (resp?.ok === false) {
-        errorMsg = (resp.error as string) ?? "Skirmish generation failed.";
+      if (!commandSucceeded(resp)) {
+        errorMsg = commandError(resp, "Skirmish generation failed.");
         return;
       }
 
@@ -227,11 +264,11 @@
   async function joinStation(shipId: string, stationName: string) {
     errorMsg = "";
     try {
-      const assignResp = await wsClient.send("assign_ship", { ship: shipId }) as { success?: boolean; message?: string };
-      if (!assignResp?.success) throw new Error(assignResp?.message ?? "assign failed");
+      const assignResp = await wsClient.send("assign_ship", { ship: shipId }) as CommandEnvelope;
+      if (!commandSucceeded(assignResp)) throw new Error(commandError(assignResp, "assign failed"));
 
-      const claimResp = await wsClient.send("claim_station", { station: stationName, ship: shipId }) as { success?: boolean; message?: string };
-      if (!claimResp?.success) throw new Error(claimResp?.message ?? "claim failed");
+      const claimResp = await wsClient.send("claim_station", { station: stationName, ship: shipId }) as CommandEnvelope;
+      if (!commandSucceeded(claimResp)) throw new Error(commandError(claimResp, "claim failed"));
 
       const detail = { assignedShip: shipId, station: stationName };
       dispatch("scenario-loaded", detail);

--- a/gui-svelte/src/components/tactical/LauncherControl.svelte
+++ b/gui-svelte/src/components/tactical/LauncherControl.svelte
@@ -20,11 +20,11 @@
   $: selectedTarget = $selectedTacticalTargetId || lockedTargetId;
 
   async function fire() {
-    const command = $selectedLauncherType === "torpedo" ? "launch_torpedo" : "launch_missile";
-    await wsClient.sendShipCommand(command, {
+    await wsClient.sendShipCommand("launch_salvo", {
+      munition_type: $selectedLauncherType,
       target: selectedTarget || undefined,
+      count: salvoSize,
       profile,
-      salvo_size: salvoSize,
       guidance_mode: guidanceMode,
       warhead_type: warheadType,
     });

--- a/gui-svelte/src/main.ts
+++ b/gui-svelte/src/main.ts
@@ -1,13 +1,29 @@
+import { get } from "svelte/store";
 import { mount } from "svelte";
 import App from "./App.svelte";
+import { gameState } from "./lib/stores/gameState.js";
+import { playerShipId } from "./lib/stores/playerShip.js";
+import { wsClient } from "./lib/ws/wsClient.js";
 
 const app = mount(App, {
   target: document.getElementById("app")!,
 });
 
 // Expose debug helper
-(window as unknown as Record<string, unknown>)._flaxosDebugState = () => ({
-  tier: (window as unknown as Record<string, unknown>).controlTier,
-});
+(window as unknown as Record<string, unknown>)._flaxosDebugState = () => {
+  const state = get(gameState) as Record<string, unknown>;
+  const shipState = (state?.state as Record<string, unknown> | undefined)
+    ?? (state?.ship as Record<string, unknown> | undefined)
+    ?? null;
+
+  return {
+    tier: (window as unknown as Record<string, unknown>).controlTier,
+    activeShipId: get(playerShipId),
+    shipStateId: shipState?.id ?? null,
+    activeScenario: state?.active_scenario ?? null,
+    ws: wsClient.getDiagnostics(),
+    stateKeys: Object.keys(state ?? {}),
+  };
+};
 
 export default app;

--- a/hybrid/ship_class_registry.py
+++ b/hybrid/ship_class_registry.py
@@ -97,11 +97,13 @@ class ShipClassRegistry:
 
         If the ship definition contains a ``ship_class`` field, the class
         template is loaded and the ship definition is deep-merged on top.
+        For backward compatibility, ``class`` is also accepted as a ship-class
+        alias when it matches a known hull definition.
         Instance-specific fields (id, name, position, velocity, orientation,
         ai_enabled, faction) always come from the ship definition.
 
-        If no ``ship_class`` is specified, the ship definition is returned
-        unchanged for backward compatibility.
+        If neither ``ship_class`` nor a resolvable ``class`` alias is
+        specified, the ship definition is returned unchanged.
 
         Args:
             ship_def: Ship definition from a scenario file
@@ -110,6 +112,10 @@ class ShipClassRegistry:
             Fully resolved ship config dict ready for Ship constructor
         """
         class_id = ship_def.get("ship_class")
+        if not class_id:
+            class_alias = ship_def.get("class")
+            if isinstance(class_alias, str) and class_alias in self._classes:
+                class_id = class_alias
         if not class_id:
             return ship_def
 

--- a/hybrid/systems/power/management.py
+++ b/hybrid/systems/power/management.py
@@ -76,10 +76,14 @@ class PowerManagementSystem:
             base = Reactor(layer_name)
             # D6: Support "output" as alias for "capacity" for backward compatibility
             capacity = params.get("capacity") or params.get("output", base.capacity)
+            # Power buses model max continuous output in kW. When no explicit
+            # ramp is provided, refill from cold to max in roughly 10 ticks,
+            # matching the project power-management design notes.
+            default_output_rate = float(capacity)
             self.reactors[layer_name] = Reactor(
                 name=layer_name,
                 capacity=capacity,
-                output_rate=params.get("output_rate", base.output_rate),
+                output_rate=params.get("output_rate", default_output_rate),
                 thermal_limit=params.get("thermal_limit", base.thermal_limit),
                 fuel_capacity=params.get("fuel_capacity"),
                 fuel_level=params.get("fuel_level"),

--- a/hybrid/systems/propulsion_system.py
+++ b/hybrid/systems/propulsion_system.py
@@ -155,7 +155,13 @@ class PropulsionSystem(BaseSystem):
 
         # Power check — only when actually thrusting (idle ships skip this)
         if thrust_magnitude > 0:
-            total_power = self.power_draw + (self.power_draw_per_thrust * thrust_magnitude * dt)
+            # The ship power bus feeds drive control electronics, pumps, and
+            # support systems. It does not provide the propulsive energy of the
+            # exhaust plume itself, which is already modeled through fuel burn
+            # and ISP. Scale the variable draw by commanded throttle, then
+            # convert the kW request into per-tick energy.
+            throttle_load = clamp(self.throttle, 0.0, 1.0)
+            total_power = (self.power_draw + (self.power_draw_per_thrust * throttle_load)) * dt
             power_system = ship.systems.get("power_management") or ship.systems.get("power")
             if power_system and not power_system.request_power(total_power, "propulsion"):
                 thrust_world_x = thrust_world_y = thrust_world_z = 0.0

--- a/tests/test_ship_class_alias.py
+++ b/tests/test_ship_class_alias.py
@@ -1,0 +1,95 @@
+"""Regression tests for backward-compatible ship class resolution.
+
+Several legacy scenarios still declare hulls with ``class: corvette`` instead
+of ``ship_class: corvette``. Those ships must still inherit their class-defined
+systems and mass metadata, otherwise station wiring silently disappears.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+SCENARIO_01 = ROOT_DIR / "scenarios" / "01_tutorial_intercept.yaml"
+
+
+def _reset_registry() -> None:
+    import hybrid.ship_class_registry as registry_module
+
+    registry_module._registry = None
+
+
+def test_class_field_resolves_known_ship_class() -> None:
+    """Known hull IDs in ``class`` should resolve just like ``ship_class``."""
+    _reset_registry()
+
+    from hybrid.ship_class_registry import get_registry
+
+    registry = get_registry()
+    resolved = registry.resolve_ship_config({
+        "id": "player",
+        "class": "corvette",
+        "systems": {
+            "propulsion": {
+                "max_thrust": 500000,
+                "fuel_level": 10000,
+                "max_fuel": 10000,
+            }
+        },
+    })
+
+    systems = resolved.get("systems", {})
+    assert resolved.get("dry_mass") == 1200.0
+    assert systems["propulsion"]["max_thrust"] == 500000
+    assert "power_management" in systems
+    assert "combat" in systems
+    assert systems["power_management"]["primary"]["output"] == 100.0
+
+
+def test_tutorial_player_inherits_class_defined_systems() -> None:
+    """Tutorial intercept player ship must load its full corvette baseline."""
+    from hybrid.scenarios.loader import ScenarioLoader
+
+    scenario = ScenarioLoader.load(str(SCENARIO_01))
+    player = next(ship for ship in scenario["ships"] if ship["id"] == "player")
+
+    systems = player["systems"]
+    assert "power_management" in systems
+    assert "combat" in systems
+    assert player["dry_mass"] == 1200.0
+
+
+def test_tutorial_player_can_accelerate_with_power_management_enabled() -> None:
+    """The tutorial player ship must still thrust after class systems resolve."""
+    from hybrid.command_handler import route_command
+    from hybrid_runner import HybridRunner
+
+    runner = HybridRunner(dt=0.1)
+    count = runner._load_scenario_file(str(SCENARIO_01))
+    assert count >= 1
+    runner.simulator.start()
+
+    player = runner.simulator.ships["player"]
+    start_speed = math.sqrt(sum(player.velocity[axis] ** 2 for axis in ("x", "y", "z")))
+
+    result = route_command(
+        player,
+        {"command": "set_thrust", "ship": "player", "thrust": 0.25},
+        list(runner.simulator.ships.values()),
+    )
+    assert not result.get("error"), result
+
+    for _ in range(50):
+        runner.simulator.tick()
+
+    end_speed = math.sqrt(sum(player.velocity[axis] ** 2 for axis in ("x", "y", "z")))
+    assert end_speed > start_speed + 10.0, (
+        f"Expected manual thrust to accelerate the tutorial ship, got start={start_speed:.2f} end={end_speed:.2f}"
+    )

--- a/tools/check_station_wiring.py
+++ b/tools/check_station_wiring.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Headless station wiring smoke checks for GUI UAT.
+
+This script exercises the tutorial intercept scenario through the same command
+names the GUI sends so bridge/UAT issues can be separated into:
+
+1. scenario / ship wiring,
+2. command dispatch,
+3. telemetry progression.
+
+Checks:
+  - the tutorial player ship inherits its class-defined systems
+  - manual thrust increases speed
+  - lock_target + rendezvous autopilot reduce target range
+
+Usage:
+  python3 tools/check_station_wiring.py
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from hybrid.command_handler import route_command
+from hybrid.scenarios.loader import ScenarioLoader
+from hybrid.simulator import Simulator
+
+
+SCENARIO_PATH = ROOT_DIR / "scenarios" / "01_tutorial_intercept.yaml"
+
+
+def build_simulator() -> Simulator:
+    scenario = ScenarioLoader.load(str(SCENARIO_PATH))
+    sim = Simulator(dt=scenario.get("dt", 0.1), time_scale=1.0)
+    for ship_data in scenario["ships"]:
+        sim.add_ship(ship_data["id"], ship_data)
+
+    all_ships = list(sim.ships.values())
+    for ship in all_ships:
+        ship._all_ships_ref = all_ships
+
+    sim.start()
+    return sim
+
+
+def issue(sim: Simulator, ship_id: str, command: str, params: dict) -> dict:
+    ship = sim.ships[ship_id]
+    result = route_command(ship, {"command": command, "ship": ship_id, **params}, list(sim.ships.values()))
+    if isinstance(result, dict) and result.get("error"):
+        raise RuntimeError(f"{command} failed: {result}")
+    return result
+
+
+def speed(ship) -> float:
+    vel = ship.velocity
+    return math.sqrt(vel["x"] ** 2 + vel["y"] ** 2 + vel["z"] ** 2)
+
+
+def distance(a, b) -> float:
+    dx = a.position["x"] - b.position["x"]
+    dy = a.position["y"] - b.position["y"]
+    dz = a.position["z"] - b.position["z"]
+    return math.sqrt(dx * dx + dy * dy + dz * dz)
+
+
+def wait_for_contact(sim: Simulator, player_id: str, target_ship_id: str, max_ticks: int = 120) -> str:
+    player = sim.ships[player_id]
+    sensors = player.systems.get("sensors")
+
+    for _ in range(max_ticks):
+        sim.tick()
+        sensors = player.systems.get("sensors")
+        tracker = getattr(sensors, "contact_tracker", None)
+        if tracker and target_ship_id in tracker.id_mapping:
+            return tracker.id_mapping[target_ship_id]
+
+    raise RuntimeError(f"Target {target_ship_id} was not detected within {max_ticks} ticks")
+
+
+def check_system_loadout(sim: Simulator) -> None:
+    player = sim.ships["player"]
+    required = {"propulsion", "navigation", "helm", "targeting", "combat", "power_management"}
+    missing = sorted(required - set(player.systems.keys()))
+    if missing:
+        raise RuntimeError(f"Player ship missing required systems: {missing}")
+
+    print("PASS loadout  player ship has full class-defined systems")
+
+
+def check_manual_thrust(sim: Simulator) -> None:
+    player = sim.ships["player"]
+    start_speed = speed(player)
+    issue(sim, "player", "set_thrust", {"thrust": 0.25})
+    for _ in range(50):
+        sim.tick()
+    end_speed = speed(player)
+
+    if end_speed <= start_speed + 10.0:
+        raise RuntimeError(
+            f"Manual thrust did not accelerate the ship enough: start={start_speed:.2f} m/s end={end_speed:.2f} m/s"
+        )
+
+    print(f"PASS manual   speed increased from {start_speed:.1f} to {end_speed:.1f} m/s")
+
+
+def check_rendezvous(sim: Simulator) -> None:
+    player = sim.ships["player"]
+    target = sim.ships["target_station"]
+
+    issue(sim, "player", "ping_sensors", {})
+    contact_id = wait_for_contact(sim, "player", "target_station")
+    issue(sim, "player", "lock_target", {"contact_id": contact_id})
+
+    start_range = distance(player, target)
+    issue(sim, "player", "autopilot", {
+        "enable": True,
+        "program": "rendezvous",
+        "target": contact_id,
+        "profile": "balanced",
+    })
+
+    for _ in range(200):
+        sim.tick()
+
+    end_range = distance(player, target)
+    if end_range >= start_range - 1000.0:
+        raise RuntimeError(
+            f"Rendezvous did not close range enough: start={start_range:.1f}m end={end_range:.1f}m"
+        )
+
+    print(f"PASS auto     range decreased from {start_range:.0f}m to {end_range:.0f}m using contact {contact_id}")
+
+
+def main() -> int:
+    print("== Station Wiring Smoke Check ==")
+    print(f"Scenario: {os.path.relpath(SCENARIO_PATH, ROOT_DIR)}")
+
+    try:
+        check_system_loadout(build_simulator())
+        check_manual_thrust(build_simulator())
+        check_rendezvous(build_simulator())
+    except Exception as exc:
+        print(f"FAIL         {exc}")
+        return 1
+
+    print("PASS overall tutorial manual + rendezvous wiring is functioning headlessly")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## What changed

This PR fixes the highest-priority client/server wiring issues that were blocking station UAT after the Svelte station refactors.

- restore backward-compatible ship-class resolution for scenarios that still use `class:` instead of `ship_class:`
- fix the Svelte mission loader to use the actual station-mode `ok` / `response` envelope
- surface real Helm command rejection reasons instead of the generic `Command rejected`
- expose a richer browser debug hook for active ship, scenario, and blocked ship-command diagnostics
- align propulsion bus draw with throttle/control load rather than raw thrust force
- increase default reactor refill behavior so the restored power bus model remains flyable in tutorial UAT
- add a regression test, a headless station-wiring smoke script, and a manual/raw UAT checklist

## Why it changed

UAT was blocked by a mix of backend and frontend wiring problems:

1. tutorial and other legacy scenarios could instantiate partial ships with missing class-defined systems, which broke deterministic bridge/station behavior
2. the Svelte mission flow still expected `success/data` responses instead of the station server's `ok/response` contract, which could leave ship and station binding in a bad state
3. once the real power bus was restored, propulsion brownouts and opaque UI errors made valid commands look dead from the operator side

## Impact

- Tutorial Helm UAT now shows real movement again for manual thrust and rendezvous engagement.
- The bridge can be debugged deterministically with `_flaxosDebugState()` and `python3 tools/check_station_wiring.py`.
- Legacy `class:` scenarios inherit their expected hull systems again instead of silently dropping systems like `power_management` or `combat`.

## Validation

- `pytest -q tests/test_ship_class_alias.py`
- `python3 tools/check_station_wiring.py`
- `npm run check`
- `npm run build`

## Residual risk

Long rendezvous burns still show sustained power/thermal pressure, and the full tutorial intercept remains a tuning problem rather than a dead-wiring problem. This PR is intended to resume UAT on panel wiring and command flow before deeper power/autopilot balance work.