### PR TITLE
feat(uat): Phase 3 ops/engineering/stealth command sweep and scenario tests

### DIFF
--- a/tests/systems/ops/__init__.py
+++ b/tests/systems/ops/__init__.py
@@ -1,0 +1,2 @@
+# tests/systems/ops/__init__.py
+"""Ops, engineering, and stealth system tests."""

--- a/tests/systems/ops/test_damage_control_scenarios.py
+++ b/tests/systems/ops/test_damage_control_scenarios.py
@@ -1,0 +1,251 @@
+# tests/systems/ops/test_damage_control_scenarios.py
+"""Damage control scenario tests: repair pipeline, system triage, emergency shutdown.
+
+Focus: scenario 22_damage_control.yaml — pre-damaged ship with sensors at 60%,
+propulsion at 70%, RCS at 85%, weapons at 80%.
+
+Gaps filled vs. existing unit tests in test_cascade_integration.py and
+test_damage_model_v060.py:
+- Repair dispatch/cancel/priority via command routing (not direct method calls)
+- Emergency shutdown + restart cycle through command handler
+- System priority and power allocation under damage conditions
+- report_status includes subsystem damage in the response
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT_DIR))
+
+from hybrid_runner import HybridRunner
+from hybrid.command_handler import route_command
+
+
+SCENARIO = "22_damage_control"
+PLAYER_ID = "player"
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def runner():
+    r = HybridRunner()
+    r.load_scenario(SCENARIO)
+    r.simulator.start()
+    return r
+
+
+@pytest.fixture
+def sim(runner):
+    return runner.simulator
+
+
+def issue(sim, command: str, params: dict) -> dict:
+    ship = sim.ships[PLAYER_ID]
+    result = route_command(
+        ship,
+        {"command": command, "ship": PLAYER_ID, **params},
+        list(sim.ships.values()),
+    )
+    return result if isinstance(result, dict) else {"error": str(result)}
+
+
+# ---------------------------------------------------------------------------
+# Pre-damaged state
+# ---------------------------------------------------------------------------
+
+class TestPreDamagedState:
+    """Scenario starts with subsystems below 100% health."""
+
+    def test_sensors_pre_damaged(self, sim):
+        ship = sim.ships[PLAYER_ID]
+        dm = ship.damage_model
+        assert dm.subsystems["sensors"].health < 100.0, (
+            "sensors should start below full health in damage_control scenario"
+        )
+
+    def test_propulsion_pre_damaged(self, sim):
+        ship = sim.ships[PLAYER_ID]
+        dm = ship.damage_model
+        assert dm.subsystems["propulsion"].health < 100.0
+
+    def test_report_status_reflects_damage(self, sim):
+        result = issue(sim, "report_status", {})
+        assert result.get("ok") is True
+        report = result.get("subsystem_report", {})
+        subsystems = report.get("subsystems", {})
+        assert "sensors" in subsystems or "propulsion" in subsystems, (
+            "report_status subsystem_report.subsystems should list damaged systems"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Repair dispatch
+# ---------------------------------------------------------------------------
+
+class TestRepairDispatch:
+    """Dispatching teams and tracking status via command routing."""
+
+    def _fresh_dispatch(self, sim, subsystem: str = "sensors") -> dict:
+        issue(sim, "cancel_repair", {"subsystem": subsystem})
+        return issue(sim, "dispatch_repair", {"subsystem": subsystem})
+
+    def test_dispatch_repair_returns_ok(self, sim):
+        result = self._fresh_dispatch(sim, "sensors")
+        assert result.get("ok") is True
+
+    def test_dispatch_repair_includes_team(self, sim):
+        result = self._fresh_dispatch(sim, "sensors")
+        assert result.get("ok") is True
+        team = result.get("team", {})
+        assert team.get("assigned_subsystem") == "sensors"
+
+    def test_dispatch_repair_provides_eta(self, sim):
+        result = self._fresh_dispatch(sim, "sensors")
+        assert result.get("ok") is True
+        assert result.get("eta") is not None
+
+    def test_repair_status_lists_active_teams(self, sim):
+        self._fresh_dispatch(sim, "propulsion")
+        result = issue(sim, "repair_status", {})
+        assert "repair_teams" in result
+
+    def test_cancel_repair_returns_dict(self, sim):
+        self._fresh_dispatch(sim, "sensors")
+        result = issue(sim, "cancel_repair", {"subsystem": "sensors"})
+        assert isinstance(result, dict)
+
+    def test_dispatch_repair_no_subsystem_rejects(self, sim):
+        result = issue(sim, "dispatch_repair", {})
+        assert result.get("ok") is False
+
+    def test_set_repair_priority_returns_ok(self, sim):
+        result = issue(sim, "set_repair_priority", {
+            "subsystem": "sensors", "priority": "high",
+        })
+        assert result.get("ok") is True
+
+    def test_set_repair_priority_invalid_rejects(self, sim):
+        result = issue(sim, "set_repair_priority", {
+            "subsystem": "sensors", "priority": "ultra_max_extreme",
+        })
+        assert result.get("ok") is False
+
+
+# ---------------------------------------------------------------------------
+# Emergency shutdown / restart
+# ---------------------------------------------------------------------------
+
+class TestEmergencyShutdown:
+    """Emergency shutdown and restart cycle."""
+
+    def _ensure_online(self, sim, subsystem: str) -> None:
+        """Restart a system if it was left shut down by a prior test."""
+        issue(sim, "restart_system", {"subsystem": subsystem})
+
+    def test_emergency_shutdown_returns_ok(self, sim):
+        self._ensure_online(sim, "sensors")
+        result = issue(sim, "emergency_shutdown", {"subsystem": "sensors"})
+        assert result.get("ok") is True
+
+    def test_emergency_shutdown_lists_subsystem_in_response(self, sim):
+        self._ensure_online(sim, "sensors")
+        result = issue(sim, "emergency_shutdown", {"subsystem": "sensors"})
+        assert result.get("ok") is True
+        assert result.get("subsystem") == "sensors"
+
+    def test_restart_system_returns_ok(self, sim):
+        issue(sim, "emergency_shutdown", {"subsystem": "sensors"})
+        result = issue(sim, "restart_system", {"subsystem": "sensors"})
+        assert result.get("ok") is True
+
+    def test_restart_clears_shutdown_list(self, sim):
+        self._ensure_online(sim, "weapons")
+        issue(sim, "emergency_shutdown", {"subsystem": "weapons"})
+        result = issue(sim, "restart_system", {"subsystem": "weapons"})
+        assert result.get("ok") is True
+        assert "weapons" not in result.get("shutdown_systems", [])
+
+    def test_emergency_shutdown_missing_subsystem_rejects(self, sim):
+        result = issue(sim, "emergency_shutdown", {})
+        assert result.get("ok") is False
+
+    def test_restart_missing_subsystem_rejects(self, sim):
+        result = issue(sim, "restart_system", {})
+        assert result.get("ok") is False
+
+
+# ---------------------------------------------------------------------------
+# System priority and power allocation under damage
+# ---------------------------------------------------------------------------
+
+class TestSystemTriage:
+    """Power allocation and priority assignment while subsystems are degraded."""
+
+    def test_set_system_priority_returns_ok(self, sim):
+        result = issue(sim, "set_system_priority", {
+            "subsystem": "propulsion", "priority": 8,
+        })
+        assert result.get("ok") is True
+
+    def test_set_system_priority_zero_returns_ok(self, sim):
+        result = issue(sim, "set_system_priority", {
+            "subsystem": "sensors", "priority": 0,
+        })
+        assert result.get("ok") is True
+
+    def test_set_system_priority_missing_subsystem_rejects(self, sim):
+        result = issue(sim, "set_system_priority", {"priority": 5})
+        assert result.get("ok") is False
+
+    def test_allocate_power_returns_ok(self, sim):
+        result = issue(sim, "allocate_power", {
+            "allocation": {"propulsion": 0.6, "sensors": 0.4},
+        })
+        assert result.get("ok") is True
+
+    def test_allocate_power_reflects_allocation(self, sim):
+        allocation = {"propulsion": 0.7, "sensors": 0.3}
+        result = issue(sim, "allocate_power", {"allocation": allocation})
+        assert result.get("ok") is True
+        returned = result.get("allocation", {})
+        assert "propulsion" in returned or result.get("status") is not None
+
+    def test_allocate_power_missing_allocation_rejects(self, sim):
+        result = issue(sim, "allocate_power", {})
+        assert result.get("ok") is False
+
+
+# ---------------------------------------------------------------------------
+# report_status completeness
+# ---------------------------------------------------------------------------
+
+class TestReportStatus:
+    """report_status must return a comprehensive view of ship systems."""
+
+    def test_report_status_returns_ok(self, sim):
+        result = issue(sim, "report_status", {})
+        assert result.get("ok") is True
+
+    def test_report_status_power_allocation(self, sim):
+        result = issue(sim, "report_status", {})
+        assert "power_allocation" in result
+
+    def test_report_status_subsystem_report(self, sim):
+        result = issue(sim, "report_status", {})
+        assert "subsystem_report" in result
+
+    def test_report_status_repair_teams(self, sim):
+        result = issue(sim, "report_status", {})
+        assert "repair_teams" in result
+
+    def test_report_status_cascade_effects(self, sim):
+        result = issue(sim, "report_status", {})
+        assert "cascade_effects" in result

--- a/tests/systems/ops/test_power_scenarios.py
+++ b/tests/systems/ops/test_power_scenarios.py
@@ -1,0 +1,242 @@
+# tests/systems/ops/test_power_scenarios.py
+"""Power management and fuel crisis scenario tests.
+
+Focus: scenario 24_fuel_crisis.yaml — ship starts at 40% fuel with a pursuing
+pirate and a distant fuel station. Tests the power/engineering command pipeline.
+
+Gaps filled vs. existing test_fuel_enforcement.py and test_management.py
+(which test models directly): these tests verify end-to-end command routing
+from engineering station commands to observable state.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT_DIR))
+
+from hybrid_runner import HybridRunner
+from hybrid.command_handler import route_command
+
+
+SCENARIO = "24_fuel_crisis"
+PLAYER_ID = "player"
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def runner():
+    r = HybridRunner()
+    r.load_scenario(SCENARIO)
+    r.simulator.start()
+    return r
+
+
+@pytest.fixture
+def sim(runner):
+    return runner.simulator
+
+
+def issue(sim, command: str, params: dict) -> dict:
+    ship = sim.ships[PLAYER_ID]
+    result = route_command(
+        ship,
+        {"command": command, "ship": PLAYER_ID, **params},
+        list(sim.ships.values()),
+    )
+    return result if isinstance(result, dict) else {"error": str(result)}
+
+
+# ---------------------------------------------------------------------------
+# Fuel crisis scenario state
+# ---------------------------------------------------------------------------
+
+class TestFuelCrisisSetup:
+    """Scenario starts with reduced fuel level."""
+
+    def test_fuel_below_full(self, sim):
+        result = issue(sim, "monitor_fuel", {})
+        assert result.get("ok") is True
+        assert result["fuel_percent"] < 100.0
+
+    def test_delta_v_positive(self, sim):
+        result = issue(sim, "monitor_fuel", {})
+        assert result.get("delta_v_remaining", 0.0) > 0.0
+
+    def test_power_management_system_present(self, sim):
+        ship = sim.ships[PLAYER_ID]
+        assert ship.systems.get("power_management") is not None
+
+
+# ---------------------------------------------------------------------------
+# Power profiles
+# ---------------------------------------------------------------------------
+
+class TestPowerProfiles:
+    """Power profile enumeration and switching."""
+
+    def test_get_power_profiles_returns_list(self, sim):
+        result = issue(sim, "get_power_profiles", {})
+        assert "profiles" in result
+        assert isinstance(result["profiles"], list)
+
+    def test_get_power_profiles_non_empty(self, sim):
+        result = issue(sim, "get_power_profiles", {})
+        assert len(result["profiles"]) > 0
+
+    def test_set_power_profile_valid_returns_profile(self, sim):
+        profiles_result = issue(sim, "get_power_profiles", {})
+        profile = profiles_result["profiles"][0]
+        result = issue(sim, "set_power_profile", {"profile": profile})
+        # set_power_profile returns status dict without 'ok', includes 'profile'
+        assert "profile" in result or result.get("ok") is True
+
+    def test_set_power_profile_unknown_rejects(self, sim):
+        result = issue(sim, "set_power_profile", {"profile": "warp_drive_max"})
+        # set_power_profile returns {'error': ...} (no 'ok' key) on unknown profile
+        assert result.get("ok") is False or "error" in result
+
+    def test_get_power_profiles_includes_active(self, sim):
+        result = issue(sim, "get_power_profiles", {})
+        assert "active_profile" in result
+
+
+# ---------------------------------------------------------------------------
+# Power allocation
+# ---------------------------------------------------------------------------
+
+class TestPowerAllocation:
+    """Power allocation across subsystems."""
+
+    def test_set_power_allocation_returns_allocation(self, sim):
+        result = issue(sim, "set_power_allocation", {
+            "allocation": {"propulsion": 0.6, "sensors": 0.4},
+        })
+        assert "power_allocation" in result
+
+    def test_get_draw_profile_returns_buses(self, sim):
+        result = issue(sim, "get_draw_profile", {})
+        assert "buses" in result
+
+    def test_get_draw_profile_includes_totals(self, sim):
+        result = issue(sim, "get_draw_profile", {})
+        assert "totals" in result
+
+    def test_get_draw_profile_has_active_profile(self, sim):
+        result = issue(sim, "get_draw_profile", {})
+        assert "active_profile" in result
+
+
+# ---------------------------------------------------------------------------
+# Reactor control
+# ---------------------------------------------------------------------------
+
+class TestReactorControl:
+    """Reactor output adjustment."""
+
+    def test_set_reactor_output_75_percent(self, sim):
+        result = issue(sim, "set_reactor_output", {"output": 0.75})
+        assert result.get("ok") is True
+        assert abs(result.get("reactor_percent", 0) - 75.0) < 1.0
+
+    def test_set_reactor_output_full(self, sim):
+        result = issue(sim, "set_reactor_output", {"output": 1.0})
+        assert result.get("ok") is True
+
+    def test_set_reactor_output_response_has_percent(self, sim):
+        result = issue(sim, "set_reactor_output", {"output": 0.5})
+        assert "reactor_percent" in result
+        assert "reactor_output" in result
+
+    def test_set_reactor_output_missing_rejects(self, sim):
+        result = issue(sim, "set_reactor_output", {})
+        assert result.get("ok") is False
+
+
+# ---------------------------------------------------------------------------
+# Drive throttle
+# ---------------------------------------------------------------------------
+
+class TestDriveThrottle:
+    """Drive limit (engineering throttle cap on helm thrust)."""
+
+    def test_throttle_drive_50_percent(self, sim):
+        result = issue(sim, "throttle_drive", {"limit": 0.5})
+        assert result.get("ok") is True
+        assert abs(result.get("drive_percent", 0) - 50.0) < 1.0
+
+    def test_throttle_drive_full(self, sim):
+        result = issue(sim, "throttle_drive", {"limit": 1.0})
+        assert result.get("ok") is True
+
+    def test_throttle_drive_clamps_below_zero(self, sim):
+        result = issue(sim, "throttle_drive", {"limit": -0.5})
+        assert result.get("ok") is True
+        assert result.get("drive_limit", 1.0) >= 0.0
+
+    def test_throttle_drive_missing_rejects(self, sim):
+        result = issue(sim, "throttle_drive", {})
+        assert result.get("ok") is False
+
+
+# ---------------------------------------------------------------------------
+# Fuel monitoring
+# ---------------------------------------------------------------------------
+
+class TestFuelMonitoring:
+    """monitor_fuel returns a complete fuel-state snapshot."""
+
+    def test_monitor_fuel_ok(self, sim):
+        result = issue(sim, "monitor_fuel", {})
+        assert result.get("ok") is True
+
+    def test_monitor_fuel_level(self, sim):
+        result = issue(sim, "monitor_fuel", {})
+        assert "fuel_level" in result
+        assert result["fuel_level"] > 0.0
+
+    def test_monitor_fuel_percent(self, sim):
+        result = issue(sim, "monitor_fuel", {})
+        assert "fuel_percent" in result
+        assert 0.0 < result["fuel_percent"] <= 100.0
+
+    def test_monitor_fuel_delta_v(self, sim):
+        result = issue(sim, "monitor_fuel", {})
+        assert "delta_v_remaining" in result
+        assert result["delta_v_remaining"] > 0.0
+
+    def test_monitor_fuel_isp_positive(self, sim):
+        result = issue(sim, "monitor_fuel", {})
+        assert result.get("isp", 0) > 0
+
+    def test_monitor_fuel_drive_limit_field(self, sim):
+        result = issue(sim, "monitor_fuel", {})
+        assert "drive_limit" in result
+        assert "reactor_output" in result
+
+
+# ---------------------------------------------------------------------------
+# Radiator management
+# ---------------------------------------------------------------------------
+
+class TestRadiatorManagement:
+    """manage_radiators routes correctly and returns a response dict."""
+
+    def test_manage_radiators_deploy_returns_dict(self, sim):
+        result = issue(sim, "manage_radiators", {"action": "deploy"})
+        assert isinstance(result, dict)
+
+    def test_manage_radiators_retract_returns_dict(self, sim):
+        result = issue(sim, "manage_radiators", {"action": "retract"})
+        assert isinstance(result, dict)
+
+    def test_manage_radiators_has_ok_or_error(self, sim):
+        result = issue(sim, "manage_radiators", {"action": "deploy"})
+        assert "ok" in result or "error" in result

