### PR TITLE
[codex] make config and admin controls always accessible

### DIFF
--- a/ANDROID_INSTALL.md
+++ b/ANDROID_INSTALL.md
@@ -146,11 +146,11 @@ To connect mobile device to desktop server:
 
 1. **Start server on desktop**:
    ```bash
-   # Recommended: station-aware server (multi-crew / permissions)
-   python -m server.station_server --host 0.0.0.0 --port 8765
+   # Recommended: unified station server entrypoint (multi-crew / permissions)
+   python -m server.main --lan --port 8765
 
    # Minimal server (no stations)
-   # python -m server.run_server --host 0.0.0.0 --port 8765
+   # python -m server.main --mode minimal --lan --port 8765
    ```
 
 2. **Find desktop IP address**:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ python tools/start_gui_stack.py --tcp-port 9000 --ws-port 9001 --http-port 3200
 # Open a browser automatically
 python tools/start_gui_stack.py --browser
 
-# Set an explicit RCON password for Mission > Server admin controls
+# Set an explicit RCON password for Config > Server admin controls
 python tools/start_gui_stack.py --rcon-password 'replace-this'
 
 # Secure remote/LAN use: restrict browser origin, require WS auth, and set RCON
@@ -88,7 +88,7 @@ For repeatable UAT runs, start the stack with a non-default RCON password and us
 
 1. Launch with `python tools/start_gui_stack.py --browser --rcon-password 'replace-this'`
 2. Load a scenario and claim a station
-3. Open `Mission > Server`
+3. Open `Config > Server`
 4. Authenticate with the RCON password
 5. Use the panel for:
    - server uptime and mission uptime visibility
@@ -104,7 +104,7 @@ Password rotation is runtime-only. If you restart the stack, the server returns 
 For remote browser access over ZeroTier, use all three controls together:
 
 1. `--game-code` to gate the WebSocket bridge
-2. `--rcon-password` for admin actions in `Mission > Server`
+2. `--rcon-password` for admin actions in `Config > Server`
 3. `--allowed-origin-host <zerotier-ip-or-hostname>` to restrict browser origins hitting the bridge
 
 Recommended example:
@@ -494,7 +494,7 @@ Key test areas:
 - Scenario system (JSON-defined ships, objectives, win/fail conditions)
 - Web GUI: Helm, Tactical, OPS, Engineering, Fleet, Mission views
 - Tier system (RAW / ARCADE / CPU-ASSIST complexity levels)
-- Asset editor REST API
+- Ship-class editor commands and Svelte Editor view
 
 ### In Progress
 

--- a/STATION_ARCHITECTURE.md
+++ b/STATION_ARCHITECTURE.md
@@ -321,9 +321,13 @@ All existing commands automatically mapped to stations:
 
 ## Running the System
 
+The canonical entrypoint is `server.main`. The old `server.station_server`
+module from the original implementation has been folded into the unified
+server entrypoint.
+
 ### Start Station-Enabled Server
 ```bash
-python -m server.station_server --host 0.0.0.0 --port 8765 --dt 0.1 --fleet-dir hybrid_fleet
+python -m server.main --mode station --host 0.0.0.0 --port 8765 --dt 0.1 --fleet-dir hybrid_fleet
 ```
 
 ### Test Client
@@ -345,6 +349,7 @@ nc localhost 8765
 
 ```
 server/
+├── main.py                     # Canonical TCP server entrypoint (--mode station)
 ├── stations/
 │   ├── __init__.py              # Package exports
 │   ├── station_types.py         # Station definitions (267 lines)
@@ -353,7 +358,6 @@ server/
 │   ├── station_telemetry.py     # Telemetry filtering (287 lines)
 │   ├── station_commands.py      # Management commands (315 lines)
 │   └── README.md                # User documentation
-├── station_server.py            # Enhanced TCP server (339 lines)
 test_station_client.py           # Test client (283 lines)
 STATION_ARCHITECTURE.md          # This document
 ```
@@ -366,7 +370,7 @@ STATION_ARCHITECTURE.md          # This document
 ✅ **Station manager**: Client registration, ship assignment, station claims working
 ✅ **Command routing**: Permission checks functioning correctly
 ✅ **Telemetry filtering**: Filtered output generated correctly
-✅ **Server startup**: Station server initializes and listens
+✅ **Server startup**: Station mode initializes and listens
 
 ## Next Steps (Phase 2)
 

--- a/docs/AI_INSTRUCTIONS.md
+++ b/docs/AI_INSTRUCTIONS.md
@@ -8,9 +8,9 @@ Act as an expert game engineer and producer on a hard‑sci‑fi bridge‑sim.
 - Fidelity > flash. Prefer deterministic, testable systems.
 
 **Coding Expectations**
-- Python 3.10+, stdlib + tkinter for HUD.
+- Python 3.10+ for backend code; TypeScript/Svelte for the default frontend in `gui-svelte/`.
 - Provide complete, runnable code with tests. Avoid placeholders.
