### PR TITLE
feat(tactical-ux): disabled state explanations, loading states, passive mode visual

### DIFF
--- a/gui-svelte/src/components/tactical/FireAuthorization.svelte
+++ b/gui-svelte/src/components/tactical/FireAuthorization.svelte
@@ -32,8 +32,18 @@
   $: autoTacticalEnabled = Boolean(autoTactical.enabled);
   $: engagementMode = String(autoTactical.engagement_mode ?? "weapons_hold");
 
+  let firingNow: string | null = null;
+  let engagementPending = false;
+  let autoTacticalPending = false;
+
   async function fireNow(weaponType: "railgun" | "torpedo" | "missile") {
-    await fireArcadeWeapon(weaponType, activeTargetId || undefined);
+    if (firingNow) return;
+    firingNow = weaponType;
+    try {
+      await fireArcadeWeapon(weaponType, activeTargetId || undefined);
+    } finally {
+      firingNow = null;
+    }
   }
 
   async function toggleAuthorization(kind: "railgun" | "torpedo" | "missile") {
@@ -41,7 +51,23 @@
   }
 
   async function toggleAutoTactical() {
-    await setAutoTacticalEnabled(autoTacticalEnabled);
+    if (autoTacticalPending) return;
+    autoTacticalPending = true;
+    try {
+      await setAutoTacticalEnabled(autoTacticalEnabled);
+    } finally {
+      autoTacticalPending = false;
+    }
+  }
+
+  async function setEngagement(key: string) {
+    if (engagementPending) return;
+    engagementPending = true;
+    try {
+      await setEngagementRules(key);
+    } finally {
+      engagementPending = false;
+    }
   }
 
   function ammoPercent(loaded: unknown, capacity: unknown): string {
@@ -62,14 +88,29 @@
   <div class="shell">
     {#if arcadeTier}
       <div class="arcade-grid">
-        <button class="arcade-btn railgun" on:click={() => fireNow("railgun")}>
+        <button
+          class="arcade-btn railgun"
+          disabled={firingNow === "railgun"}
+          title={!activeTargetId ? "Select a target first" : "Fire railgun at locked target"}
+          on:click={() => fireNow("railgun")}
+        >
           <span>RAILGUN</span>
         </button>
-        <button class="arcade-btn torpedo" on:click={() => fireNow("torpedo")}>
+        <button
+          class="arcade-btn torpedo"
+          disabled={firingNow === "torpedo" || Number(inventory.torpedoes.loaded) <= 0}
+          title={Number(inventory.torpedoes.loaded) <= 0 ? "No torpedoes loaded" : !activeTargetId ? "Select a target first" : "Fire torpedo at locked target"}
+          on:click={() => fireNow("torpedo")}
+        >
           <span>TORPEDO</span>
           <strong>{ammoPercent(inventory.torpedoes.loaded, inventory.torpedoes.capacity)}</strong>
         </button>
-        <button class="arcade-btn missile" on:click={() => fireNow("missile")}>
+        <button
+          class="arcade-btn missile"
+          disabled={firingNow === "missile" || Number(inventory.missiles.loaded) <= 0}
+          title={Number(inventory.missiles.loaded) <= 0 ? "No missiles loaded" : !activeTargetId ? "Select a target first" : "Fire missile at locked target"}
+          on:click={() => fireNow("missile")}
+        >
           <span>MISSILE</span>
           <strong>{ammoPercent(inventory.missiles.loaded, inventory.missiles.capacity)}</strong>
         </button>
@@ -79,10 +120,12 @@
       <button
         class="auto-toggle"
         class:active={autoTacticalEnabled}
+        disabled={autoTacticalPending}
+        title={autoTacticalEnabled ? "Disable autonomous weapon engagement" : "Enable autonomous weapon engagement"}
         type="button"
         on:click={toggleAutoTactical}
       >
-        AUTO-TACTICAL: {autoTacticalEnabled ? "ENABLED" : "DISABLED"}
+        AUTO-TACTICAL: {autoTacticalPending ? "…" : autoTacticalEnabled ? "ENABLED" : "DISABLED"}
       </button>
 
       <!-- Engagement rules -->
@@ -90,8 +133,10 @@
         {#each ENGAGEMENT_MODES as { key, label }}
           <button
             class:selected={engagementMode === key}
+            disabled={engagementPending}
+            title={{ weapons_free: "Engage any valid target", weapons_hold: "Do not fire — hold all weapons", defensive_only: "Engage only inbound munitions" }[key]}
             type="button"
-            on:click={() => setEngagementRules(key)}
+            on:click={() => setEngagement(key)}
           >
             {label}
           </button>

--- a/gui-svelte/src/components/tactical/PdcControl.svelte
+++ b/gui-svelte/src/components/tactical/PdcControl.svelte
@@ -18,6 +18,8 @@
     { label: "HOLD", value: "hold_fire" },
   ];
 
+  let modePending = false;
+
   $: ship = extractShipState($gameState);
   $: combat = getCombatState(ship);
   $: incomingMunitions = getIncomingMunitions($gameState, ship);
@@ -26,8 +28,22 @@
     ? toStringValue(combat.pdc_priority_targets[0])
     : "";
 
+  const modeDescriptions: Record<string, string> = {
+    auto: "Automatically engage incoming threats",
+    manual: "PDC fires only on explicit command",
+    network: "Coordinate engagement across all PDC mounts",
+    priority: "Engage threat-board priority targets first",
+    hold_fire: "PDC will not fire — all mounts safed",
+  };
+
   async function setMode(next: string) {
-    await setPdcMode(next);
+    if (modePending || mode === next) return;
+    modePending = true;
+    try {
+      await setPdcMode(next);
+    } finally {
+      modePending = false;
+    }
   }
 
   async function applyPriority(event: Event) {
@@ -41,7 +57,13 @@
   <div class="shell">
     <div class="mode-grid">
       {#each modes as item}
-        <button class:selected={mode === item.value} type="button" on:click={() => setMode(item.value)}>{item.label}</button>
+        <button
+          class:selected={mode === item.value}
+          disabled={modePending}
+          title={modeDescriptions[item.value] ?? item.label}
+          type="button"
+          on:click={() => setMode(item.value)}
+        >{item.label}</button>
       {/each}
     </div>
 

--- a/gui-svelte/src/components/tactical/RailgunControl.svelte
+++ b/gui-svelte/src/components/tactical/RailgunControl.svelte
@@ -11,11 +11,28 @@
   $: targetId = $selectedTacticalTargetId || getLockedTargetId(ship);
   $: arcadeTier = $tier === "arcade";
 
+  let firing = new Set<string>();
+
   async function fireMount(mountId: string) {
-    await fireRailgun({
-      mountId,
-      targetId: targetId || undefined,
-    });
+    if (firing.has(mountId)) return;
+    firing = new Set(firing).add(mountId);
+    try {
+      await fireRailgun({ mountId, targetId: targetId || undefined });
+    } finally {
+      firing = new Set(firing);
+      firing.delete(mountId);
+      firing = firing;
+    }
+  }
+
+  function fireTitle(mount: ReturnType<typeof getRailgunMounts>[number]): string {
+    if (mount.ammo <= 0) return "No ammunition";
+    if (!mount.ready) {
+      const pct = Math.round(mount.charge * 100);
+      return pct < 100 ? `Charging (${pct}%)` : "Not ready";
+    }
+    if (!targetId) return "No target selected";
+    return "Fire railgun";
   }
 </script>
 
@@ -28,12 +45,23 @@
         <div class="mount-row">
           <div class="meta">
             <strong>{mount.id}</strong>
-            <span>{mount.ammo} slugs · {mount.ready ? "READY" : mount.status.toUpperCase()}</span>
+            <span>
+              {mount.ammo} slugs ·
+              {#if mount.ready}
+                READY
+              {:else}
+                {mount.status.toUpperCase()} {mount.charge < 1 ? `${Math.round(mount.charge * 100)}%` : ""}
+              {/if}
+            </span>
           </div>
           <div class="track">
             <div class="fill" class:arcade={arcadeTier} style={`width: ${Math.round(mount.charge * 100)}%;`}></div>
           </div>
-          <button disabled={!mount.ready || mount.ammo <= 0} on:click={() => fireMount(mount.id)}>FIRE</button>
+          <button
+            disabled={!mount.ready || mount.ammo <= 0 || firing.has(mount.id)}
+            title={fireTitle(mount)}
+            on:click={() => fireMount(mount.id)}
+          >{firing.has(mount.id) ? "…" : "FIRE"}</button>
         </div>
       {/each}
     {/if}

--- a/gui-svelte/src/components/tactical/SensorContacts.svelte
+++ b/gui-svelte/src/components/tactical/SensorContacts.svelte
@@ -51,10 +51,19 @@
   <div class="shell">
     {#if !passive}
       <div class="toolbar">
-        <button disabled={!canPing || busy} on:click={pingSensors}>
-          {cooldown > 0 ? `PING ${cooldown.toFixed(1)}s` : "PING SENSORS"}
+        <button
+          disabled={!canPing || busy}
+          title={cooldown > 0 ? `Active ping cooling down — ready in ${cooldown.toFixed(1)}s` : busy ? "Pinging…" : "Send active sonar ping to resolve contacts"}
+          on:click={pingSensors}
+        >
+          {cooldown > 0 ? `PING ${cooldown.toFixed(1)}s` : busy ? "PINGING…" : "PING SENSORS"}
         </button>
         <div class="summary">{contacts.length} contacts</div>
+      </div>
+    {:else}
+      <div class="toolbar passive-bar">
+        <span class="passive-badge">PASSIVE</span>
+        <div class="summary">{contacts.length} contacts · read-only</div>
       </div>
     {/if}
 
@@ -69,6 +78,7 @@
             class:passive={passive}
             type="button"
             disabled={passive}
+            title={passive ? "Passive mode — active lock unavailable" : `Lock ${contact.id} as tactical target`}
             on:click={() => lockContact(contact.id)}
           >
             <div class="topline">
@@ -148,7 +158,23 @@
   }
 
   .contact-row.passive {
-    cursor: default;
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+
+  .passive-bar {
+    align-items: center;
+  }
+
+  .passive-badge {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.1em;
+    padding: 3px 7px;
+    border-radius: 3px;
+    background: rgba(255, 216, 77, 0.18);
+    color: #ffd84d;
+    border: 1px solid rgba(255, 216, 77, 0.35);
   }
 
   .contact-row strong {

--- a/gui-svelte/src/components/tactical/TacticalMap.svelte
+++ b/gui-svelte/src/components/tactical/TacticalMap.svelte
@@ -181,19 +181,43 @@
 </script>
 
 <Panel title="Tactical Map" domain="sensor" priority="primary" className="tactical-map-panel">
-  <SpatialMapCanvas
-    mode="tactical"
-    {tracks}
-    {rings}
-    {links}
-    {legendItems}
-    ownshipId="ownship"
-    selectedId={$selectedTacticalTargetId}
-    {initialRadius}
-    caption="Plan view emphasizes target geometry and weapon envelopes. The elevation strip now only mirrors ownship and focused tracks so Z cues stay readable. Wheel zooms on cursor; drag pans."
-    selectionActionLabel="Lock"
-    selectionActionDisabled={!$selectedTacticalTargetId || lockBusy}
-    on:select={(event) => selectedTacticalTargetId.set(event.detail.id)}
-    on:activate={(event) => lockSelected(event.detail.id)}
-  />
+  <div class="map-wrapper" class:lock-busy={lockBusy}>
+    <SpatialMapCanvas
+      mode="tactical"
+      {tracks}
+      {rings}
+      {links}
+      {legendItems}
+      ownshipId="ownship"
+      selectedId={$selectedTacticalTargetId}
+      {initialRadius}
+      caption="Scroll to zoom · drag to pan · click contact to select · Lock to acquire targeting"
+      selectionActionLabel={lockBusy ? "Locking…" : "Lock"}
+      selectionActionDisabled={!$selectedTacticalTargetId || lockBusy}
+      on:select={(event) => selectedTacticalTargetId.set(event.detail.id)}
+      on:activate={(event) => lockSelected(event.detail.id)}
+    />
+  </div>
 </Panel>
+
+<style>
+  .map-wrapper {
+    position: relative;
+    display: contents;
+  }
+
+  .map-wrapper.lock-busy::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border: 2px solid rgba(var(--tier-accent-rgb), 0.5);
+    border-radius: var(--radius-sm);
+    pointer-events: none;
+    animation: lock-pulse 0.7s ease-in-out infinite;
+  }
+
+  @keyframes lock-pulse {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 0.9; }
+  }
+</style>

--- a/gui-svelte/src/components/tactical/TargetingDisplay.svelte
+++ b/gui-svelte/src/components/tactical/TargetingDisplay.svelte
@@ -20,6 +20,7 @@
 
   let solution: Record<string, unknown> = {};
   let pollHandle: number | null = null;
+  let locking = false;
 
   $: ship = extractShipState($gameState);
   $: targeting = getTargetingSummary(ship);
@@ -51,9 +52,14 @@
   }
 
   async function lockSelectedTarget() {
-    if (!targetId) return;
-    await lockTarget(targetId);
-    await refreshSolution();
+    if (!targetId || locking) return;
+    locking = true;
+    try {
+      await lockTarget(targetId);
+      await refreshSolution();
+    } finally {
+      locking = false;
+    }
   }
 
   async function clearTargetLock() {
@@ -92,8 +98,16 @@
     </div>
 
     <div class="actions">
-      <button disabled={!targetId} on:click={lockSelectedTarget}>LOCK TARGET</button>
-      <button disabled={!lockedTargetId} on:click={clearTargetLock}>CLEAR LOCK</button>
+      <button
+        disabled={!targetId || locking}
+        title={!targetId ? "Select a contact first" : locking ? "Acquiring lock…" : "Acquire targeting lock"}
+        on:click={lockSelectedTarget}
+      >{locking ? "LOCKING…" : "LOCK TARGET"}</button>
+      <button
+        disabled={!lockedTargetId}
+        title={!lockedTargetId ? "No active lock" : "Release targeting lock"}
+        on:click={clearTargetLock}
+      >CLEAR LOCK</button>
     </div>
   </div>
 </Panel>

--- a/gui-svelte/src/components/tactical/ThreatBoard.svelte
+++ b/gui-svelte/src/components/tactical/ThreatBoard.svelte
@@ -8,25 +8,41 @@
   $: ship = extractShipState($gameState);
   $: threats = getThreatList(ship).slice(0, 8);
 
+  let locking: string | null = null;
+
   async function lockThreat(contactId: string) {
-    selectedTacticalTargetId.set(contactId);
-    await lockTarget(contactId);
+    if (locking) return;
+    locking = contactId;
+    try {
+      selectedTacticalTargetId.set(contactId);
+      await lockTarget(contactId);
+    } finally {
+      locking = null;
+    }
   }
 </script>
 
 <Panel title="Threat Board" domain="weapons" priority="secondary" className="threat-board-panel">
   <div class="shell">
     {#if threats.length === 0}
-      <div class="empty">Threat queue clear.</div>
+      <div class="empty">No active threats detected.</div>
     {:else}
       {#each threats as threat, index}
-        <button class="threat-row {threat.threatLevel}" class:selected={threat.id === $selectedTacticalTargetId} type="button" on:click={() => lockThreat(threat.id)}>
+        <button
+          class="threat-row {threat.threatLevel}"
+          class:selected={threat.id === $selectedTacticalTargetId}
+          class:locking={locking === threat.id}
+          disabled={locking != null}
+          title="Lock {threat.id} as primary target"
+          type="button"
+          on:click={() => lockThreat(threat.id)}
+        >
           <span class="index">{index + 1}</span>
           <div class="body">
             <strong>{threat.id}</strong>
             <span>{threat.classification || "Unknown"} · {formatDistance(threat.distance)}</span>
           </div>
-          <span class="score">{Math.round(threat.threatScore * 100)}</span>
+          <span class="score" title="Composite threat score (0–100): range, closure rate, classification">{Math.round(threat.threatScore * 100)}</span>
         </button>
       {/each}
     {/if}
@@ -54,6 +70,10 @@
 
   .threat-row.selected {
     border-color: rgba(var(--tier-accent-rgb), 0.5);
+  }
+
+  .threat-row.locking {
+    opacity: 0.6;
   }
 
   .threat-row.red { border-color: rgba(255, 68, 68, 0.45); }


### PR DESCRIPTION
## Summary

Phase 1 of the tactical UX polish plan. Every panel now explains disabled states, shows in-flight feedback, and distinguishes passive/read-only modes.

- **RailgunControl**: FIRE button title shows "Charging (X%)" / "No ammunition" / "No target selected"; charge % shown inline; button shows "…" while in-flight
- **TargetingDisplay**: LOCK TARGET shows "LOCKING…" and disables during in-flight; both buttons have `title` for every disabled state
- **FireAuthorization**: arcade fire buttons disabled when empty with reason in title; CPU-assist engagement mode buttons have title per mode + disabled-while-pending; auto-tactical toggle shows "…" during flight
- **PdcControl**: mode buttons have tooltip describing each mode's behaviour; disabled while a mode change is in-flight
- **ThreatBoard**: row dims while acquiring lock; score column tooltip explains the 0–100 scale; "No active threats detected" empty state
- **SensorContacts**: passive mode now shows a PASSIVE badge and 55% opacity + `cursor: not-allowed` on rows; ping button shows cooldown or "PINGING…"
- **TacticalMap**: animated border pulse while `lockBusy`; caption reduced to one-line usage hint

## Test plan

- [x] `npm run build` in `gui-svelte/` — clean, no errors
- [ ] Human: hover over disabled FIRE/LOCK/PING buttons — tooltip appears
- [ ] Human: fire railgun while another mount is recharging — FIRE shows "…" then reverts
- [ ] Human: lock a threat from ThreatBoard — row dims briefly while acquiring
- [ ] Human: switch PDC mode — button disables briefly while in-flight
- [ ] Human: view SensorContacts in passive mode — PASSIVE badge visible, clicks blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)