--- a/tests/systems/ops/test_stealth_scenarios.py
+++ b/tests/systems/ops/test_stealth_scenarios.py
@@ -1,0 +1,197 @@
+# tests/systems/ops/test_stealth_scenarios.py
+"""Stealth/ECM scenario tests: EMCON, jamming, ECM status pipeline.
+
+Focus: scenario 25_silent_running.yaml — corvette starts with EMCON active,
+must navigate through sensor corridors.
+
+Gaps filled vs. existing test_eccm.py and test_home_on_jam.py (which test
+mechanics directly): these tests verify the command-routing path from
+station commands through to observable ECM state changes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT_DIR))
+
+from hybrid_runner import HybridRunner
+from hybrid.command_handler import route_command
+
+
+SCENARIO = "25_silent_running"
+PLAYER_ID = "player"
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def runner():
+    r = HybridRunner()
+    r.load_scenario(SCENARIO)
+    r.simulator.start()
+    return r
+
+
+@pytest.fixture
+def sim(runner):
+    return runner.simulator
+
+
+def issue(sim, command: str, params: dict) -> dict:
+    ship = sim.ships[PLAYER_ID]
+    result = route_command(
+        ship,
+        {"command": command, "ship": PLAYER_ID, **params},
+        list(sim.ships.values()),
+    )
+    return result if isinstance(result, dict) else {"error": str(result)}
+
+
+# ---------------------------------------------------------------------------
+# Scenario setup checks
+# ---------------------------------------------------------------------------
+
+class TestSilentRunningSetup:
+    """Scenario starts with ECM system present and EMCON active."""
+
+    def test_ecm_system_present(self, sim):
+        ship = sim.ships[PLAYER_ID]
+        assert ship.systems.get("ecm") is not None
+
+    def test_ecm_status_command_returns_state(self, sim):
+        result = issue(sim, "ecm_status", {})
+        assert isinstance(result, dict)
+        assert "emcon_active" in result
+
+    def test_initial_emcon_active_is_bool(self, sim):
+        result = issue(sim, "ecm_status", {})
+        assert isinstance(result["emcon_active"], bool)
+
+    def test_ecm_status_has_reduction_fields(self, sim):
+        result = issue(sim, "ecm_status", {})
+        assert "emcon_ir_reduction" in result
+        assert "emcon_rcs_reduction" in result
+
+
+# ---------------------------------------------------------------------------
+# EMCON toggle
+# ---------------------------------------------------------------------------
+
+class TestEmconToggle:
+    """set_emcon changes the observable emcon state."""
+
+    def test_set_emcon_engage_returns_ok(self, sim):
+        result = issue(sim, "set_emcon", {"active": True})
+        assert result.get("ok") is True
+
+    def test_set_emcon_disengage_returns_ok(self, sim):
+        result = issue(sim, "set_emcon", {"active": False})
+        assert result.get("ok") is True
+
+    def test_set_emcon_response_includes_state(self, sim):
+        result = issue(sim, "set_emcon", {"active": True})
+        assert "emcon_active" in result
+
+    def test_emcon_state_reflected_in_ecm_status(self, sim):
+        # Disengage first so we start from a known baseline
+        issue(sim, "set_emcon", {"active": False})
+        status_off = issue(sim, "ecm_status", {})
+        emcon_off_value = status_off.get("emcon_active")
+
+        # Engage and check status flipped
+        issue(sim, "set_emcon", {"active": True})
+        status_on = issue(sim, "ecm_status", {})
+        emcon_on_value = status_on.get("emcon_active")
+
+        assert emcon_off_value != emcon_on_value, (
+            "emcon_active should change between disengaged and engaged states"
+        )
+
+    def test_set_emcon_engage_message_mentions_emcon(self, sim):
+        result = issue(sim, "set_emcon", {"active": True})
+        msg = result.get("status", "")
+        assert "emcon" in msg.lower() or "emission" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# ECM status fields
+# ---------------------------------------------------------------------------
+
+class TestEcmStatusFields:
+    """ecm_status returns a complete sensor-facing state snapshot."""
+
+    def test_jammer_fields_present(self, sim):
+        result = issue(sim, "ecm_status", {})
+        assert "jammer_enabled" in result
+        assert "jammer_power" in result
+
+    def test_chaff_flare_counts_present(self, sim):
+        result = issue(sim, "ecm_status", {})
+        assert "chaff_count" in result
+        assert "flare_count" in result
+
+    def test_ecm_factor_present(self, sim):
+        result = issue(sim, "ecm_status", {})
+        assert "ecm_factor" in result
+
+    def test_status_field_is_string(self, sim):
+        result = issue(sim, "ecm_status", {})
+        assert isinstance(result.get("status"), str)
+
+    def test_ir_reduction_is_positive(self, sim):
+        result = issue(sim, "ecm_status", {})
+        ir = result.get("emcon_ir_reduction", 0.0)
+        assert ir > 0.0, "EMCON IR reduction should be a positive fraction"
+
+
+# ---------------------------------------------------------------------------
+# Cold drift (thermal stealth)
+# ---------------------------------------------------------------------------
+
+class TestColdDrift:
+    """cold_drift routes correctly even when thermal system is absent.
+
+    The 25_silent_running scenario does not provision a thermal system, so
+    cold_drift returns an error — but the command must still return a dict
+    with proper error signalling (not crash or return None).
+    """
+
+    def test_cold_drift_returns_dict(self, sim):
+        result = issue(sim, "cold_drift", {})
+        assert isinstance(result, dict)
+
+    def test_cold_drift_returns_error_or_ok(self, sim):
+        result = issue(sim, "cold_drift", {})
+        assert "error" in result or "ok" in result
+
+    def test_exit_cold_drift_returns_dict(self, sim):
+        result = issue(sim, "exit_cold_drift", {})
+        assert isinstance(result, dict)
+
+    def test_exit_cold_drift_shape_consistent(self, sim):
+        result = issue(sim, "exit_cold_drift", {})
+        assert "error" in result or "ok" in result
+
+
+# ---------------------------------------------------------------------------
+# Rejection cases
+# ---------------------------------------------------------------------------
+
+class TestStealthRejections:
+    """Commands that must fail gracefully with clear error messages."""
+
+    def test_set_repair_priority_missing_subsystem(self, sim):
+        result = issue(sim, "set_repair_priority", {"priority": "high"})
+        assert result.get("ok") is False
+        assert "error" in result or "message" in result
+
+    def test_dispatch_repair_missing_subsystem(self, sim):
+        result = issue(sim, "dispatch_repair", {})
+        assert result.get("ok") is False

--- a/tools/uat_commands.sh
+++ b/tools/uat_commands.sh
@@ -11,13 +11,17 @@ Usage:
   tools/uat_commands.sh print
   tools/uat_commands.sh start <rcon-password>
   tools/uat_commands.sh smoke
+  tools/uat_commands.sh tactical
+  tools/uat_commands.sh ops
   tools/uat_commands.sh monitor
 
 Modes:
-  print    Print the standard UAT commands and mission docs
-  start    Launch the default Svelte stack with browser + RCON password
-  smoke    Run station wiring smoke checks
-  monitor  Tail the latest session log and fail on critical patterns
+  print     Print the standard UAT commands and mission docs
+  start     Launch the default Svelte stack with browser + RCON password
+  smoke     Run station wiring smoke checks (helm/tutorial)
+  tactical  Run tactical command sweep (Phase 2: combat, railgun, torpedoes, missiles)
+  ops       Run ops/engineering/stealth command sweep (Phase 3: repair, power, EMCON)
+  monitor   Tail the latest session log and fail on critical patterns
 EOF
 }
 
@@ -28,13 +32,19 @@ Flaxos Spaceship Sim UAT Commands
 1. Start the stack
 python3 tools/start_gui_stack.py --browser --rcon-password 'replace-this'
 
-2. Run the fast bridge smoke
+2. Run the fast bridge smoke (Phase 0-1: shell + helm)
 python3 tools/check_station_wiring.py
 
-3. Watch logs during UAT in a second terminal
+3. Run the tactical command sweep (Phase 2: combat, railgun, torpedoes, missiles)
+python3 tools/uat_command_sweep.py
+
+4. Run the ops/engineering/stealth sweep (Phase 3: repair, power, EMCON)
+python3 tools/uat_ops_sweep.py
+
+5. Watch logs during UAT in a second terminal
 python3 tools/uat_monitor.py --follow --fail-on-critical
 
-4. UAT docs
+6. UAT docs
 docs/UAT_MASTER_PLAN.md
 docs/STATION_UAT_WIRING_CHECKLIST.md
 docs/MOBILE_GUI_TESTING.md
@@ -58,6 +68,12 @@ case "$mode" in
     ;;
   smoke)
     exec python3 tools/check_station_wiring.py
+    ;;
+  tactical)
+    exec python3 tools/uat_command_sweep.py
+    ;;
+  ops)
+    exec python3 tools/uat_ops_sweep.py
     ;;
   monitor)
     exec python3 tools/uat_monitor.py --follow --fail-on-critical

--- a/tools/uat_ops_sweep.py
+++ b/tools/uat_ops_sweep.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Ops/Engineering/Stealth command sweep — headless UAT for Phase 3.
+
+Covers all ops and engineering station commands across three scenarios:
+  22_damage_control.yaml  — pre-damaged ship, repair pipeline
+  24_fuel_crisis.yaml     — low fuel, power management pressure
+  25_silent_running.yaml  — EMCON/ECM stealth commands
+
+Verifies:
+  - Every command returns a dict (no crash, no None)
+  - Power/repair/status commands include expected keys
+  - If ok=False, an error/message/reason key is present
+
+Exit code: 0 if all checks pass, 1 if any fail.
+
+Usage:
+  python3 tools/uat_ops_sweep.py
+  python3 tools/uat_ops_sweep.py --verbose
+  python3 tools/uat_ops_sweep.py --scenario scenarios/22_damage_control.yaml
+"""
+
+from __future__ import annotations
+
+import sys
+import argparse
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from hybrid.command_handler import route_command
+from hybrid.scenarios.loader import ScenarioLoader
+from hybrid.simulator import Simulator
+
+PLAYER_ID = "player"
+
+_passes = 0
+_fails = 0
+_verbose = False
+
+
+def log(msg: str) -> None:
+    if _verbose:
+        print(f"  {msg}")
+
+
+def check(label: str, result, *, expect_ok: bool | None = None) -> bool:
+    global _passes, _fails
+    ok = True
+    reason = None
+
+    if not isinstance(result, dict):
+        ok = False
+        reason = f"returned {type(result).__name__} instead of dict"
+    elif "ok" not in result and "error" not in result:
+        ok = False
+        reason = f"response missing both 'ok' and 'error' keys — keys: {list(result.keys())}"
+    elif expect_ok is True and not result.get("ok"):
+        ok = False
+        reason = f"expected ok=True, got {result}"
+    elif expect_ok is False and result.get("ok"):
+        ok = False
+        reason = f"expected ok=False (rejection), got {result}"
+    elif result.get("ok") is False and "error" not in result and "message" not in result and "reason" not in result:
+        ok = False
+        reason = f"ok=False but no error/message/reason key — keys: {list(result.keys())}"
+
+    if ok:
+        _passes += 1
+        print(f"  PASS  {label}")
+        log(str(result))
+    else:
+        _fails += 1
+        print(f"  FAIL  {label}: {reason}")
+    return ok
+
+
+def check_state(label: str, result, *, required_keys: list[str] | None = None) -> bool:
+    global _passes, _fails
+    ok = True
+    reason = None
+
+    if not isinstance(result, dict):
+        ok = False
+        reason = f"returned {type(result).__name__} instead of dict"
+    elif not result:
+        ok = False
+        reason = "returned empty dict"
+    elif required_keys:
+        missing = [k for k in required_keys if k not in result]
+        if missing:
+            ok = False
+            reason = f"missing required keys: {missing}"
+
+    if ok:
+        _passes += 1
+        print(f"  PASS  {label}")
+        log(str(list(result.keys())))
+    else:
+        _fails += 1
+        print(f"  FAIL  {label}: {reason}")
+    return ok
+
+
+def build_sim(scenario_name: str) -> Simulator:
+    scenario_path = ROOT_DIR / "scenarios" / scenario_name
+    scenario = ScenarioLoader.load(str(scenario_path))
+    sim = Simulator(dt=scenario.get("dt", 0.1), time_scale=1.0)
+    for ship_data in scenario["ships"]:
+        sim.add_ship(ship_data["id"], ship_data)
+    all_ships = list(sim.ships.values())
+    for ship in all_ships:
+        ship._all_ships_ref = all_ships
+    sim.start()
+    return sim
+
+
+def issue(sim: Simulator, command: str, params: dict) -> dict:
+    ship = sim.ships[PLAYER_ID]
+    result = route_command(
+        ship,
+        {"command": command, "ship": PLAYER_ID, **params},
+        list(sim.ships.values()),
+    )
+    if not isinstance(result, dict):
+        return {"error": f"non-dict result: {result!r}"}
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Repair / damage-control commands (scenario 22)
+# ---------------------------------------------------------------------------
+
+def run_repair_commands(sim: Simulator) -> None:
+    print("\n--- Repair / Damage Control ---")
+    check_state("report_status",
+                issue(sim, "report_status", {}),
+                required_keys=["power_allocation", "subsystem_report"])
+
+    check("dispatch_repair sensors",
+          issue(sim, "dispatch_repair", {"subsystem": "sensors"}),
+          expect_ok=True)
+
+    check_state("repair_status",
+                issue(sim, "repair_status", {}),
+                required_keys=["repair_teams"])
+
+    check("set_repair_priority sensors high",
+          issue(sim, "set_repair_priority", {"subsystem": "sensors", "priority": "high"}),
+          expect_ok=True)
+
+    check("cancel_repair sensors",
+          issue(sim, "cancel_repair", {"subsystem": "sensors"}))
+
+    check("emergency_shutdown propulsion",
+          issue(sim, "emergency_shutdown", {"subsystem": "propulsion"}),
+          expect_ok=True)
+
+    check("restart_system propulsion",
+          issue(sim, "restart_system", {"subsystem": "propulsion"}),
+          expect_ok=True)
+
+    check("set_system_priority propulsion=8",
+          issue(sim, "set_system_priority", {"subsystem": "propulsion", "priority": 8}),
+          expect_ok=True)
+
+    check("allocate_power",
+          issue(sim, "allocate_power", {
+              "allocation": {"propulsion": 0.5, "sensors": 0.3, "weapons": 0.2},
+          }),
+          expect_ok=True)
+
+
+def run_repair_rejection_cases(sim: Simulator) -> None:
+    print("\n--- Repair rejection cases (expect ok=False) ---")
+    check("dispatch_repair no subsystem",
+          issue(sim, "dispatch_repair", {}),
+          expect_ok=False)
+
+    check("cancel_repair unknown subsystem",
+          issue(sim, "cancel_repair", {"subsystem": "nonexistent_system"}))
+
+    check("emergency_shutdown no subsystem",
+          issue(sim, "emergency_shutdown", {}),
+          expect_ok=False)
+
+
+# ---------------------------------------------------------------------------
+# Power management commands (scenario 24)
+# ---------------------------------------------------------------------------
+
+def run_power_commands(sim: Simulator) -> None:
+    print("\n--- Power Management ---")
+    profiles_result = issue(sim, "get_power_profiles", {})
+    check_state("get_power_profiles",
+                profiles_result,
+                required_keys=["profiles"])
+
+    # Use the first available profile (avoid guessing the name)
+    profiles = profiles_result.get("profiles", [])
+    if profiles:
+        check_state(f"set_power_profile {profiles[0]}",
+                    issue(sim, "set_power_profile", {"profile": profiles[0]}),
+                    required_keys=["profile"])
+    else:
+        print("  SKIP  set_power_profile — no profiles defined")
+
+    check_state("get_draw_profile",
+                issue(sim, "get_draw_profile", {}),
+                required_keys=["active_profile", "buses"])
+
+    check_state("set_power_allocation",
+                issue(sim, "set_power_allocation", {
+                    "allocation": {"propulsion": 0.5, "sensors": 0.3},
+                }),
+                required_keys=["power_allocation"])
+
+
+def run_engineering_commands(sim: Simulator) -> None:
+    print("\n--- Engineering ---")
+    check("set_reactor_output 0.75",
+          issue(sim, "set_reactor_output", {"output": 0.75}),
+          expect_ok=True)
+
+    check("throttle_drive 0.6",
+          issue(sim, "throttle_drive", {"limit": 0.6}),
+          expect_ok=True)
+
+    check_state("monitor_fuel",
+                issue(sim, "monitor_fuel", {}),
+                required_keys=["fuel_level", "fuel_percent", "delta_v_remaining"])
+
+    # manage_radiators — action may not be defined on all ships, accept either result
+    result = issue(sim, "manage_radiators", {"action": "deploy"})
+    check("manage_radiators deploy (shape)", result)
+
+    # Restore full reactor output
+    issue(sim, "set_reactor_output", {"output": 1.0})
+    issue(sim, "throttle_drive", {"limit": 1.0})
+
+
+def run_power_rejection_cases(sim: Simulator) -> None:
+    print("\n--- Power rejection cases (expect ok=False) ---")
+    check("set_power_profile unknown",
+          issue(sim, "set_power_profile", {"profile": "turbo_laser_disco"}),
+          expect_ok=False)
+
+    # Reactor/drive accept out-of-range values by clamping; only missing params reject
+    check("set_reactor_output missing output",
+          issue(sim, "set_reactor_output", {}),
+          expect_ok=False)
+
+    check("throttle_drive missing limit",
+          issue(sim, "throttle_drive", {}),
+          expect_ok=False)
+
+
+# ---------------------------------------------------------------------------
+# ECM / EMCON / stealth commands (scenario 25)
+# ---------------------------------------------------------------------------
+
+def run_stealth_commands(sim: Simulator) -> None:
+    print("\n--- ECM / EMCON / Stealth ---")
+    check_state("ecm_status initial",
+                issue(sim, "ecm_status", {}),
+                required_keys=["emcon_active", "emcon_ir_reduction", "emcon_rcs_reduction"])
+
+    # Engage EMCON (scenario starts with emcon_active=True, so this toggles it off first)
+    r_off = issue(sim, "set_emcon", {"active": False})
+    check("set_emcon active=False", r_off, expect_ok=True)
+
+    r_on = issue(sim, "set_emcon", {"active": True})
+    check("set_emcon active=True", r_on, expect_ok=True)
+
+    # Verify emcon state changed
+    status_after = issue(sim, "ecm_status", {})
+    check_state("ecm_status after set_emcon",
+                status_after,
+                required_keys=["emcon_active"])
+
+    # Thermal system may not be present; cold_drift returns shape-only error
+    r_cold = issue(sim, "cold_drift", {})
+    check("cold_drift (shape only — thermal may be absent)", r_cold)
+
+    r_exit = issue(sim, "exit_cold_drift", {})
+    check("exit_cold_drift (shape only)", r_exit)
+
+
+def run_stealth_rejection_cases(sim: Simulator) -> None:
+    print("\n--- Stealth rejection cases (expect ok=False) ---")
+    # set_emcon with no active param defaults gracefully; test a command that truly rejects
+    check("set_repair_priority missing subsystem",
+          issue(sim, "set_repair_priority", {"priority": "high"}),
+          expect_ok=False)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def run_phase(name: str, scenario: str, runner_fn) -> None:
+    print(f"\n{'='*60}")
+    print(f"Phase: {name}  ({scenario})")
+    print(f"{'='*60}")
+    try:
+        sim = build_sim(scenario)
+        runner_fn(sim)
+    except Exception as exc:
+        global _fails
+        _fails += 1
+        print(f"  FAIL  scenario load/setup: {exc}")
+        import traceback; traceback.print_exc()
+
+
+def main() -> int:
+    global _verbose
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument(
+        "--only",
+        choices=["repair", "power", "stealth"],
+        help="Run only the named phase",
+    )
+    args = parser.parse_args()
+    _verbose = args.verbose
+
+    print("== Ops/Engineering/Stealth Command Sweep ==")
+
+    if not args.only or args.only == "repair":
+        run_phase(
+            "Damage Control",
+            "22_damage_control.yaml",
+            lambda sim: (
+                run_repair_commands(sim),
+                run_repair_rejection_cases(sim),
+            ),
+        )
+
+    if not args.only or args.only == "power":
+        run_phase(
+            "Fuel Crisis / Power Management",
+            "24_fuel_crisis.yaml",
+            lambda sim: (
+                run_power_commands(sim),
+                run_engineering_commands(sim),
+                run_power_rejection_cases(sim),
+            ),
+        )
+
+    if not args.only or args.only == "stealth":
+        run_phase(
+            "Silent Running / Stealth",
+            "25_silent_running.yaml",
+            lambda sim: (
+                run_stealth_commands(sim),
+                run_stealth_rejection_cases(sim),
+            ),
+        )
+
+    total = _passes + _fails
+    print(f"\n== Results: {_passes}/{total} passed ==")
+    if _fails:
+        print(f"   {_fails} failed")
+        return 1
+
+    print("   All ops/engineering/stealth commands routed correctly")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- **`tools/uat_ops_sweep.py`** — 30-check headless command sweep across scenarios 22 (damage control), 24 (fuel crisis), and 25 (silent running); covers repair dispatch/cancel, power profiles, reactor/drive control, EMCON toggle, and ECM status
- **`tests/systems/ops/`** — 77 pytest scenario tests split across three files: `test_damage_control_scenarios.py`, `test_power_scenarios.py`, `test_stealth_scenarios.py`
- **`tools/uat_commands.sh`** — adds `tactical` and `ops` subcommands so the Phase 2 and Phase 3 sweeps are accessible as `tools/uat_commands.sh tactical` and `tools/uat_commands.sh ops`

Continues the UAT coding plan:
| Phase | What | Tooling |
|-------|------|---------|
| 0–1 | Shell + Helm | `check_station_wiring.py` |
| 2 | Tactical / Weapons | `uat_command_sweep.py`, `tests/systems/combat/test_*_scenarios.py` (PR #406) |
| **3** | **Ops / Engineering / Stealth** | **this PR** |

## Test plan

- [ ] `python3 tools/uat_ops_sweep.py` → `30/30 passed`
- [ ] `python3 -m pytest tests/systems/ops/ -q` → `77 passed`
- [ ] `python3 -m pytest tests/ -q` → no regressions (2191 passed baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)