-- Keep APIs stable for HUD/Server unless version bump.
+- Keep TCP/WS contracts and GUI/server APIs stable unless a versioned change is intentional.
 
 **Review Protocol**
 - Run tests; report pass/fail with diffs.
@@ -19,8 +19,8 @@ Act as an expert game engineer and producer on a hard‑sci‑fi bridge‑sim.
 
 **Release & Deployment Sync**
 - Prepare CHANGELOG & MIGRATION NOTES.
-- Confirm demo scenario runs end‑to‑end.
-- Update README (user) and DEV_NOTES (technical).
+- Confirm demo scenario runs end-to-end.
+- Update README plus the relevant `docs/`, `AGENTS.md`, or prompt/helper files when behavior or entrypoints change.
 
 **Communication**
 - After each sprint: summarize (Built / Tested / Pass-Fail / Ready to Deploy).

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -135,7 +135,7 @@ This allows GUI clients to auto-configure connection settings.
 
 ## Admin / RCON
 
-The default Svelte GUI exposes authenticated admin controls in `Mission > Server`.
+The default Svelte GUI exposes authenticated admin controls in `Config > Server`.
 Start the stack with `--rcon-password` or set `FLAXOS_RCON_PASSWORD` to enable them.
 For secure remote browser access, pair RCON with `--game-code` on the WebSocket bridge and, ideally, `--allowed-origin-host`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,6 +29,10 @@ Flaxos Spaceship Simulator is a **hard sci-fi multiplayer space combat simulator
 - **Deterministic simulation** - Consistent physics with fixed timestep
 - **Client-server architecture** - TCP JSON protocol for network play
 
+The current default browser experience is the Svelte frontend in `gui-svelte/`,
+served through `gui/ws_bridge.py` and usually launched with
+`python tools/start_gui_stack.py`.
+
 ### Design Principles
 
 1. **Separation of Concerns**: Physics, networking, and UI are isolated
@@ -45,14 +49,16 @@ Flaxos Spaceship Simulator is a **hard sci-fi multiplayer space combat simulator
 ┌─────────────────────────────────────────────────────────────┐
 │                     Client Applications                      │
 │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
-│  │ Mobile UI    │  │ Desktop GUI  │  │ Custom Client│      │
-│  │ (Flask/HTML) │  │ (Tkinter)    │  │ (TCP JSON)   │      │
+│  │ Mobile UI    │  │ Browser GUI  │  │ Custom Client│      │
+│  │ (Flask/HTML) │  │ (Svelte/Web) │  │ (TCP JSON)   │      │
 │  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘      │
 └─────────┼──────────────────┼──────────────────┼─────────────┘
           │                  │                  │
-          └──────────────────┴──────────────────┘
+          │         WebSocket bridge           │
+          │           (gui/ws_bridge.py)       │
+          └──────────────────┬──────────────────┘
                              │
-                    TCP JSON Protocol
+                      TCP JSON Protocol
                              │
 ┌─────────────────────────────┼─────────────────────────────────┐
 │                    Server Layer                                │
@@ -123,7 +129,7 @@ python -m server.main --lan
 - Filter telemetry/events by station (station mode)
 - Manage client sessions
 - Provide autodiscovery endpoint (`_discover` command)
-- Handle authenticated RCON admin operations for the `Mission > Server` UI
+- Handle authenticated RCON admin operations for the `Config > Server` UI
 
 **Key Components:**
 - `UnifiedServer` - Main server class with mode switching
@@ -760,4 +766,4 @@ Flaxos-Spaceshi_-Sim_0.01/
 **Review Frequency**: After architectural changes
 The default browser operator workflow is the Svelte UI served on port `3100`,
 talking to the WebSocket bridge on port `8081`. Authenticated admin/UAT
