### PR TITLE
[codex] Tactical audit: unify weapon wiring and state

### DIFF
--- a/gui-svelte/src/components/games/MunitionProgrammingPanel.svelte
+++ b/gui-svelte/src/components/games/MunitionProgrammingPanel.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
   import Panel from "../layout/Panel.svelte";
-  import { wsClient } from "../../lib/ws/wsClient.js";
   import { selectedLauncherType } from "../../lib/stores/tacticalUi.js";
+  import {
+    getMunitionProfileOptions,
+    GUIDANCE_OPTIONS,
+    programMunition,
+    WARHEAD_OPTIONS,
+  } from "../tactical/tacticalActions.js";
 
   let guidanceMode = "guided";
   let warheadType = "fragmentation";
@@ -11,17 +16,21 @@
   let terminalRange = "4000";
   let boostDuration = "6";
   let datalink = true;
+  $: profileOptions = getMunitionProfileOptions($selectedLauncherType);
+  $: if (!profileOptions.includes(flightProfile)) {
+    flightProfile = profileOptions[0] ?? "direct";
+  }
 
   async function program() {
-    await wsClient.sendShipCommand("program_munition", {
-      munition_type: $selectedLauncherType,
-      guidance_mode: guidanceMode,
-      warhead_type: warheadType,
-      flight_profile: flightProfile,
-      pn_gain: Number(pnGain),
-      fuse_distance: Number(fuseDistance),
-      terminal_range: Number(terminalRange),
-      boost_duration: Number(boostDuration),
+    await programMunition({
+      munitionType: $selectedLauncherType,
+      guidanceMode,
+      warheadType,
+      flightProfile,
+      pnGain: Number(pnGain),
+      fuseDistance: Number(fuseDistance),
+      terminalRange: Number(terminalRange),
+      boostDuration: Number(boostDuration),
       datalink,
     });
   }
@@ -30,9 +39,30 @@
 <Panel title="Munition Programming" domain="weapons" priority="secondary" className="munition-programming-panel">
   <div class="shell">
     <div class="grid">
-      <label><span>Guidance</span><input bind:value={guidanceMode} /></label>
-      <label><span>Warhead</span><input bind:value={warheadType} /></label>
-      <label><span>Profile</span><input bind:value={flightProfile} /></label>
+      <label>
+        <span>Guidance</span>
+        <select bind:value={guidanceMode}>
+          {#each GUIDANCE_OPTIONS as option}
+            <option value={option}>{option}</option>
+          {/each}
+        </select>
+      </label>
+      <label>
+        <span>Warhead</span>
+        <select bind:value={warheadType}>
+          {#each WARHEAD_OPTIONS as option}
+            <option value={option}>{option}</option>
+          {/each}
+        </select>
+      </label>
+      <label>
+        <span>Profile</span>
+        <select bind:value={flightProfile}>
+          {#each profileOptions as option}
+            <option value={option}>{option}</option>
+          {/each}
+        </select>
+      </label>
       <label><span>PN gain</span><input bind:value={pnGain} /></label>
       <label><span>Fuse distance</span><input bind:value={fuseDistance} /></label>
       <label><span>Terminal range</span><input bind:value={terminalRange} /></label>

--- a/gui-svelte/src/components/tactical/FireAuthorization.svelte
+++ b/gui-svelte/src/components/tactical/FireAuthorization.svelte
@@ -3,7 +3,6 @@
   import ProposalQueue from "../shared/ProposalQueue.svelte";
   import { gameState } from "../../lib/stores/gameState.js";
   import { tier } from "../../lib/stores/tier.js";
-  import { wsClient } from "../../lib/ws/wsClient.js";
   import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
   import {
     extractShipState,
@@ -12,6 +11,12 @@
     getLauncherInventory,
     getLockedTargetId,
   } from "./tacticalData.js";
+  import {
+    fireArcadeWeapon,
+    setEngagementRules,
+    toggleAutoTactical as setAutoTacticalEnabled,
+    toggleWeaponAuthorization,
+  } from "./tacticalActions.js";
   import { proposals } from "../../lib/stores/proposals.js";
 
   $: ship = extractShipState($gameState);
@@ -27,30 +32,16 @@
   $: autoTacticalEnabled = Boolean(autoTactical.enabled);
   $: engagementMode = String(autoTactical.engagement_mode ?? "weapons_hold");
 
-  async function fireNow(command: "fire_railgun" | "launch_torpedo" | "launch_missile") {
-    const params: Record<string, unknown> = {};
-    if (activeTargetId) params.target = activeTargetId;
-    if (command !== "fire_railgun") params.profile = "direct";
-    await wsClient.sendShipCommand(command, params);
+  async function fireNow(weaponType: "railgun" | "torpedo" | "missile") {
+    await fireArcadeWeapon(weaponType, activeTargetId || undefined);
   }
 
   async function toggleAuthorization(kind: "railgun" | "torpedo" | "missile") {
-    const enabled = authorized[kind];
-    await wsClient.sendShipCommand(enabled ? "deauthorize_weapon" : "authorize_weapon", {
-      weapon_type: kind,
-      profile: "direct",
-    });
+    await toggleWeaponAuthorization(kind, authorized[kind], { profile: "direct" });
   }
 
   async function toggleAutoTactical() {
-    await wsClient.sendShipCommand(
-      autoTacticalEnabled ? "disable_auto_tactical" : "enable_auto_tactical",
-      {}
-    );
-  }
-
-  async function setEngagementRules(mode: string) {
-    await wsClient.sendShipCommand("set_engagement_rules", { mode });
+    await setAutoTacticalEnabled(autoTacticalEnabled);
   }
 
   function ammoPercent(loaded: unknown, capacity: unknown): string {
@@ -71,14 +62,14 @@
   <div class="shell">
     {#if arcadeTier}
       <div class="arcade-grid">
-        <button class="arcade-btn railgun" on:click={() => fireNow("fire_railgun")}>
+        <button class="arcade-btn railgun" on:click={() => fireNow("railgun")}>
           <span>RAILGUN</span>
         </button>
-        <button class="arcade-btn torpedo" on:click={() => fireNow("launch_torpedo")}>
+        <button class="arcade-btn torpedo" on:click={() => fireNow("torpedo")}>
           <span>TORPEDO</span>
           <strong>{ammoPercent(inventory.torpedoes.loaded, inventory.torpedoes.capacity)}</strong>
         </button>
-        <button class="arcade-btn missile" on:click={() => fireNow("launch_missile")}>
+        <button class="arcade-btn missile" on:click={() => fireNow("missile")}>
           <span>MISSILE</span>
           <strong>{ammoPercent(inventory.missiles.loaded, inventory.missiles.capacity)}</strong>
         </button>

--- a/gui-svelte/src/components/tactical/LauncherControl.svelte
+++ b/gui-svelte/src/components/tactical/LauncherControl.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
   import Panel from "../layout/Panel.svelte";
   import { gameState } from "../../lib/stores/gameState.js";
-  import { wsClient } from "../../lib/ws/wsClient.js";
   import { selectedLauncherType, selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
   import { extractShipState, getLockedTargetId, getTacticalContacts } from "./tacticalData.js";
+  import {
+    getMunitionProfileOptions,
+    GUIDANCE_OPTIONS,
+    launchSalvo,
+    programMunition,
+    WARHEAD_OPTIONS,
+  } from "./tacticalActions.js";
 
-  const profiles = ["direct", "evasive", "terminal_pop", "bracket"];
   const salvoOptions = [1, 2, 4];
 
   let salvoSize = 1;
@@ -18,26 +23,28 @@
   $: contacts = getTacticalContacts(ship);
   $: lockedTargetId = getLockedTargetId(ship);
   $: selectedTarget = $selectedTacticalTargetId || lockedTargetId;
+  $: profileOptions = getMunitionProfileOptions($selectedLauncherType);
+  $: if (!profileOptions.includes(profile)) {
+    profile = profileOptions[0] ?? "direct";
+  }
 
   async function fire() {
-    await wsClient.sendShipCommand("launch_salvo", {
-      munition_type: $selectedLauncherType,
-      target: selectedTarget || undefined,
+    await launchSalvo({
+      munitionType: $selectedLauncherType,
+      targetId: selectedTarget || undefined,
       count: salvoSize,
       profile,
-      guidance_mode: guidanceMode,
-      warhead_type: warheadType,
+      guidanceMode,
+      warheadType,
     });
   }
 
   async function program() {
-    await wsClient.sendShipCommand("program_munition", {
-      munition_type: $selectedLauncherType,
-      flight_profile: profile,
-      guidance_mode: guidanceMode,
-      warhead_type: warheadType,
-      salvo_size: salvoSize,
-      target: selectedTarget || undefined,
+    await programMunition({
+      munitionType: $selectedLauncherType,
+      flightProfile: profile,
+      guidanceMode,
+      warheadType,
     });
   }
 
@@ -76,7 +83,7 @@
       <label>
         <span>Profile</span>
         <select bind:value={profile}>
-          {#each profiles as option}
+          {#each profileOptions as option}
             <option value={option}>{option}</option>
           {/each}
         </select>
@@ -84,8 +91,22 @@
     </div>
 
     <div class="option-grid">
-      <label><span>Guidance</span><input bind:value={guidanceMode} /></label>
-      <label><span>Warhead</span><input bind:value={warheadType} /></label>
+      <label>
+        <span>Guidance</span>
+        <select bind:value={guidanceMode}>
+          {#each GUIDANCE_OPTIONS as option}
+            <option value={option}>{option}</option>
+          {/each}
+        </select>
+      </label>
+      <label>
+        <span>Warhead</span>
+        <select bind:value={warheadType}>
+          {#each WARHEAD_OPTIONS as option}
+            <option value={option}>{option}</option>
+          {/each}
+        </select>
+      </label>
     </div>
 
     <div class="actions">

--- a/gui-svelte/src/components/tactical/PdcControl.svelte
+++ b/gui-svelte/src/components/tactical/PdcControl.svelte
@@ -1,34 +1,39 @@
 <script lang="ts">
   import Panel from "../layout/Panel.svelte";
   import { gameState } from "../../lib/stores/gameState.js";
-  import { wsClient } from "../../lib/ws/wsClient.js";
-  import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
-  import { extractShipState, getCombatState, getThreatList, toStringValue } from "./tacticalData.js";
+  import {
+    extractShipState,
+    formatDistance,
+    getCombatState,
+    getIncomingMunitions,
+    toStringValue,
+  } from "./tacticalData.js";
+  import { setPdcMode, setPdcPriority } from "./tacticalActions.js";
 
   const modes = [
     { label: "AUTO", value: "auto" },
     { label: "MANUAL", value: "manual" },
+    { label: "NETWORK", value: "network" },
     { label: "PRIORITY", value: "priority" },
     { label: "HOLD", value: "hold_fire" },
   ];
 
   $: ship = extractShipState($gameState);
   $: combat = getCombatState(ship);
-  $: threats = getThreatList(ship);
+  $: incomingMunitions = getIncomingMunitions($gameState, ship);
   $: mode = toStringValue(combat.pdc_mode, "auto");
-  $: priorityTarget = $selectedTacticalTargetId;
+  $: priorityTarget = Array.isArray(combat.pdc_priority_targets)
+    ? toStringValue(combat.pdc_priority_targets[0])
+    : "";
 
   async function setMode(next: string) {
-    await wsClient.sendShipCommand("set_pdc_mode", { mode: next });
+    await setPdcMode(next);
   }
 
   async function applyPriority(event: Event) {
     const targetId = (event.currentTarget as HTMLSelectElement).value;
     if (!targetId) return;
-    await wsClient.sendShipCommand("set_pdc_priority", {
-      torpedo_ids: [targetId],
-      target_id: targetId,
-    });
+    await setPdcPriority([targetId]);
   }
 </script>
 
@@ -41,11 +46,13 @@
     </div>
 
     <label>
-      <span>Priority target</span>
+      <span>Priority munition</span>
       <select value={priorityTarget} on:change={applyPriority}>
-        <option value="">Select track</option>
-        {#each threats as threat}
-          <option value={threat.id}>{threat.id} · {threat.classification}</option>
+        <option value="">Select incoming threat</option>
+        {#each incomingMunitions as munition}
+          <option value={munition.id}>
+            {munition.id} · {munition.munitionType.toUpperCase()} · {formatDistance(munition.distance)}
+          </option>
         {/each}
       </select>
     </label>
@@ -61,7 +68,7 @@
 
   .mode-grid {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     gap: 6px;
   }
 

--- a/gui-svelte/src/components/tactical/RailgunControl.svelte
+++ b/gui-svelte/src/components/tactical/RailgunControl.svelte
@@ -2,9 +2,9 @@
   import Panel from "../layout/Panel.svelte";
   import { gameState } from "../../lib/stores/gameState.js";
   import { tier } from "../../lib/stores/tier.js";
-  import { wsClient } from "../../lib/ws/wsClient.js";
   import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
   import { extractShipState, getLockedTargetId, getRailgunMounts } from "./tacticalData.js";
+  import { fireRailgun } from "./tacticalActions.js";
 
   $: ship = extractShipState($gameState);
   $: mounts = getRailgunMounts(ship);
@@ -12,9 +12,9 @@
   $: arcadeTier = $tier === "arcade";
 
   async function fireMount(mountId: string) {
-    await wsClient.sendShipCommand("fire_railgun", {
-      mount_id: mountId,
-      target: targetId || undefined,
+    await fireRailgun({
+      mountId,
+      targetId: targetId || undefined,
     });
   }
 </script>

--- a/gui-svelte/src/components/tactical/SensorContacts.svelte
+++ b/gui-svelte/src/components/tactical/SensorContacts.svelte
@@ -14,6 +14,7 @@
     getTacticalContacts,
     toNumber,
   } from "./tacticalData.js";
+  import { lockTarget } from "./tacticalActions.js";
 
   export let passive = false;
 
@@ -42,7 +43,7 @@
   async function lockContact(contactId: string) {
     selectedTacticalTargetId.set(contactId);
     if (passive) return;
-    await wsClient.sendShipCommand("lock_target", { contact_id: contactId });
+    await lockTarget(contactId);
   }
 </script>
 

--- a/gui-svelte/src/components/tactical/TacticalMap.svelte
+++ b/gui-svelte/src/components/tactical/TacticalMap.svelte
@@ -3,9 +3,9 @@
   import SpatialMapCanvas from "../spatial/SpatialMapCanvas.svelte";
   import type { SpatialLegendItem, SpatialLink, SpatialRing, SpatialTrack } from "../spatial/spatialMapTypes.js";
   import { gameState } from "../../lib/stores/gameState.js";
-  import { wsClient } from "../../lib/ws/wsClient.js";
   import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
   import { extractShipState, getTacticalContacts, getWeaponMounts } from "./tacticalData.js";
+  import { lockTarget } from "./tacticalActions.js";
   import { getOrientation, getPosition, getVelocity, toStringValue, toVec3 } from "../helm/helmData.js";
 
   type CombatEntity = Record<string, unknown>;
@@ -173,7 +173,7 @@
     lockBusy = true;
     try {
       selectedTacticalTargetId.set(id);
-      await wsClient.sendShipCommand("lock_target", { contact_id: id });
+      await lockTarget(id);
     } finally {
       lockBusy = false;
     }

--- a/gui-svelte/src/components/tactical/TargetingDisplay.svelte
+++ b/gui-svelte/src/components/tactical/TargetingDisplay.svelte
@@ -14,6 +14,7 @@
     toNumber,
     toStringValue,
   } from "./tacticalData.js";
+  import { lockTarget, unlockTarget } from "./tacticalActions.js";
 
   const stages = ["Acquisition", "Weapons Lock", "Solution", "Ready to Fire"];
 
@@ -49,14 +50,14 @@
     }
   }
 
-  async function designateTarget() {
+  async function lockSelectedTarget() {
     if (!targetId) return;
-    await wsClient.sendShipCommand("designate_target", { contact_id: targetId });
+    await lockTarget(targetId);
     await refreshSolution();
   }
 
-  async function unlockTarget() {
-    await wsClient.sendShipCommand("unlock_target", {});
+  async function clearTargetLock() {
+    await unlockTarget();
     solution = {};
   }
 </script>
@@ -91,8 +92,8 @@
     </div>
 
     <div class="actions">
-      <button disabled={!targetId} on:click={designateTarget}>DESIGNATE</button>
-      <button disabled={!lockedTargetId} on:click={unlockTarget}>UNLOCK</button>
+      <button disabled={!targetId} on:click={lockSelectedTarget}>LOCK TARGET</button>
+      <button disabled={!lockedTargetId} on:click={clearTargetLock}>CLEAR LOCK</button>
     </div>
   </div>
 </Panel>

--- a/gui-svelte/src/components/tactical/ThreatBoard.svelte
+++ b/gui-svelte/src/components/tactical/ThreatBoard.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
   import Panel from "../layout/Panel.svelte";
   import { gameState } from "../../lib/stores/gameState.js";
-  import { wsClient } from "../../lib/ws/wsClient.js";
   import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
   import { extractShipState, formatDistance, getThreatList } from "./tacticalData.js";
+  import { lockTarget } from "./tacticalActions.js";
 
   $: ship = extractShipState($gameState);
   $: threats = getThreatList(ship).slice(0, 8);
 
   async function lockThreat(contactId: string) {
     selectedTacticalTargetId.set(contactId);
-    await wsClient.sendShipCommand("lock_target", { contact_id: contactId });
+    await lockTarget(contactId);
   }
 </script>
 

--- a/gui-svelte/src/components/tactical/tacticalActions.ts
+++ b/gui-svelte/src/components/tactical/tacticalActions.ts
@@ -1,0 +1,139 @@
+import { wsClient } from "../../lib/ws/wsClient.js";
+
+export type TacticalWeaponType = "railgun" | "torpedo" | "missile";
+export type MunitionType = "torpedo" | "missile";
+
+export const GUIDANCE_OPTIONS = ["dumb", "guided", "smart"] as const;
+export const WARHEAD_OPTIONS = ["fragmentation", "shaped_charge", "emp"] as const;
+export const TORPEDO_PROFILE_OPTIONS = ["direct", "evasive"] as const;
+export const MISSILE_PROFILE_OPTIONS = ["direct", "evasive", "terminal_pop", "bracket"] as const;
+
+export function getMunitionProfileOptions(munitionType: MunitionType): readonly string[] {
+  return munitionType === "torpedo" ? TORPEDO_PROFILE_OPTIONS : MISSILE_PROFILE_OPTIONS;
+}
+
+function withOptionalTarget(targetId?: string): Record<string, unknown> {
+  return targetId ? { target: targetId } : {};
+}
+
+export async function lockTarget(contactId: string) {
+  return wsClient.sendShipCommand("lock_target", { contact_id: contactId });
+}
+
+export async function unlockTarget() {
+  return wsClient.sendShipCommand("unlock_target", {});
+}
+
+export async function toggleAutoTactical(enabled: boolean) {
+  return wsClient.sendShipCommand(enabled ? "disable_auto_tactical" : "enable_auto_tactical", {});
+}
+
+export async function setEngagementRules(mode: string) {
+  return wsClient.sendShipCommand("set_engagement_rules", { mode });
+}
+
+export async function toggleWeaponAuthorization(
+  weaponType: TacticalWeaponType,
+  enabled: boolean,
+  options: { count?: number; profile?: string } = {},
+) {
+  const command = enabled ? "deauthorize_weapon" : "authorize_weapon";
+  return wsClient.sendShipCommand(command, {
+    weapon_type: weaponType,
+    count: options.count ?? 1,
+    profile: options.profile ?? "direct",
+  });
+}
+
+export async function fireRailgun(options: {
+  mountId?: string;
+  targetId?: string;
+  slugType?: string;
+}) {
+  const params: Record<string, unknown> = {
+    ...withOptionalTarget(options.targetId),
+  };
+
+  if (options.mountId) params.mount_id = options.mountId;
+  if (options.slugType) params.slug_type = options.slugType;
+
+  return wsClient.sendShipCommand("fire_railgun", params);
+}
+
+export async function launchDirectMunition(
+  munitionType: MunitionType,
+  options: {
+    targetId?: string;
+    profile?: string;
+    guidanceMode?: string;
+    warheadType?: string;
+  } = {},
+) {
+  const command = munitionType === "torpedo" ? "launch_torpedo" : "launch_missile";
+  return wsClient.sendShipCommand(command, {
+    ...withOptionalTarget(options.targetId),
+    profile: options.profile ?? "direct",
+    guidance_mode: options.guidanceMode,
+    warhead_type: options.warheadType,
+  });
+}
+
+export async function fireArcadeWeapon(
+  weaponType: TacticalWeaponType,
+  targetId?: string,
+) {
+  if (weaponType === "railgun") {
+    return fireRailgun({ targetId });
+  }
+  return launchDirectMunition(weaponType, { targetId, profile: "direct" });
+}
+
+export async function launchSalvo(options: {
+  munitionType: MunitionType;
+  count: number;
+  targetId?: string;
+  profile?: string;
+  guidanceMode?: string;
+  warheadType?: string;
+}) {
+  return wsClient.sendShipCommand("launch_salvo", {
+    munition_type: options.munitionType,
+    count: options.count,
+    ...withOptionalTarget(options.targetId),
+    profile: options.profile ?? "direct",
+    guidance_mode: options.guidanceMode,
+    warhead_type: options.warheadType,
+  });
+}
+
+export async function programMunition(options: {
+  munitionType: MunitionType;
+  guidanceMode?: string;
+  warheadType?: string;
+  flightProfile?: string;
+  pnGain?: number;
+  fuseDistance?: number;
+  terminalRange?: number;
+  boostDuration?: number;
+  datalink?: boolean;
+}) {
+  return wsClient.sendShipCommand("program_munition", {
+    munition_type: options.munitionType,
+    guidance_mode: options.guidanceMode,
+    warhead_type: options.warheadType,
+    flight_profile: options.flightProfile,
+    pn_gain: options.pnGain,
+    fuse_distance: options.fuseDistance,
+    terminal_range: options.terminalRange,
+    boost_duration: options.boostDuration,
+    datalink: options.datalink,
+  });
+}
+
+export async function setPdcMode(mode: string) {
+  return wsClient.sendShipCommand("set_pdc_mode", { mode });
+}
+
+export async function setPdcPriority(torpedoIds: string[]) {
+  return wsClient.sendShipCommand("set_pdc_priority", { torpedo_ids: torpedoIds });
+}

--- a/gui-svelte/src/components/tactical/tacticalData.ts
+++ b/gui-svelte/src/components/tactical/tacticalData.ts
@@ -50,6 +50,19 @@ export interface WeaponMountState {
   range: number;
 }
 
+export interface ActiveMunitionState {
+  id: string;
+  munitionType: "torpedo" | "missile";
+  shooter: string;
+  target: string;
+  distance: number;
+  eta: number | null;
+  profile: string;
+  guidanceMode: string;
+  warheadType: string;
+  state: string;
+}
+
 const ZERO_VEC: Vec3 = { x: 0, y: 0, z: 0 };
 
 function textIncludes(source: string, values: string[]): boolean {
@@ -145,7 +158,7 @@ export function getTargetingState(ship: JsonMap): JsonMap {
 }
 
 export function getCombatState(ship: JsonMap): JsonMap {
-  return asRecord(ship.weapons) ?? asRecord(ship.combat) ?? getSystem(ship, "combat");
+  return asRecord(ship.combat) ?? getSystem(ship, "combat") ?? asRecord(ship.weapons) ?? {};
 }
 
 export function getECMState(ship: JsonMap): JsonMap {
@@ -240,6 +253,40 @@ export function getLauncherInventory(ship: JsonMap): { torpedoes: JsonMap; missi
     torpedoes: asRecord(combat.torpedoes) ?? {},
     missiles: asRecord(combat.missiles) ?? {},
   };
+}
+
+export function getIncomingMunitions(gameState: JsonMap, ship: JsonMap): ActiveMunitionState[] {
+  const shipId = toStringValue(ship.id);
+  const active = Array.isArray(gameState.torpedoes) ? gameState.torpedoes : [];
+
+  return active
+    .map((item) => asRecord(item))
+    .filter((item): item is JsonMap => Boolean(item))
+    .filter((item) => toStringValue(item.target) === shipId && toStringValue(item.shooter) !== shipId)
+    .map((item) => {
+      const munitionType: ActiveMunitionState["munitionType"] =
+        toStringValue(item.munition_type, "torpedo") === "missile"
+          ? "missile"
+          : "torpedo";
+      return {
+        id: toStringValue(item.id),
+        munitionType,
+        shooter: toStringValue(item.shooter),
+        target: toStringValue(item.target),
+        distance: toNumber(item.distance),
+        eta: item.eta == null ? null : toNumber(item.eta),
+        profile: toStringValue(item.profile, "direct"),
+        guidanceMode: toStringValue(item.guidance_mode, "guided"),
+        warheadType: toStringValue(item.warhead_type, "fragmentation"),
+        state: toStringValue(item.state, "unknown"),
+      };
+    })
+    .sort((a, b) => {
+      const etaA = a.eta ?? Number.POSITIVE_INFINITY;
+      const etaB = b.eta ?? Number.POSITIVE_INFINITY;
+      if (etaA !== etaB) return etaA - etaB;
+      return a.distance - b.distance;
+    });
 }
 
 export function getBestWeaponSolution(ship: JsonMap): JsonMap {

--- a/hybrid/commands/tactical_commands.py
+++ b/hybrid/commands/tactical_commands.py
@@ -140,40 +140,7 @@ def cmd_set_pdc_mode(combat, ship, params):
     Returns:
         dict: Mode change confirmation with affected PDC mounts
     """
-    valid_modes = ("auto", "manual", "hold_fire", "priority", "network")
-    mode = params.get("mode")
-    if mode not in valid_modes:
-        return error_dict("INVALID_MODE", f"PDC mode must be one of {valid_modes}, got '{mode}'")
-
-    affected = []
-    for mount_id, weapon in combat.truth_weapons.items():
-        if mount_id.startswith("pdc"):
-            weapon.pdc_mode = mode
-            if mode == "hold_fire":
-                weapon.enabled = False
-            else:
-                weapon.enabled = True
-            affected.append(mount_id)
-
-    # Clear stale network engagements when switching modes
-    combat._pdc_engagements.clear()
-
-    if not affected:
-        return error_dict("NO_PDC", "No PDC mounts available on this ship")
-
-    # Publish event
-    if hasattr(ship, "event_bus") and ship.event_bus:
-        ship.event_bus.publish("pdc_mode_changed", {
-            "ship_id": ship.id,
-            "mode": mode,
-            "mounts": affected,
-        })
-
-    return success_dict(
-        f"PDC mode set to {mode.upper()}",
-        mode=mode,
-        affected_mounts=affected,
-    )
+    return combat.command("set_pdc_mode", params)
 
 
 def cmd_launch_torpedo(combat, ship, params):
@@ -212,16 +179,11 @@ def cmd_launch_torpedo(combat, ship, params):
     if not target_id:
         return error_dict("NO_TARGET", "No target designated for torpedo launch")
 
-    # Route through legacy weapons system for torpedo
-    weapons = ship.systems.get("weapons")
-    if weapons and hasattr(weapons, "fire"):
-        return weapons.fire({
-            "weapon_type": "torpedo",
-            "target": target_id,
-            "profile": profile,
-        })
-
-    return error_dict("NO_TORPEDO", "No torpedo system available")
+    all_ships = params.get("all_ships", {})
+    return combat.launch_torpedo(
+        target_id, profile, all_ships,
+        warhead_type=warhead_type, guidance_mode=guidance_mode,
+    )
 
 
 def cmd_launch_missile(combat, ship, params):
@@ -516,24 +478,7 @@ def cmd_set_pdc_priority(combat, ship, params):
     Returns:
         dict: Confirmation with the accepted priority list
     """
-    torpedo_ids = params.get("torpedo_ids")
-    if not isinstance(torpedo_ids, list):
-        return error_dict(
-            "INVALID_PARAMETER",
-            "torpedo_ids must be a list of torpedo IDs in priority order"
-        )
-    combat.pdc_priority_targets = list(torpedo_ids)
-
-    if hasattr(ship, "event_bus") and ship.event_bus:
-        ship.event_bus.publish("pdc_priority_set", {
-            "ship_id": ship.id,
-            "torpedo_ids": combat.pdc_priority_targets,
-        })
-
-    return success_dict(
-        f"PDC priority queue set ({len(torpedo_ids)} targets)",
-        torpedo_ids=combat.pdc_priority_targets,
-    )
+    return combat.command("set_pdc_priority", params)
 
 
 def cmd_authorize_weapon(combat, ship, params):

--- a/tests/systems/combat/test_tactical_command_wiring.py
+++ b/tests/systems/combat/test_tactical_command_wiring.py
@@ -1,0 +1,81 @@
+"""Regression coverage for tactical command wiring consistency."""
+
+from unittest.mock import MagicMock
+
+
+def test_dispatcher_launch_torpedo_uses_combat_system_not_legacy_weapons():
+    """Typed tactical command path should launch through CombatSystem.
+
+    The GUI's live path already routes launch_torpedo to combat. Keep the
+    registered tactical command path aligned so tests, tools, and alternate
+    dispatchers do not silently fall back to legacy weapons.fire().
+    """
+    from hybrid.commands.dispatch import create_default_dispatcher
+
+    dispatcher = create_default_dispatcher()
+
+    combat = MagicMock()
+    combat.launch_torpedo.return_value = {"ok": True, "via": "combat"}
+
+    targeting = MagicMock()
+    targeting.locked_target = "C001"
+
+    legacy_weapons = MagicMock()
+
+    ship = MagicMock()
+    ship.id = "player"
+    ship.systems = {
+        "combat": combat,
+        "targeting": targeting,
+        "weapons": legacy_weapons,
+    }
+
+    result = dispatcher.dispatch("launch_torpedo", ship, {"profile": "direct"})
+
+    assert result["ok"] is True
+    assert result["via"] == "combat"
+    combat.launch_torpedo.assert_called_once_with(
+        "C001", "direct", {},
+        warhead_type=None, guidance_mode=None,
+    )
+    legacy_weapons.fire.assert_not_called()
+
+
+def test_dispatcher_set_pdc_mode_uses_combat_command_path():
+    """Registered tactical PDC mode command should delegate to combat.command()."""
+    from hybrid.commands.dispatch import create_default_dispatcher
+
+    dispatcher = create_default_dispatcher()
+
+    combat = MagicMock()
+    combat.command.return_value = {"ok": True, "mode": "network"}
+
+    ship = MagicMock()
+    ship.id = "player"
+    ship.systems = {"combat": combat}
+
+    result = dispatcher.dispatch("set_pdc_mode", ship, {"mode": "network"})
+
+    assert result["ok"] is True
+    assert result["mode"] == "network"
+    combat.command.assert_called_once_with("set_pdc_mode", {"mode": "network"})
+
+
+def test_dispatcher_set_pdc_priority_uses_combat_command_path():
+    """Registered tactical PDC priority command should delegate to combat.command()."""
+    from hybrid.commands.dispatch import create_default_dispatcher
+
+    dispatcher = create_default_dispatcher()
+
+    combat = MagicMock()
+    combat.command.return_value = {"ok": True, "torpedo_ids": ["torp_1"]}
+
+    ship = MagicMock()
+    ship.id = "player"
+    ship.systems = {"combat": combat}
+
+    result = dispatcher.dispatch("set_pdc_priority", ship, {"torpedo_ids": ["torp_1"]})
+
+    assert result["ok"] is True
+    assert result["torpedo_ids"] == ["torp_1"]
+    combat.command.assert_called_once_with("set_pdc_priority", {"torpedo_ids": ["torp_1"]})


### PR DESCRIPTION
## What changed
This tranche hardens the tactical GUI and command path so the visible tactical controls are routed through one canonical action layer and consume authoritative combat/targeting state.

- added shared `tacticalActions` helpers for lock, fire, salvo, munition programming, PDC mode, and PDC priority actions
- rewired the tactical Svelte panels to use the shared action layer instead of ad hoc payloads
- normalized tactical state reads to prefer `combat` / `targeting` telemetry over legacy `ship.weapons`
- changed PDC priority selection to operate on actual incoming munitions rather than generic contacts
- aligned registered tactical dispatcher paths so torpedo launch and PDC commands delegate through `CombatSystem`
- added regression coverage for tactical command wiring

## Why
The tactical UI had drifted across multiple control surfaces. Different panels were issuing slightly different payloads, some controls were reading stale or ambiguous state, and launcher/PDC workflows were not deterministic across the tactical view.

This PR fixes the first required tranche: make the GUI wiring explicit and consistent, and make state presentation come from the same backend authority the commands use.

## Audit findings
Current tactical audit findings after this tranche:

- target-lock semantics were inconsistent across panels (`designate_target` alias vs `lock_target`)
- tactical panels were split between `ship.weapons` and `ship.combat` state
- PDC priority UI was keyed to generic threats rather than incoming munition IDs expected by the backend
- the alternate registered tactical dispatcher path had drifted from the live command route for torpedo and PDC actions

Remaining follow-up identified during audit:

- publish explicit combat event-bus notifications for PDC mode / priority changes so non-polling consumers can react immediately
- continue the workflow pass from target selection -> lock -> authorize/program/fire across arcade, CPU-assist, and manual tiers

## Validation
- `cd gui-svelte && npm run check`
- `python3 -m pytest tests/systems/combat/test_tactical_command_wiring.py -q`
- `python3 -m pytest tests/systems/combat/test_pdc_defense_modes.py tests/systems/combat/test_tactical_command_wiring.py tests/test_multi_target.py -q` run in the isolated local tactical branch before trimming the publishable tranche