-controls live in `Mission > Server` and are backed by `UnifiedServer._handle_rcon`.
+controls live in `Config > Server` and are backed by `UnifiedServer._handle_rcon`.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -45,13 +45,14 @@ The `StationAwareDispatcher.get_available_commands()` method (`station_dispatch.
 
 ---
 
-### 2. Telemetry snapshot errors in `server.run_server`
+### 2. Telemetry snapshot errors in the minimal server entrypoint
 **Status**: ✅ RESOLVED (2026-01-20)
 **Severity**: High (Server telemetry)
 **Affected Components**: `hybrid/systems/power/management.py`, ship configs
 
 **Description:**
-Running `python -m server.run_server` previously logged repeated telemetry errors:
+Running `python -m server.main --mode minimal` (or the older
+`python -m server.run_server`) previously logged repeated telemetry errors:
 - `Error loading system power_management: 'float' object has no attribute 'get'`
 
 **Resolution:**

--- a/docs/NAV_HELM_GUI_TEST_PLAN.md
+++ b/docs/NAV_HELM_GUI_TEST_PLAN.md
@@ -6,7 +6,7 @@ This plan captures repeatable GUI checks and supporting scripts for validating n
 - Start the GUI stack: `python tools/start_gui_stack.py --browser --rcon-password 'replace-this'`
 - Open the GUI: http://localhost:3100/
 - Ensure the scenario is loaded from the scenario panel (Tutorial: Intercept and Approach).
-- Optional but recommended: open `Mission > Server` once and confirm the scenario name and mission uptime are visible before switching to Helm.
+- Optional but recommended: open `Config > Server` once and confirm the scenario name and mission uptime are visible before switching to Helm.
 
 ## Manual GUI Test Cases
 

--- a/docs/STATION_UAT_WIRING_CHECKLIST.md
+++ b/docs/STATION_UAT_WIRING_CHECKLIST.md
@@ -16,14 +16,14 @@ Use it to answer three questions in order:
 2. Open the Svelte GUI.
 3. Open browser devtools and run:
    `_flaxosDebugState()`
-4. Load a scenario, then open `Mission > Server` and authenticate with the same RCON password.
+4. Load a scenario, then open `Config > Server` and authenticate with the same RCON password.
 
 Expected before starting a mission:
 - `ws.isConnected` is `true`
 - `activeShipId` is `null`
 - `blockedCommandTotal` is `0`
 
-Expected after authenticating in `Mission > Server`:
+Expected after authenticating in `Config > Server`:
 - server uptime is visible
 - mission uptime becomes non-`n/a` after loading a mission
 - scenario name, pause state, sim time, and time scale refresh without reloading the page
@@ -48,7 +48,7 @@ If this fails, stop and fix backend/scenario wiring first. UI UAT will not be tr
 
 Run this once before the station-specific flows:
 
-1. In `Mission > Server`, click `Refresh`.
+1. In `Config > Server`, click `Refresh`.
 2. Toggle `Pause Simulation`, then resume.
 3. Set time scale to `2x`, then back to `1x`.
 
@@ -173,4 +173,4 @@ If a panel appears wired but nothing happens:
    `python3 tools/check_station_wiring.py`
 4. If headless passes but GUI fails, the issue is client binding or view wiring.
 5. If headless fails, the issue is scenario/backend command flow.
-6. If `Mission > Server` shows success but uptime/state does not change, treat it as a backend admin-command regression and stop UAT.
+6. If `Config > Server` shows success but uptime/state does not change, treat it as a backend admin-command regression and stop UAT.

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -25,16 +25,28 @@ Welcome to the Flaxos Spaceship Sim! This tutorial will guide you through the ba
 ### Prerequisites
 
 **Required:**
-- Python 3.8+
+- Python 3.10+
 - PyYAML (`pip install pyyaml`)
 - Flask (`pip install flask`)
+- websockets (`pip install websockets`)
+
+**Recommended for the default browser UI:**
+- Node.js + npm (used by `tools/start_gui_stack.py` to build `gui-svelte/`)
 
 **Optional:**
 - NumPy (`pip install numpy`) - Required for fleet formations
 
 ### Starting the Server
 
-From your project directory:
+Recommended all-in-one startup:
+
+```bash
+python tools/start_gui_stack.py --browser
+```
+
+That launches the TCP server, WS bridge, and browser GUI together.
+
+Manual server-only startup (useful for direct TCP/mobile clients):
 
 ```bash
 # Terminal 1: Start the unified server (station-aware / multi-crew)
@@ -48,10 +60,11 @@ The server will:
 
 ### Connecting Your First Client
 
-**Option 1: Desktop HUD (Recommended for Learning)**
+**Option 1: Browser GUI (Recommended)**
 ```bash
-# Terminal 2: Start the HUD
-python hybrid/gui/gui.py
+# If you used the all-in-one startup above, the browser opens automatically.
+# Otherwise launch the full browser stack in a fresh terminal:
+python tools/start_gui_stack.py --browser
 ```
 
 **Option 2: Mobile UI (Android/Pydroid)**

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,7 +1,8 @@
 # User Guide (Player)
 
-## Controls (Tk HUD)
-This section applies to the legacy desktop HUD (`python hybrid/gui/gui.py`).
+## Controls (Legacy Desktop Reference)
+This section is only for older desktop-control layouts kept for historical
+reference. The default supported interface is the browser GUI.
 
 - Click a contact to select as **target**
 - **F** — Fire weapon (if in FOV + turret arc, power & cooldown OK)
@@ -13,10 +14,10 @@ This section applies to the legacy desktop HUD (`python hybrid/gui/gui.py`).
 - Use the **Sensors** panel to select a contact, then **Lock Target**
 - Use **Autopilot** panel to engage programs (intercept/match/hold/hold_velocity)
 - Use **Weapons** panel to fire (via `fire_weapon` commands)
-- Use **Mission > Server** for authenticated admin/UAT controls such as pause/resume, mission reset, server reset, connected-client inspection, and runtime RCON password rotation
+- Use **Config > Server** for authenticated admin/UAT controls such as pause/resume, mission reset, server reset, connected-client inspection, and runtime RCON password rotation
 
 ## Tips
 - Stay within the **weapon arc** wedge on the radar to enable firing.
 - Targets with **ECM** degrade missile lock; fire closer or use ECCM‑capable missiles.
 - PDC will auto‑engage the nearest inbound missile if within arc/range.
-- For repeatable UAT, launch with `python tools/start_gui_stack.py --browser --rcon-password 'replace-this'` and authenticate inside `Mission > Server`.
+- For repeatable UAT, launch with `python tools/start_gui_stack.py --browser --rcon-password 'replace-this'` and authenticate inside `Config > Server`.

--- a/gui-svelte/src/App.svelte
+++ b/gui-svelte/src/App.svelte
@@ -20,22 +20,22 @@
   import ScienceView from "./views/ScienceView.svelte";
   import CommsView from "./views/CommsView.svelte";
   import FleetView from "./views/FleetView.svelte";
-  import MissionView from "./views/MissionView.svelte";
+  import ConfigView from "./views/MissionView.svelte";
   import EditorView from "./views/EditorView.svelte";
 
   // Station → allowed views mapping (mirrors index.html logic)
   const STATION_VIEWS: Record<string, string[]> = {
-    captain:         ["helm", "tactical", "fleet", "comms", "ops", "mission"],
-    helm:            ["helm", "tactical", "mission"],
-    tactical:        ["tactical", "helm", "mission"],
-    ops:             ["ops", "engineering", "mission"],
-    engineering:     ["engineering", "ops", "mission"],
-    comms:           ["comms", "mission"],
-    science:         ["science", "tactical", "mission"],
-    fleet_commander: ["fleet", "tactical", "mission"],
+    captain:         ["helm", "tactical", "fleet", "comms", "ops", "config"],
+    helm:            ["helm", "tactical", "config"],
+    tactical:        ["tactical", "helm", "config"],
+    ops:             ["ops", "engineering", "config"],
+    engineering:     ["engineering", "ops", "config"],
+    comms:           ["comms", "config"],
+    science:         ["science", "tactical", "config"],
+    fleet_commander: ["fleet", "tactical", "config"],
   };
 
-  let activeView = "mission";
+  let activeView = "config";
   let allowedViews: string[] | null = null; // null = all (pre-station-claim)
 
   function onViewChange(e: CustomEvent<{ view: string }>) {
@@ -44,9 +44,9 @@
 
   function onStationClaimed(e: CustomEvent<{ station: string }>) {
     const station = e.detail.station;
-    allowedViews = STATION_VIEWS[station] ?? ["mission"];
-    // Auto-switch to first allowed view that isn't mission (if available)
-    const preferred = allowedViews.find((v) => v !== "mission") ?? allowedViews[0];
+    allowedViews = STATION_VIEWS[station] ?? ["config"];
+    // Auto-switch to first allowed view that isn't config (if available)
+    const preferred = allowedViews.find((v) => v !== "config") ?? allowedViews[0];
     if (preferred && !allowedViews.includes(activeView)) {
       activeView = preferred;
     }
@@ -56,7 +56,7 @@
     allowedViews = null; // unlock all views
   }
 
-  // Listen for scenario-loaded to switch to helm/mission view
+  // Listen for scenario-loaded to switch to helm/config view
   function onScenarioLoaded(e: Event) {
     // Server returns player_ship_id / assigned_ship — check all possible keys
     type ScenarioDetail = Record<string, string | undefined>;
@@ -124,8 +124,8 @@
     <div class="view-container" class:active={activeView === "fleet"}>
       <FleetView />
     </div>
-    <div class="view-container" class:active={activeView === "mission"}>
-      <MissionView />
+    <div class="view-container" class:active={activeView === "config"}>
+      <ConfigView />
     </div>
     <div class="view-container" class:active={activeView === "editor"}>
       <EditorView />

--- a/gui-svelte/src/components/layout/ViewTabs.svelte
+++ b/gui-svelte/src/components/layout/ViewTabs.svelte
@@ -3,7 +3,7 @@
 
   const dispatch = createEventDispatcher<{ "view-change": { view: string } }>();
 
-  export let activeView = "mission";
+  export let activeView = "config";
   export let allowedViews: string[] | null = null; // null = all allowed
 
   const VIEWS: { id: string; label: string; key: string }[] = [
@@ -14,7 +14,7 @@
     { id: "science",     label: "SCIENCE",     key: "5" },
     { id: "comms",       label: "COMMS",       key: "6" },
     { id: "fleet",       label: "FLEET",       key: "7" },
-    { id: "mission",     label: "MISSION",     key: "8" },
+    { id: "config",      label: "CONFIG",      key: "8" },
     { id: "editor",      label: "EDITOR",      key: "9" },
   ];
 

--- a/gui-svelte/src/views/MissionView.svelte
+++ b/gui-svelte/src/views/MissionView.svelte
@@ -15,8 +15,8 @@
   // Reference to ScenarioLoader so we can call showPostMission()
   let loaderRef: ScenarioLoader | undefined;
 
-  // Which in-game panel is active
-  let activePanel: "objectives" | "campaign" | "console" | "server" = "objectives";
+  // Which config panel is active
+  let activePanel: "objectives" | "campaign" | "console" | "server" = "server";
 
   // ── Event wiring ─────────────────────────────────────────────────
   function onScenarioLoaded(e: Event) {
@@ -90,88 +90,79 @@
 </script>
 
 <div class="mission-view">
-  {#if phase === "lobby" || phase === "ended"}
-    <!-- ── Full-screen scenario loader ── -->
-    <div class="loader-fullscreen">
-      <ScenarioLoader
-        bind:this={loaderRef}
-        on:scenario-loaded={(e) => onScenarioLoaded(e)}
-        on:next-mission={() => onNextMission()}
-      />
+  <div class="config-layout" class:mission-live={phase === "playing"}>
+    <!-- Left: mission loader / scenario controls -->
+    <div class="loader-sidebar">
+      <Panel
+        title={phase === "ended" ? "Mission Results" : "Mission Select"}
+        domain="nav"
+        priority={phase === "playing" ? "tertiary" : "primary"}
+        collapsible={phase === "playing"}
+      >
+        <div class="loader-wrap" class:compact={phase === "playing"}>
+          <ScenarioLoader
+            bind:this={loaderRef}
+            on:scenario-loaded={(e) => onScenarioLoaded(e)}
+            on:next-mission={() => onNextMission()}
+          />
+        </div>
+      </Panel>
     </div>
 
-  {:else if phase === "playing"}
-    <!-- ── In-mission layout ── -->
-    <div class="playing-layout">
-      <!-- Left: compact scenario loader (collapsed) -->
-      <div class="loader-sidebar">
-        <Panel title="Mission Select" domain="nav" priority="tertiary" collapsible={true}>
-          <div class="loader-collapsed-wrap">
-            <ScenarioLoader
-              bind:this={loaderRef}
-              on:scenario-loaded={(e) => onScenarioLoaded(e)}
-              on:next-mission={() => onNextMission()}
-            />
-          </div>
-        </Panel>
+    <!-- Right: always-available config/admin panels -->
+    <div class="mission-panels">
+      <div class="panel-tabs" role="tablist">
+        <button
+          class="tab-btn"
+          class:active={activePanel === "server"}
+          role="tab"
+          aria-selected={activePanel === "server"}
+          on:click={() => activePanel = "server"}
+        >SERVER</button>
+        <button
+          class="tab-btn"
+          class:active={activePanel === "console"}
+          role="tab"
+          aria-selected={activePanel === "console"}
+          on:click={() => activePanel = "console"}
+        >CONSOLE</button>
+        <button
+          class="tab-btn"
+          class:active={activePanel === "campaign"}
+          role="tab"
+          aria-selected={activePanel === "campaign"}
+          on:click={() => activePanel = "campaign"}
+        >CAMPAIGN</button>
+        <button
+          class="tab-btn"
+          class:active={activePanel === "objectives"}
+          role="tab"
+          aria-selected={activePanel === "objectives"}
+          on:click={() => activePanel = "objectives"}
+        >OBJECTIVES</button>
       </div>
 
-      <!-- Right: in-mission panels -->
-      <div class="mission-panels">
-        <!-- Panel tabs -->
-        <div class="panel-tabs" role="tablist">
-          <button
-            class="tab-btn"
-            class:active={activePanel === "objectives"}
-            role="tab"
-            aria-selected={activePanel === "objectives"}
-            on:click={() => activePanel = "objectives"}
-          >OBJECTIVES</button>
-          <button
-            class="tab-btn"
-            class:active={activePanel === "campaign"}
-            role="tab"
-            aria-selected={activePanel === "campaign"}
-            on:click={() => activePanel = "campaign"}
-          >CAMPAIGN</button>
-          <button
-            class="tab-btn"
-            class:active={activePanel === "console"}
-            role="tab"
-            aria-selected={activePanel === "console"}
-            on:click={() => activePanel = "console"}
-          >CONSOLE</button>
-          <button
-            class="tab-btn"
-            class:active={activePanel === "server"}
-            role="tab"
-            aria-selected={activePanel === "server"}
-            on:click={() => activePanel = "server"}
-          >SERVER</button>
-        </div>
-
-        <div class="panel-body">
-          {#if activePanel === "objectives"}
-            <Panel title="Mission Objectives" domain="nav" priority="primary" collapsible={false}>
-              <MissionObjectives />
-            </Panel>
-          {:else if activePanel === "campaign"}
-            <Panel title="Campaign" domain="comms" priority="secondary" collapsible={false}>
-              <CampaignHub />
-            </Panel>
-          {:else if activePanel === "console"}
-            <Panel title="Command Console" domain="" priority="tertiary" collapsible={false}>
-              <CommandPrompt />
-            </Panel>
-          {:else if activePanel === "server"}
-            <Panel title="Server Admin" domain="" priority="secondary" collapsible={false}>
-              <ServerAdminPanel />
-            </Panel>
-          {/if}
-        </div>
+      <div class="panel-body">
+        {#if activePanel === "objectives"}
+          <Panel title="Mission Objectives" domain="nav" priority="primary" collapsible={false}>
+            <MissionObjectives />
+          </Panel>
+        {:else if activePanel === "campaign"}
+          <Panel title="Campaign" domain="comms" priority="secondary" collapsible={false}>
+            <CampaignHub />
+          </Panel>
+        {:else if activePanel === "console"}
+          <Panel title="Command Console" domain="" priority="tertiary" collapsible={false}>
+            <CommandPrompt />
+          </Panel>
+        {:else if activePanel === "server"}
+          <Panel title="Server Admin" domain="" priority="secondary" collapsible={false}>
+            <ServerAdminPanel />
+          </Panel>
+        {/if}
       </div>
     </div>
-  {/if}
+  </div>
 </div>
 
 <style>
@@ -183,14 +174,7 @@
     flex-direction: column;
   }
 
-  /* ── Full-screen loader (lobby / ended) ── */
-  .loader-fullscreen {
-    flex: 1;
-    overflow-y: auto;
-  }
-
-  /* ── Playing layout ── */
-  .playing-layout {
+  .config-layout {
     display: grid;
     grid-template-columns: 340px 1fr;
     gap: var(--space-xs);
@@ -206,7 +190,12 @@
     gap: var(--space-xs);
   }
 
-  .loader-collapsed-wrap {
+  .loader-wrap {
+    height: 100%;
+    overflow-y: auto;
+  }
+
+  .loader-wrap.compact {
     max-height: 300px;
     overflow-y: auto;
   }
@@ -269,5 +258,16 @@
 
   .panel-body :global(.panel-body) {
     overflow-y: auto;
+  }
+
+  @media (max-width: 960px) {
+    .config-layout {
+      grid-template-columns: 1fr;
+      grid-template-rows: minmax(220px, auto) 1fr;
+    }
+
+    .loader-wrap.compact {
+      max-height: none;
+    }
   }
 </style>

--- a/prompts/DEPLOYMENT_SYNC_PROMPT.txt
+++ b/prompts/DEPLOYMENT_SYNC_PROMPT.txt
@@ -3,7 +3,7 @@ Act as a Release/Build Engineer.
 Given the repo, prepare a deployment plan for the demo:
 - Branching and version tags
 - Packaging commands and artifacts
-- Upgrade notes between S2 and S3 (API, HUD expectations)
+- Upgrade notes for backend, WebSocket bridge, and Svelte GUI consumers
 - Test matrix (OS/Python versions)
 - Rollback plan and known issues
 

--- a/prompts/REPO_REVIEW_PROMPT.txt
+++ b/prompts/REPO_REVIEW_PROMPT.txt
@@ -6,8 +6,8 @@ Repository path provided. Perform a deep technical review and return:
 - Any local changes you had to make; propose PRs if needed.
 
 2) Architecture
-- Modules and responsibilities (hybrid/*, server, HUD).
-- Data flow between Server and HUD; coupling risks.
+- Modules and responsibilities (`hybrid/*`, `server/*`, `gui/ws_bridge.py`, `gui-svelte/*`).
+- Data flow between the TCP server, WS bridge, and browser GUI; coupling risks.
 - Physics/integration: dt stability, guidance math, ECM/ECCM model.
 
 3) Correctness & Risks

--- a/tests/test_start_gui_stack_security.py
+++ b/tests/test_start_gui_stack_security.py
@@ -1,6 +1,10 @@
-"""Regression coverage for secure launcher URL handling."""
+"""Regression coverage for secure launcher handling."""
 
-from tools.start_gui_stack import _append_query_param
+from tools.start_gui_stack import (
+    _append_query_param,
+    _resolve_allowed_origin_hosts,
+    _resolve_rcon_password,
+)
 
 
 def test_append_query_param_adds_new_value():
@@ -19,3 +23,41 @@ def test_append_query_param_replaces_existing_value():
         )
         == "http://localhost:3100/?game_code=new&foo=bar"
     )
+
+
+def test_resolve_rcon_password_prefers_cli(monkeypatch):
+    monkeypatch.setenv("FLAXOS_RCON_PASSWORD", "env-secret")
+    assert _resolve_rcon_password("cli-secret") == "cli-secret"
+
+
+def test_resolve_rcon_password_uses_env_when_cli_missing(monkeypatch):
+    monkeypatch.setenv("FLAXOS_RCON_PASSWORD", "env-secret")
+    assert _resolve_rcon_password(None) == "env-secret"
+
+
+def test_resolve_rcon_password_falls_back_to_admin(monkeypatch):
+    monkeypatch.delenv("FLAXOS_RCON_PASSWORD", raising=False)
+    assert _resolve_rcon_password(None) == "admin"
+
+
+def test_resolve_allowed_origin_hosts_adds_loopback_hosts():
+    assert _resolve_allowed_origin_hosts(["100.64.10.24"]) == [
+        "100.64.10.24",
+        "127.0.0.1",
+        "::1",
+        "localhost",
+    ]
+
+
+def test_resolve_allowed_origin_hosts_splits_and_normalizes_values():
+    assert _resolve_allowed_origin_hosts([" LOCALHOST, 100.64.10.24 ", "zt-host.local"]) == [
+        "100.64.10.24",
+        "127.0.0.1",
+        "::1",
+        "localhost",
+        "zt-host.local",
+    ]
+
+
+def test_resolve_allowed_origin_hosts_keeps_empty_config_open():
+    assert _resolve_allowed_origin_hosts([]) == []

--- a/tools/launch-spacesim-passworded.sh
+++ b/tools/launch-spacesim-passworded.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Flaxos Spaceship Sim — Password Prompt Launcher
+# Prompts for an RCON password, then launches the standard stack launcher.
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BASE_LAUNCHER="$PROJECT_DIR/tools/launch-spacesim.sh"
+
+notify() {
+    notify-send "Spaceship Sim" "$1" --icon=applications-games 2>/dev/null || true
+}
+
+die() {
+    echo "ERROR: $1" >&2
+    notify "Launch failed: $1"
+    read -rp "Press Enter to close..."
+    exit 1
+}
+
+have_zenity() {
+    command -v zenity >/dev/null 2>&1
+}
+
+prompt_password() {
+    local prompt="$1"
+    local value=""
+
+    if have_zenity; then
+        value="$(zenity --password --title="Spaceship Sim" --text="$prompt")" || return 1
+        printf '%s' "$value"
+        return 0
+    fi
+
+    read -rsp "$prompt: " value || return 1
+    echo
+    printf '%s' "$value"
+}
+
+prompt_text() {
+    local prompt="$1"
+    local value=""
+
+    if have_zenity; then
+        value="$(zenity --entry --title="Spaceship Sim" --text="$prompt")" || return 1
+        printf '%s' "$value"
+        return 0
+    fi
+
+    read -rp "$prompt: " value || return 1
+    printf '%s' "$value"
+}
+
+confirm_yes_no() {
+    local prompt="$1"
+
+    if have_zenity; then
+        zenity --question --title="Spaceship Sim" --text="$prompt"
+        return $?
+    fi
+
+    local answer=""
+    read -rp "$prompt [y/N]: " answer || return 1
+    [[ "$answer" =~ ^[Yy]$ ]]
+}
+
+for attempt in 1 2 3; do
+    RCON_PASSWORD="$(prompt_password "Enter the RCON password for Mission > Server")" || exit 0
+    [[ -n "$RCON_PASSWORD" ]] || {
+        notify "RCON password cannot be empty"
+        continue
+    }
+
+    CONFIRM_PASSWORD="$(prompt_password "Confirm the RCON password")" || exit 0
+    if [[ "$RCON_PASSWORD" == "$CONFIRM_PASSWORD" ]]; then
+        break
+    fi
+
+    notify "Passwords did not match"
+    if [[ "$attempt" -eq 3 ]]; then
+        die "RCON password confirmation failed three times"
+    fi
+done
+
+LAUNCH_ARGS=(--browser)
+
+if confirm_yes_no "Enable LAN / ZeroTier mode?"; then
+    ZT_HOSTS="$(prompt_text "Optional: enter ZeroTier IPs or hostnames to allow (comma-separated). localhost stays allowed automatically.")" || exit 0
+    GAME_CODE="$(prompt_text "Optional: enter a shared game code (leave blank to auto-generate)")" || exit 0
+
+    LAUNCH_ARGS+=(--lan --allowed-origin-host "localhost")
+    if [[ -n "${ZT_HOSTS// }" ]]; then
+        IFS=',' read -r -a ZT_HOST_ARRAY <<< "$ZT_HOSTS"
+        for host in "${ZT_HOST_ARRAY[@]}"; do
+            host="$(printf '%s' "$host" | xargs)"
+            [[ -n "$host" ]] || continue
+            LAUNCH_ARGS+=(--allowed-origin-host "$host")
+        done
+    fi
+
+    if [[ -n "$GAME_CODE" ]]; then
+        LAUNCH_ARGS+=(--game-code "$GAME_CODE")
+    fi
+fi
+
+export FLAXOS_RCON_PASSWORD="$RCON_PASSWORD"
+exec "$BASE_LAUNCHER" "${LAUNCH_ARGS[@]}"

--- a/tools/spaceship-sim-secure.desktop
+++ b/tools/spaceship-sim-secure.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Spaceship Sim (Secure Launch)
+Comment=Prompt for an RCON password and launch Flaxos Spaceship Sim
+Icon=applications-games
+Exec=xfce4-terminal --hold -e "bash -c '/home/flax/games/spaceship-sim/tools/launch-spacesim-passworded.sh'"
+Terminal=false
+Categories=Game;Simulation;
+StartupNotify=true

--- a/tools/start_gui_stack.py
+++ b/tools/start_gui_stack.py
@@ -2,8 +2,7 @@
 Start the full GUI stack in a single terminal:
 - TCP simulation server (unified entrypoint)
 - WebSocket bridge
-- GUI static file server
-- Asset editor server (REST API + editor UI)
+- GUI frontend (`gui-svelte` build by default, legacy `gui/` on demand)
 
 Uses the unified server.main entrypoint with --mode flag.
 """
@@ -94,6 +93,33 @@ def _append_query_param(url: str, key: str, value: str) -> str:
     )
 
 
+def _resolve_rcon_password(cli_value: str | None) -> str:
+    """Resolve RCON password with CLI taking precedence over inherited env."""
+    env_value = os.environ.get("FLAXOS_RCON_PASSWORD")
+    if cli_value:
+        return cli_value
+    if env_value:
+        return env_value
+    return "admin"
+
+
+def _resolve_allowed_origin_hosts(hosts: list[str] | None) -> list[str]:
+    """Normalize allowlist entries and preserve loopback origins when enabled."""
+    normalized: set[str] = set()
+    for raw_value in hosts or []:
+        if not raw_value:
+            continue
+        for candidate in raw_value.split(","):
+            host = candidate.strip().lower()
+            if host:
+                normalized.add(host)
+
+    if normalized:
+        normalized.update({"localhost", "127.0.0.1", "::1"})
+
+    return sorted(normalized)
+
+
 def main() -> int:
     signal.signal(signal.SIGTERM, _handle_shutdown_signal)
     signal.signal(signal.SIGINT, _handle_shutdown_signal)
@@ -147,8 +173,8 @@ def main() -> int:
     )
     parser.add_argument(
         "--rcon-password",
-        default="admin",
-        help="RCON password for admin commands (default: admin for localhost-only use)",
+        default=None,
+        help="RCON password for admin commands (defaults to FLAXOS_RCON_PASSWORD or admin)",
     )
     parser.add_argument(
         "--allowed-origin-host",
@@ -165,6 +191,9 @@ def main() -> int:
     if args.server:
         mode = "minimal" if args.server == "run" else "station"
         print(f"[warn] --server is deprecated, use --mode {mode} instead")
+
+    args.rcon_password = _resolve_rcon_password(args.rcon_password)
+    args.allowed_origin_host = _resolve_allowed_origin_hosts(args.allowed_origin_host)
 
     python = sys.executable
 


### PR DESCRIPTION
## What changed

This PR makes server/admin controls reachable without first loading a mission, and adds a secure desktop launch flow for setting the RCON password before the stack starts.

## Why

The previous layout buried `Mission > Server` behind the mission flow, which made UAT and remote admin awkward:
- you had to load a mission before the RCON panel was reachable
- once in-mission, you had to navigate back into the Mission tab to reach admin controls
- local desktop startup did not provide a clean password-prompt flow for RCON setup
- origin allowlisting could unintentionally block localhost when adding ZeroTier hosts

## User impact

- Top-level `MISSION` is now `CONFIG`
- `Config > Server` is always available, even before a mission is loaded
- `ScenarioLoader`, `Server`, `Console`, `Campaign`, and `Objectives` are consolidated into the config surface
- `SERVER` is the default active config subpanel so RCON/admin is immediately accessible
- Added a secure desktop launcher that prompts for the RCON password and optional ZeroTier/LAN settings
- Launcher allowlists keep localhost/loopback access while letting users add optional ZeroTier IPs/hosts
- Updated docs and AI helper guidance to match the current config/admin flow and launcher behavior

## Root cause

Admin and configuration controls were coupled to the mission lifecycle inside the Mission view. Separately, the new passworded launcher needed the stack launcher to honor `FLAXOS_RCON_PASSWORD`, and remote-origin setup needed loopback hosts preserved automatically.

## Validation

- `npm run check`
- `npm run build`
- `/home/flax/games/spaceship-sim/.venv/bin/pytest -q tests/test_start_gui_stack_security.py`
- `python3 -m py_compile tools/start_gui_stack.py`
- `bash -n tools/launch-spacesim-passworded.sh`

## Notes

- The PR intentionally excludes unrelated local smoke-test artifacts and HAR files from the source checkout.
- The secure desktop launcher is added as `tools/spaceship-sim-secure.desktop`; local desktop installation remains a user/workstation action outside the repo.
