### PR TITLE
[codex] Add live schematic displays for helm, tactical, and engineering

### DIFF
--- a/gui/components/power-draw-display.js
+++ b/gui/components/power-draw-display.js
@@ -15,6 +15,35 @@ import { wsClient } from "../js/ws-client.js";
 const POLL_INTERVAL_MS = 3000;
 const BUS_NAMES = ["primary", "secondary", "tertiary"];
 
+function normalizeDrawProfile(raw) {
+  const profile = raw?.response || raw;
+  if (!profile || typeof profile !== "object") return null;
+
+  if (profile.buses && typeof profile.buses === "object") {
+    const normalized = {};
+    for (const bus of BUS_NAMES) {
+      const entry = profile.buses?.[bus];
+      if (!entry) continue;
+      normalized[bus] = {
+        supply: Number(entry.available_kw ?? entry.supply ?? 0),
+        requested: Number(entry.requested_kw ?? entry.requested ?? 0),
+        delta: Number(
+          entry.delta_kw ?? entry.delta ??
+          ((entry.available_kw ?? entry.supply ?? 0) - (entry.requested_kw ?? entry.requested ?? 0))
+        ),
+        status: entry.status || "balanced",
+      };
+    }
+    return normalized;
+  }
+
+  if (BUS_NAMES.some((bus) => profile[bus])) {
+    return profile;
+  }
+
+  return null;
+}
+
 class PowerDrawDisplay extends HTMLElement {
   constructor() {
     super();
@@ -50,7 +79,7 @@ class PowerDrawDisplay extends HTMLElement {
   async _fetchDrawProfile() {
     try {
       const resp = await wsClient.sendShipCommand("get_draw_profile", {});
-      this._drawData = resp;
+      this._drawData = normalizeDrawProfile(resp);
       this._render();
     } catch (err) {
       console.warn("power-draw-display: fetch failed:", err.message);

--- a/gui/components/power-flow-display.js
+++ b/gui/components/power-flow-display.js
@@ -1,0 +1,315 @@
+/**
+ * Power Flow Display — reactor -> buses -> subsystem loads.
+ *
+ * Combines:
+ *   - get_draw_profile (per-bus available/requested/top consumers)
+ *   - ship.engineering (reactor output percentage)
+ *   - ship.thermal (heat / radiator state)
+ *
+ * The component is display-only. Existing power controls remain in the
+ * allocation/profile panels.
+ */
+import { stateManager } from "../js/state-manager.js";
+import { wsClient } from "../js/ws-client.js";
+
+const POLL_MS = 2500;
+const BUS_ORDER = ["primary", "secondary", "tertiary", "unassigned"];
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeDrawProfile(raw) {
+  const profile = raw?.response || raw;
+  if (!profile || typeof profile !== "object") return null;
+
+  if (profile.buses && typeof profile.buses === "object") {
+    return profile;
+  }
+
+  const hasLegacy = BUS_ORDER.some((bus) => profile?.[bus]);
+  if (!hasLegacy) return null;
+
+  const buses = {};
+  let availableTotal = 0;
+  let requestedTotal = 0;
+
+  for (const bus of BUS_ORDER) {
+    const entry = profile?.[bus];
+    if (!entry) continue;
+    const available = Number(entry.available_kw ?? entry.supply ?? 0);
+    const requested = Number(entry.requested_kw ?? entry.requested ?? 0);
+    buses[bus] = {
+      available_kw: available,
+      requested_kw: requested,
+      delta_kw: Number(entry.delta_kw ?? entry.delta ?? (available - requested)),
+      status: entry.status || "balanced",
+      systems: entry.systems || [],
+      top_consumers: entry.top_consumers || [],
+    };
+    availableTotal += available;
+    requestedTotal += requested;
+  }
+
+  return {
+    active_profile: profile.active_profile || null,
+    buses,
+    totals: {
+      available_kw: availableTotal,
+      requested_kw: requestedTotal,
+      delta_kw: availableTotal - requestedTotal,
+    },
+  };
+}
+
+function busColor(available, requested) {
+  if (available <= 0 && requested <= 0) return "#445063";
+  if (available <= 0) return "#ff5b5b";
+  const ratio = requested / available;
+  if (ratio > 1) return "#ff5b5b";
+  if (ratio >= 0.8) return "#ffb020";
+  return "#35c56f";
+}
+
+function lineWidth(value, maxValue) {
+  if (maxValue <= 0) return 2;
+  return clamp(1.5 + (value / maxValue) * 6, 1.5, 7.5);
+}
+
+function formatKw(value) {
+  if (value == null || Number.isNaN(value)) return "?";
+  if (Math.abs(value) >= 1000) return `${(value / 1000).toFixed(1)} MW`;
+  return `${value.toFixed(value >= 100 ? 0 : 1)} kW`;
+}
+
+function shortName(name = "") {
+  return name
+    .replace(/[_.-]/g, " ")
+    .replace(/\bpower\b/ig, "")
+    .trim()
+    .toUpperCase()
+    .slice(0, 9);
+}
+
+class PowerFlowDisplay extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._profile = null;
+    this._pollTimer = null;
+    this._unsubs = [];
+  }
+
+  connectedCallback() {
+    this._renderShell();
+    this._unsubs = [
+      stateManager.subscribe("engineering", () => this._draw()),
+      stateManager.subscribe("thermal", () => this._draw()),
+    ];
+    this._poll();
+    this._pollTimer = setInterval(() => this._poll(), POLL_MS);
+  }
+
+  disconnectedCallback() {
+    if (this._pollTimer) {
+      clearInterval(this._pollTimer);
+      this._pollTimer = null;
+    }
+    this._unsubs.forEach((unsub) => unsub?.());
+    this._unsubs = [];
+  }
+
+  async _poll() {
+    try {
+      const raw = await wsClient.sendShipCommand("get_draw_profile", {});
+      this._profile = normalizeDrawProfile(raw);
+      this._draw();
+    } catch (_) {
+      // Ignore transient bridge / ship selection failures.
+    }
+  }
+
+  _renderShell() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+        }
+
+        svg {
+          width: 100%;
+          height: auto;
+          display: block;
+        }
+
+        .frame {
+          fill: rgba(9, 12, 18, 0.6);
+          stroke: #263042;
+          stroke-width: 1;
+        }
+
+        .title {
+          font-size: 7px;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+          fill: #708097;
+        }
+
+        .bus-name {
+          font-size: 7px;
+          letter-spacing: 0.08em;
+          fill: #d5deea;
+          text-anchor: middle;
+        }
+
+        .bus-meta,
+        .consumer-meta,
+        .footer {
+          font-size: 6px;
+          fill: #8896a9;
+          text-anchor: middle;
+        }
+
+        .reactor-text {
+          font-size: 7px;
+          fill: #d5deea;
+          text-anchor: middle;
+        }
+
+        .empty {
+          font-size: 8px;
+          fill: #7a889b;
+          text-anchor: middle;
+        }
+      </style>
+
+      <svg viewBox="0 0 320 210" xmlns="http://www.w3.org/2000/svg">
+        <rect class="frame" x="8" y="8" width="304" height="194" rx="8" />
+        <text class="title" x="18" y="22">POWER FLOW</text>
+        <g id="flow-layer"></g>
+      </svg>
+    `;
+  }
+
+  _draw() {
+    const layer = this.shadowRoot.getElementById("flow-layer");
+    if (!layer) return;
+
+    const profile = this._profile;
+    if (!profile?.buses) {
+      layer.innerHTML = `<text class="empty" x="160" y="108">Waiting for power telemetry...</text>`;
+      return;
+    }
+
+    const engineering = stateManager.getShipState?.()?.engineering || {};
+    const thermal = stateManager.getThermal?.() || stateManager.getShipState?.()?.thermal || {};
+    const busEntries = BUS_ORDER
+      .filter((bus) => profile.buses?.[bus])
+      .map((bus) => [bus, profile.buses[bus]]);
+
+    if (!busEntries.length) {
+      layer.innerHTML = `<text class="empty" x="160" y="108">No power buses available</text>`;
+      return;
+    }
+
+    const totals = profile.totals || {};
+    const maxBusRequest = Math.max(
+      1,
+      ...busEntries.map(([, entry]) => Number(entry.requested_kw || 0))
+    );
+    const reactorTelemetry = engineering.reactor_output ?? (
+      engineering.reactor_percent != null ? engineering.reactor_percent / 100 : null
+    );
+    const reactorPct = clamp(
+      reactorTelemetry ?? (totals.available_kw > 0 ? totals.requested_kw / totals.available_kw : 0),
+      0,
+      1
+    );
+    const reactorRing = 2 * Math.PI * 20;
+    const reactorColor = busColor(totals.available_kw || 0, totals.requested_kw || 0);
+
+    const heatPercent = clamp((thermal.temperature_percent ?? 0) / 100, 0, 1);
+    const heatColor = thermal.is_emergency
+      ? "#ff5b5b"
+      : thermal.is_overheating
+        ? "#ffb020"
+        : heatPercent > 0.45
+          ? "#59b6ff"
+          : "#35c56f";
+
+    let html = `
+      <circle cx="160" cy="42" r="21" fill="#111722" stroke="#30405a" stroke-width="1.2" />
+      <circle cx="160" cy="42" r="20" fill="none" stroke="${reactorColor}" stroke-width="4"
+        stroke-dasharray="${(reactorPct * reactorRing).toFixed(1)} ${reactorRing.toFixed(1)}"
+        transform="rotate(-90 160 42)" />
+      <text class="reactor-text" x="160" y="39">REACTOR</text>
+      <text class="reactor-text" x="160" y="49">${Math.round(reactorPct * 100)}%</text>
+      <text class="footer" x="160" y="62">${formatKw(totals.available_kw || 0)} avail</text>
+    `;
+
+    const busXs = busEntries.map((_, index) => {
+      if (busEntries.length === 1) return 160;
+      const spacing = 176 / (busEntries.length - 1);
+      return 72 + index * spacing;
+    });
+    const busY = 104;
+
+    busEntries.forEach(([busName, bus], index) => {
+      const x = busXs[index] ?? (56 + index * 64);
+      const available = Number(bus.available_kw || 0);
+      const requested = Number(bus.requested_kw || 0);
+      const color = busColor(available, requested);
+      const width = lineWidth(requested, maxBusRequest);
+      const consumers = (bus.systems?.length ? bus.systems : bus.top_consumers || []).slice(0, 4);
+
+      html += `
+        <line x1="160" y1="63" x2="${x}" y2="${busY - 16}"
+          stroke="${color}" stroke-width="${width.toFixed(1)}" opacity="0.8" />
+        <rect x="${x - 28}" y="${busY - 16}" width="56" height="28" rx="5"
+          fill="#111722" stroke="${color}" stroke-width="1.3" />
+        <text class="bus-name" x="${x}" y="${busY - 3}">${busName.toUpperCase()}</text>
+        <text class="bus-meta" x="${x}" y="${busY + 8}">
+          ${formatKw(requested).replace(" kW", "")} / ${formatKw(available).replace(" kW", "")}
+        </text>
+      `;
+
+      const leafStartY = 142;
+      const leafStep = 15;
+      consumers.forEach((consumer, cIndex) => {
+        const cy = leafStartY + cIndex * leafStep;
+        const draw = Number(consumer.draw_kw || 0);
+        const drawWidth = lineWidth(draw, requested || maxBusRequest);
+
+        html += `
+          <line x1="${x}" y1="${busY + 12}" x2="${x}" y2="${cy - 6}"
+            stroke="${color}" stroke-width="${drawWidth.toFixed(1)}" opacity="0.55" />
+          <circle cx="${x}" cy="${cy}" r="${clamp(4 + draw / Math.max(1, requested) * 10, 4, 10).toFixed(1)}"
+            fill="#111722" stroke="${color}" stroke-width="1" />
+          <text class="consumer-meta" x="${x}" y="${cy + 1.8}">${shortName(consumer.name)}</text>
+          <text class="consumer-meta" x="${x}" y="${cy + 10}">${formatKw(draw).replace(" kW", "")}</text>
+        `;
+      });
+    });
+
+    html += `
+      <g transform="translate(128 184)">
+        <rect x="0" y="-6" width="64" height="12" rx="3" fill="none" stroke="${heatColor}" stroke-width="1.1" />
+        <line x1="6" y1="-10" x2="6" y2="10" stroke="${heatColor}" stroke-width="1" />
+        <line x1="58" y1="-10" x2="58" y2="10" stroke="${heatColor}" stroke-width="1" />
+        <line x1="16" y1="-10" x2="16" y2="10" stroke="${heatColor}" stroke-width="1" />
+        <line x1="26" y1="-10" x2="26" y2="10" stroke="${heatColor}" stroke-width="1" />
+        <line x1="38" y1="-10" x2="38" y2="10" stroke="${heatColor}" stroke-width="1" />
+        <line x1="48" y1="-10" x2="48" y2="10" stroke="${heatColor}" stroke-width="1" />
+      </g>
+      <text class="footer" x="160" y="197">
+        THERMAL ${Math.round((thermal.temperature_percent ?? 0))}% • ${Math.round(thermal.hull_temperature ?? 0)} K
+      </text>
+      <text class="footer" x="286" y="22">${profile.active_profile ? `PROFILE ${String(profile.active_profile).toUpperCase()}` : ""}</text>
+    `;
+
+    layer.innerHTML = html;
+  }
+}
+
+customElements.define("power-flow-display", PowerFlowDisplay);

--- a/gui/components/ship-orientation-display.js
+++ b/gui/components/ship-orientation-display.js
@@ -1,0 +1,338 @@
+/**
+ * Ship Orientation Display — live helm schematic for drift, attitude, and RCS state.
+ *
+ * Uses:
+ *   - stateManager.getNavigation() for heading, velocity, throttle
+ *   - ship.trajectory for drift / velocity heading
+ *   - ship.rcs for per-thruster firing state
+ *   - ship.helm for the commanded attitude target
+ *
+ * The main top-down view keeps the ship body fixed in ship frame. Velocity and
+ * command markers rotate around it, which makes drift and attitude error easy to
+ * read at a glance. A small side inset mirrors pitch attitude.
+ */
+import { stateManager } from "../js/state-manager.js";
+
+const THRUSTER_POS = {
+  pitch_up:       { x: 211, y: 54 },
+  pitch_down:     { x: 211, y: 110 },
+  yaw_left:       { x: 222, y: 66 },
+  yaw_right:      { x: 222, y: 98 },
+  pitch_up_aft:   { x: 57,  y: 54 },
+  pitch_down_aft: { x: 57,  y: 110 },
+  yaw_left_aft:   { x: 46,  y: 66 },
+  yaw_right_aft:  { x: 46,  y: 98 },
+  roll_cw:        { x: 146, y: 124 },
+  roll_ccw:       { x: 122, y: 40 },
+  roll_cw_2:      { x: 122, y: 124 },
+  roll_ccw_2:     { x: 146, y: 40 },
+};
+
+const SHIP_CENTER = { x: 134, y: 82 };
+const SIDE_CENTER = { x: 269, y: 68 };
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function shortestAngle(targetDeg, currentDeg) {
+  return ((targetDeg - currentDeg + 540) % 360) - 180;
+}
+
+function thrusterColor(throttle) {
+  if (throttle < 0.02) return "#1a1d28";
+  if (throttle < 0.25) return "#1d6f4f";
+  if (throttle < 0.6) return "#35b46e";
+  if (throttle < 0.85) return "#ffb020";
+  return "#ff5a36";
+}
+
+function vectorSpeed(velocity = [0, 0, 0]) {
+  const [vx, vy, vz] = velocity;
+  return Math.sqrt(vx * vx + vy * vy + vz * vz);
+}
+
+function yawFromVelocity(velocity = [0, 0, 0]) {
+  const [vx, vy] = velocity;
+  if (Math.abs(vx) < 0.001 && Math.abs(vy) < 0.001) return null;
+  return Math.atan2(vy, vx) * 180 / Math.PI;
+}
+
+function formatSignedAngle(angle, positiveLabel, negativeLabel) {
+  if (Math.abs(angle) < 0.5) return "0°";
+  return `${Math.abs(angle).toFixed(0)}° ${angle >= 0 ? positiveLabel : negativeLabel}`;
+}
+
+class ShipOrientationDisplay extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._unsub = null;
+    this._lastUpdate = 0;
+    this._rafId = null;
+  }
+
+  connectedCallback() {
+    this._render();
+    this._unsub = stateManager.subscribe("*", () => this._scheduleUpdate());
+    this._scheduleUpdate();
+  }
+
+  disconnectedCallback() {
+    if (this._unsub) {
+      this._unsub();
+      this._unsub = null;
+    }
+    if (this._rafId) {
+      cancelAnimationFrame(this._rafId);
+      this._rafId = null;
+    }
+  }
+
+  _scheduleUpdate() {
+    const now = performance.now();
+    if (now - this._lastUpdate < 120) return;
+    this._lastUpdate = now;
+    if (this._rafId) cancelAnimationFrame(this._rafId);
+    this._rafId = requestAnimationFrame(() => this._update());
+  }
+
+  _render() {
+    const thrusterDots = Object.entries(THRUSTER_POS).map(([id, pos]) => `
+      <circle id="t-${id}" cx="${pos.x}" cy="${pos.y}" r="4"
+        fill="#1a1d28" stroke="#273046" stroke-width="0.8" />
+    `).join("");
+
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          font-family: var(--font-mono, "JetBrains Mono", monospace);
+        }
+
+        svg {
+          width: 100%;
+          height: auto;
+          display: block;
+        }
+
+        .hull {
+          fill: #171b26;
+          stroke: #3a455a;
+          stroke-width: 1.5;
+        }
+
+        .frame {
+          fill: rgba(9, 12, 18, 0.55);
+          stroke: #263042;
+          stroke-width: 1;
+        }
+
+        .centerline,
+        .side-axis {
+          stroke: #334057;
+          stroke-width: 0.7;
+          stroke-dasharray: 4 3;
+        }
+
+        .label {
+          font-size: 7px;
+          letter-spacing: 0.12em;
+          fill: #6f7f98;
+          text-transform: uppercase;
+        }
+
+        .readout {
+          font-size: 8px;
+          fill: #b7c5d8;
+        }
+
+        .dim {
+          fill: #7a889b;
+        }
+
+        .accent {
+          fill: #44aaff;
+        }
+
+        .warn {
+          fill: #ffb020;
+        }
+
+        #drive-plume,
+        #vel-arrow,
+        #target-arrow {
+          transition: opacity 0.12s ease;
+        }
+
+        #side-ship,
+        #side-target {
+          transition: transform 0.12s ease;
+          transform-origin: ${SIDE_CENTER.x}px ${SIDE_CENTER.y}px;
+        }
+      </style>
+
+      <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <radialGradient id="plume-grad" cx="80%" cy="50%" r="80%" fx="80%" fy="50%">
+            <stop offset="0%" stop-color="#ffb020" stop-opacity="0.95" />
+            <stop offset="55%" stop-color="#ff5a36" stop-opacity="0.45" />
+            <stop offset="100%" stop-color="#250000" stop-opacity="0" />
+          </radialGradient>
+          <marker id="vel-head" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+            <polygon points="0 0, 6 3, 0 6" fill="#44aaff" opacity="0.85" />
+          </marker>
+          <marker id="target-head" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+            <polygon points="0 0, 6 3, 0 6" fill="#ffb020" opacity="0.85" />
+          </marker>
+        </defs>
+
+        <rect class="frame" x="8" y="8" width="304" height="164" rx="8" />
+
+        <text class="label" x="16" y="22">DRIFT / ATTITUDE</text>
+        <text class="label" x="236" y="22">PITCH</text>
+
+        <ellipse id="drive-plume" cx="30" cy="82" rx="10" ry="7" fill="url(#plume-grad)" opacity="0" />
+
+        <polygon class="hull" points="48,82 68,52 214,54 244,82 214,110 68,112" />
+        <line class="centerline" x1="44" y1="${SHIP_CENTER.y}" x2="246" y2="${SHIP_CENTER.y}" />
+        <ellipse cx="57" cy="70" rx="5" ry="3" fill="none" stroke="#31415a" stroke-width="1" />
+        <ellipse cx="57" cy="94" rx="5" ry="3" fill="none" stroke="#31415a" stroke-width="1" />
+        <polygon points="239,82 229,76 229,88" fill="#52617b" />
+
+        <line id="vel-arrow"
+          x1="${SHIP_CENTER.x}" y1="${SHIP_CENTER.y}"
+          x2="${SHIP_CENTER.x + 42}" y2="${SHIP_CENTER.y}"
+          stroke="#44aaff" stroke-width="1.8" opacity="0"
+          marker-end="url(#vel-head)" />
+
+        <line id="target-arrow"
+          x1="${SHIP_CENTER.x}" y1="${SHIP_CENTER.y}"
+          x2="${SHIP_CENTER.x + 34}" y2="${SHIP_CENTER.y}"
+          stroke="#ffb020" stroke-width="1.4" stroke-dasharray="5 3" opacity="0"
+          marker-end="url(#target-head)" />
+
+        ${thrusterDots}
+
+        <line class="side-axis" x1="236" y1="${SIDE_CENTER.y}" x2="302" y2="${SIDE_CENTER.y}" />
+        <line class="side-axis" x1="${SIDE_CENTER.x}" y1="32" x2="${SIDE_CENTER.x}" y2="106" />
+
+        <g id="side-target" transform="rotate(0 ${SIDE_CENTER.x} ${SIDE_CENTER.y})">
+          <polygon points="250,68 264,61 287,61 294,68 287,75 264,75"
+            fill="none" stroke="#ffb020" stroke-width="1" stroke-dasharray="4 2" opacity="0.9" />
+        </g>
+        <g id="side-ship" transform="rotate(0 ${SIDE_CENTER.x} ${SIDE_CENTER.y})">
+          <polygon points="250,68 264,60 288,60 297,68 288,76 264,76"
+            fill="#171b26" stroke="#4d5a71" stroke-width="1.2" />
+        </g>
+
+        <text id="speed-lbl" class="readout" x="16" y="142">SPD 0 m/s</text>
+        <text id="drift-lbl" class="readout accent" x="16" y="154">DRIFT 0°</text>
+        <text id="yawerr-lbl" class="readout warn" x="16" y="166">YAW ERR 0°</text>
+        <text id="pitch-lbl" class="readout" x="236" y="118">PITCH 0°</text>
+        <text id="pitcherr-lbl" class="readout warn" x="236" y="130">PITCH ERR 0°</text>
+        <text id="rate-lbl" class="readout dim" x="236" y="142">OMEGA 0.0°/s</text>
+      </svg>
+    `;
+  }
+
+  _update() {
+    const ship = stateManager.getShipState?.() || {};
+    const nav = stateManager.getNavigation?.() || {};
+    const rcs = ship?.rcs || ship?.systems?.rcs || null;
+    const helm = ship?.helm || ship?.systems?.helm || null;
+    const trajectory = ship?.trajectory || ship?.navigation || {};
+
+    const heading = nav.heading || ship.orientation || { pitch: 0, yaw: 0, roll: 0 };
+    const velocity = nav.velocity || [0, 0, 0];
+    const speed = vectorSpeed(velocity);
+    const velocityYaw = trajectory.velocity_heading?.yaw ?? yawFromVelocity(velocity);
+    const driftYaw = velocityYaw == null ? 0 : shortestAngle(velocityYaw, heading.yaw || 0);
+
+    const target = helm?.attitude_target || rcs?.attitude_target || null;
+    const yawError = target ? shortestAngle(target.yaw ?? heading.yaw ?? 0, heading.yaw ?? 0) : 0;
+    const pitchError = target ? shortestAngle(target.pitch ?? heading.pitch ?? 0, heading.pitch ?? 0) : 0;
+    const angularVelocity = ship?.angular_velocity || {};
+    const omegaMag = Math.sqrt(
+      (angularVelocity.pitch || 0) ** 2 +
+      (angularVelocity.yaw || 0) ** 2 +
+      (angularVelocity.roll || 0) ** 2
+    );
+
+    const plume = this.shadowRoot.getElementById("drive-plume");
+    const thrust = clamp(nav.thrust ?? helm?.manual_throttle ?? 0, 0, 1);
+    if (plume) {
+      plume.setAttribute("opacity", (thrust * 0.88).toFixed(2));
+      plume.setAttribute("rx", (8 + thrust * 18).toFixed(1));
+      plume.setAttribute("ry", (5 + thrust * 13).toFixed(1));
+    }
+
+    const velArrow = this.shadowRoot.getElementById("vel-arrow");
+    if (velArrow) {
+      if (speed > 1 && velocityYaw != null) {
+        const angleRad = driftYaw * Math.PI / 180;
+        const arrowLen = Math.min(48, 20 + speed * 0.015);
+        velArrow.setAttribute("x2", (SHIP_CENTER.x + arrowLen * Math.cos(angleRad)).toFixed(1));
+        velArrow.setAttribute("y2", (SHIP_CENTER.y - arrowLen * Math.sin(angleRad)).toFixed(1));
+        velArrow.setAttribute("opacity", "0.9");
+      } else {
+        velArrow.setAttribute("opacity", "0");
+      }
+    }
+
+    const targetArrow = this.shadowRoot.getElementById("target-arrow");
+    if (targetArrow) {
+      if (target && Math.abs(yawError) > 0.5) {
+        const angleRad = yawError * Math.PI / 180;
+        const arrowLen = 38;
+        targetArrow.setAttribute("x2", (SHIP_CENTER.x + arrowLen * Math.cos(angleRad)).toFixed(1));
+        targetArrow.setAttribute("y2", (SHIP_CENTER.y - arrowLen * Math.sin(angleRad)).toFixed(1));
+        targetArrow.setAttribute("opacity", "0.9");
+      } else {
+        targetArrow.setAttribute("opacity", "0");
+      }
+    }
+
+    const thrusters = rcs?.thrusters || [];
+    Object.entries(THRUSTER_POS).forEach(([id]) => {
+      const thruster = thrusters.find((entry) => entry.id === id);
+      const el = this.shadowRoot.getElementById(`t-${id}`);
+      if (!el) return;
+
+      const throttle = thruster?.throttle || 0;
+      const active = throttle > 0.02;
+      el.setAttribute("fill", thrusterColor(throttle));
+      el.setAttribute("stroke", active ? "#8df4b7" : "#273046");
+      el.setAttribute("r", active ? "5" : "4");
+      el.setAttribute("opacity", active ? "1" : "0.78");
+    });
+
+    const sideShip = this.shadowRoot.getElementById("side-ship");
+    const sideTarget = this.shadowRoot.getElementById("side-target");
+    const pitch = clamp(heading.pitch || 0, -60, 60);
+    if (sideShip) {
+      sideShip.setAttribute("transform", `rotate(${-pitch} ${SIDE_CENTER.x} ${SIDE_CENTER.y})`);
+    }
+    if (sideTarget) {
+      const targetPitch = clamp(target?.pitch ?? pitch, -60, 60);
+      sideTarget.setAttribute("transform", `rotate(${-targetPitch} ${SIDE_CENTER.x} ${SIDE_CENTER.y})`);
+      sideTarget.style.opacity = target ? "1" : "0.2";
+    }
+
+    const speedLabel = this.shadowRoot.getElementById("speed-lbl");
+    const driftLabel = this.shadowRoot.getElementById("drift-lbl");
+    const yawErrLabel = this.shadowRoot.getElementById("yawerr-lbl");
+    const pitchLabel = this.shadowRoot.getElementById("pitch-lbl");
+    const pitchErrLabel = this.shadowRoot.getElementById("pitcherr-lbl");
+    const rateLabel = this.shadowRoot.getElementById("rate-lbl");
+
+    if (speedLabel) speedLabel.textContent = `SPD ${speed.toFixed(0)} m/s`;
+    if (driftLabel) driftLabel.textContent = `DRIFT ${formatSignedAngle(driftYaw, "PORT", "STBD")}`;
+    if (yawErrLabel) yawErrLabel.textContent = `YAW ERR ${target ? formatSignedAngle(yawError, "PORT", "STBD") : "—"}`;
+    if (pitchLabel) pitchLabel.textContent = `PITCH ${(heading.pitch || 0).toFixed(0)}°`;
+    if (pitchErrLabel) pitchErrLabel.textContent = `PITCH ERR ${target ? formatSignedAngle(pitchError, "UP", "DN") : "—"}`;
+    if (rateLabel) rateLabel.textContent = `OMEGA ${omegaMag.toFixed(1)}°/s`;
+  }
+}
+
+customElements.define("ship-orientation-display", ShipOrientationDisplay);

--- a/gui/components/weapons-hardpoints-display.js
+++ b/gui/components/weapons-hardpoints-display.js
@@ -1,0 +1,314 @@
+/**
+ * Weapons Hardpoints Display — top-down ship schematic with live weapon states.
+ *
+ * Shows each weapon mount on a corvette silhouette with live state indicators:
+ *   READY (green) · CHARGING (amber fill arc) · RELOADING (blue arc)
+ *   EXHAUSTED (gray) · OFFLINE (red)
+ * Briefly flashes white when a weapon fires (ammo decrement detected).
+ *
+ * Data: stateManager.getWeapons()/getCombat()
+ *   .truth_weapons — per-mount state for railguns and PDCs
+ *   .torpedoes     — aggregate tube state {tubes, loaded, capacity, cooldown}
+ *   .missiles      — aggregate launcher state {launchers, loaded, capacity, cooldown}
+ *
+ * Ship nose → RIGHT (+X). SVG viewBox 0 0 320 160.
+ */
+import { stateManager } from "../js/state-manager.js";
+
+// Known hardpoint positions on the ship silhouette (nose → right)
+const HP_LAYOUT = {
+  railgun_1: { x: 262, y: 80,  r: 13, label: "RG" },
+  railgun_2: { x: 250, y: 67,  r: 12, label: "RG2" },
+  pdc_1:     { x: 230, y: 57,  r: 10, label: "PDC" },
+  pdc_2:     { x: 230, y: 103, r: 10, label: "PDC" },
+  pdc_3:     { x: 175, y: 50,  r: 10, label: "PDC" },
+  pdc_4:     { x: 175, y: 110, r: 10, label: "PDC" },
+};
+
+// Auto-position fallback for unknown mounts (placed aft of midship)
+const AUTO_FALLBACK = [
+  { x: 130, y: 58 }, { x: 130, y: 102 },
+  { x: 105, y: 62 }, { x: 105, y: 98 },
+];
+
+// Torpedo/missile tube bank anchor positions (aft section)
+const TORP_ANCHOR  = { x: 90, y: 68 };
+const MSL_ANCHOR   = { x: 90, y: 92 };
+
+const COLORS = {
+  ready:     "#00cc66",
+  charging:  "#ff9900",
+  reloading: "#4488ff",
+  exhausted: "#444",
+  destroyed: "#cc2244",
+  fire_flash:"#ffffff",
+};
+
+function svgArcPath(cx, cy, r, startDeg, endDeg) {
+  const rad = (d) => (d - 90) * Math.PI / 180;
+  const x1 = cx + r * Math.cos(rad(startDeg));
+  const y1 = cy + r * Math.sin(rad(startDeg));
+  const x2 = cx + r * Math.cos(rad(endDeg));
+  const y2 = cy + r * Math.sin(rad(endDeg));
+  const large = (endDeg - startDeg) > 180 ? 1 : 0;
+  return `M ${x1} ${y1} A ${r} ${r} 0 ${large} 1 ${x2} ${y2}`;
+}
+
+class WeaponsHardpointsDisplay extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this._unsub = null;
+    this._lastUpdate = 0;
+    this._rafId = null;
+    this._prevAmmo = {};   // mount_id → last known ammo count
+    this._flashUntil = {}; // mount_id → timestamp to stop flashing
+    this._knownMounts = [];
+  }
+
+  connectedCallback() {
+    this._render();
+    this._unsub = stateManager.subscribe("*", () => this._scheduleUpdate());
+    this._scheduleUpdate();
+  }
+
+  disconnectedCallback() {
+    if (this._unsub) { this._unsub(); this._unsub = null; }
+    if (this._rafId) { cancelAnimationFrame(this._rafId); this._rafId = null; }
+  }
+
+  _scheduleUpdate() {
+    const now = performance.now();
+    if (now - this._lastUpdate < 150) return; // ~6 Hz
+    this._lastUpdate = now;
+    if (this._rafId) cancelAnimationFrame(this._rafId);
+    this._rafId = requestAnimationFrame(() => this._update());
+  }
+
+  _render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host { display: block; font-family: var(--font-mono, monospace); }
+        svg { width: 100%; height: auto; display: block; }
+        .hull { fill: #1a1a2e; stroke: #3a3a5a; stroke-width: 1.5; }
+        .centerline { stroke: #2a2a4a; stroke-width: 0.5; stroke-dasharray: 4 3; }
+        .hp-bg { fill: #111; stroke: #333; stroke-width: 1; }
+        .hp-fill { transition: fill 0.1s; }
+        .hp-ring { fill: none; stroke-width: 2.5; stroke-linecap: round; }
+        .hp-label { font-size: 7px; fill: #999; text-anchor: middle; dominant-baseline: middle; pointer-events: none; }
+        .hp-ammo { font-size: 6px; fill: #666; text-anchor: middle; }
+        .hp-disabled { stroke: ${COLORS.destroyed}; stroke-width: 1.6; stroke-linecap: round; }
+        .tube-dot { transition: fill 0.15s; }
+        .tube-label { font-size: 6px; fill: #666; }
+        .legend { font-size: 6px; fill: #555; }
+      </style>
+      <svg viewBox="0 0 320 160" xmlns="http://www.w3.org/2000/svg">
+        <!-- Ship silhouette (nose pointing right) -->
+        <polygon class="hull"
+          points="55,80 80,50 230,52 282,80 230,108 80,110" />
+        <!-- Centerline -->
+        <line class="centerline" x1="55" y1="80" x2="282" y2="80" />
+        <!-- Engine bells (stern) -->
+        <ellipse cx="62" cy="68" rx="6" ry="4" fill="none" stroke="#2a3a5a" stroke-width="1"/>
+        <ellipse cx="62" cy="92" rx="6" ry="4" fill="none" stroke="#2a3a5a" stroke-width="1"/>
+
+        <!-- Hardpoint groups (populated by _buildHardpoints) -->
+        <g id="hp-layer"></g>
+
+        <!-- Torpedo tube bank -->
+        <g id="torp-bank"></g>
+        <!-- Missile launcher bank -->
+        <g id="msl-bank"></g>
+
+        <!-- Legend -->
+        <g transform="translate(6,150)">
+          <circle cx="4"  cy="3" r="3" fill="${COLORS.ready}"/>
+          <text class="legend" x="10" y="5">READY</text>
+          <circle cx="46" cy="3" r="3" fill="${COLORS.charging}"/>
+          <text class="legend" x="52" y="5">CHARGING</text>
+          <circle cx="96" cy="3" r="3" fill="${COLORS.reloading}"/>
+          <text class="legend" x="102" y="5">RELOAD</text>
+          <circle cx="138" cy="3" r="3" fill="${COLORS.exhausted}"/>
+          <text class="legend" x="144" y="5">EMPTY</text>
+          <circle cx="178" cy="3" r="3" fill="${COLORS.destroyed}"/>
+          <text class="legend" x="184" y="5">OFFLINE</text>
+        </g>
+      </svg>`;
+  }
+
+  _weaponState(w) {
+    if (w?.enabled === false) return "destroyed";
+    if (w?.reloading) return "reloading";
+    if (w?.charge_state === "charging") return "charging";
+    if ((w?.ammo ?? 0) === 0) return "exhausted";
+    return "ready";
+  }
+
+  _progress(w) {
+    if (w.charge_state === "charging") return w.charge_progress || 0;
+    if (w.reloading) return w.reload_progress || 0;
+    return 0;
+  }
+
+  _buildHardpoints(mounts) {
+    const layer = this.shadowRoot.getElementById("hp-layer");
+    if (!layer) return;
+
+    const mountIds = Object.keys(mounts);
+    const existingIds = new Set([...layer.querySelectorAll("[data-mount]")].map(el => el.dataset.mount));
+    const newIds = new Set(mountIds);
+
+    // Remove stale groups
+    existingIds.forEach(id => {
+      if (!newIds.has(id)) layer.querySelector(`[data-mount="${id}"]`)?.remove();
+    });
+
+    let fallbackIdx = 0;
+    mountIds.forEach(mid => {
+      if (existingIds.has(mid)) return; // already present
+      const pos = HP_LAYOUT[mid] || { ...AUTO_FALLBACK[fallbackIdx++ % AUTO_FALLBACK.length], r: 10, label: mid.toUpperCase().slice(0,3) };
+      const { x, y, r = 10, label } = pos;
+      const circ = 2 * Math.PI * (r - 1);
+
+      const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+      g.setAttribute("data-mount", mid);
+      g.innerHTML = `
+        <circle class="hp-bg"  cx="${x}" cy="${y}" r="${r}" />
+        <circle class="hp-fill" data-role="fill"  cx="${x}" cy="${y}" r="${r - 3}" fill="${COLORS.ready}" />
+        <path   class="hp-ring" data-role="ring"
+          d="" stroke="${COLORS.ready}" />
+        <g data-role="disabled-mark" visibility="hidden">
+          <line class="hp-disabled" x1="${x - (r - 3)}" y1="${y - (r - 3)}" x2="${x + (r - 3)}" y2="${y + (r - 3)}" />
+          <line class="hp-disabled" x1="${x + (r - 3)}" y1="${y - (r - 3)}" x2="${x - (r - 3)}" y2="${y + (r - 3)}" />
+        </g>
+        <text   class="hp-label" x="${x}" y="${y}">${label}</text>
+        <text   class="hp-ammo" data-role="ammo" x="${x}" y="${y + r + 6}"></text>`;
+      layer.appendChild(g);
+    });
+    this._knownMounts = mountIds;
+  }
+
+  _updateHardpoint(mid, w) {
+    const g = this.shadowRoot.querySelector(`[data-mount="${mid}"]`);
+    if (!g) return;
+
+    const pos = HP_LAYOUT[mid] || AUTO_FALLBACK[0];
+    const { x, y, r = 10 } = pos;
+
+    const now = performance.now();
+    const flashing = this._flashUntil[mid] && now < this._flashUntil[mid];
+
+    // Detect fire event
+    const prevAmmo = this._prevAmmo[mid];
+    if (prevAmmo !== undefined && w.ammo !== null && w.ammo < prevAmmo) {
+      this._flashUntil[mid] = now + 150;
+    }
+    this._prevAmmo[mid] = w.ammo;
+
+    const state = this._weaponState(w);
+    const prog  = this._progress(w);
+    const col   = flashing ? COLORS.fire_flash : COLORS[state];
+
+    const fillEl = g.querySelector("[data-role='fill']");
+    const ringEl = g.querySelector("[data-role='ring']");
+    const ammoEl = g.querySelector("[data-role='ammo']");
+    const disabledEl = g.querySelector("[data-role='disabled-mark']");
+
+    if (fillEl) fillEl.setAttribute("fill", col);
+    if (disabledEl) {
+      disabledEl.setAttribute("visibility", w?.enabled === false ? "visible" : "hidden");
+    }
+
+    // Progress arc (charge or reload)
+    if (ringEl) {
+      if (prog > 0) {
+        const endDeg = prog * 360;
+        ringEl.setAttribute("d", svgArcPath(x, y, r - 1, 0, endDeg));
+        ringEl.setAttribute("stroke", col);
+      } else {
+        ringEl.setAttribute("d", "");
+      }
+    }
+
+    // Ammo readout
+    if (ammoEl) {
+      if (w.charge_state === "charging") {
+        ammoEl.textContent = `${Math.round((w.charge_progress || 0) * 100)}%`;
+        ammoEl.setAttribute("fill", COLORS.charging);
+      } else if (w.reloading) {
+        const remaining = Math.max(0, (w.reload_time || 0) * (1 - (w.reload_progress || 0)));
+        ammoEl.textContent = `${remaining.toFixed(1)}s`;
+        ammoEl.setAttribute("fill", COLORS.reloading);
+      } else if (w.ammo !== null && w.ammo !== undefined) {
+        const pct = w.ammo_capacity > 0 ? Math.round(w.ammo / w.ammo_capacity * 100) : 100;
+        ammoEl.textContent = w.ammo_capacity > 100 ? `${pct}%` : `×${w.ammo}`;
+        ammoEl.setAttribute("fill", w.ammo <= 3 ? "#ff4444" : "#666");
+      } else {
+        ammoEl.textContent = "";
+      }
+    }
+  }
+
+  _updateTubeBank(anchor, count, loaded, cooldown, label, bankId) {
+    const bank = this.shadowRoot.getElementById(bankId);
+    if (!bank) return;
+    if (count === 0) { bank.innerHTML = ""; return; }
+
+    const { x, y } = anchor;
+    const dots = Math.min(count, 6);
+    const spacing = 9;
+    const dotY = y;
+    let html = `<text class="tube-label" x="${x - 2}" y="${dotY - 8}">${label}</text>`;
+
+    for (let i = 0; i < dots; i++) {
+      const dx = x + i * spacing;
+      const full = i < loaded;
+      const col = cooldown > 0 && full ? COLORS.reloading : full ? COLORS.ready : COLORS.exhausted;
+      html += `<circle class="tube-dot" cx="${dx}" cy="${dotY}" r="3.5" fill="${col}" />`;
+    }
+    if (count > 6) {
+      html += `<text class="tube-label" x="${x + dots * spacing + 2}" y="${dotY + 3}">+${count - 6}</text>`;
+    }
+    bank.innerHTML = html;
+  }
+
+  _update() {
+    const ship = stateManager.getShipState?.();
+    const weapons = stateManager.getWeapons?.() || ship?.weapons || {};
+    const combat = stateManager.getCombat?.() || null;
+    const truthWeapons = weapons.truth_weapons || combat?.truth_weapons || {};
+    const torpedoes = weapons.torpedoes || combat?.torpedoes;
+    const missiles = weapons.missiles || combat?.missiles;
+
+    if (!Object.keys(truthWeapons).length && !torpedoes && !missiles) return;
+
+    this._buildHardpoints(truthWeapons);
+
+    Object.entries(truthWeapons).forEach(([mid, w]) => {
+      this._updateHardpoint(mid, w);
+    });
+
+    if (torpedoes) {
+      this._updateTubeBank(
+        TORP_ANCHOR, torpedoes.tubes || 0, torpedoes.loaded || 0,
+        torpedoes.cooldown || 0, "TORP", "torp-bank"
+      );
+    }
+    if (missiles) {
+      this._updateTubeBank(
+        MSL_ANCHOR, missiles.launchers || 0, missiles.loaded || 0,
+        missiles.cooldown || 0, "MSL", "msl-bank"
+      );
+    }
+
+    // If flash timers are running, reschedule soon to clear them
+    const now = performance.now();
+    const hasFlash = Object.values(this._flashUntil).some(t => t > now);
+    if (hasFlash) {
+      this._lastUpdate = 0; // bypass throttle for flash clearance
+      setTimeout(() => this._scheduleUpdate(), 160);
+    }
+  }
+}
+
+customElements.define("weapons-hardpoints-display", WeaponsHardpointsDisplay);

--- a/gui/index.html
+++ b/gui/index.html
@@ -181,9 +181,19 @@
       min-height: var(--panel-height-md);
     }
 
+    .helm-orientation-panel {
+      grid-column: span 4;
+      min-height: var(--panel-height-md);
+    }
+
     .helm-rcs-panel {
       grid-column: span 4;
       min-height: var(--panel-height-sm);
+    }
+
+    .helm-rcs-thruster-panel {
+      grid-column: span 4;
+      min-height: var(--panel-height-md);
     }
 
     .helm-maneuver-panel {
@@ -239,6 +249,11 @@
     .tac-charge-game-panel {
       grid-column: span 4;
       min-height: var(--panel-height-sm);
+    }
+
+    .tac-hardpoints-panel {
+      grid-column: span 6;
+      min-height: var(--panel-height-md);
     }
 
     .tac-weapons-panel {
@@ -539,6 +554,7 @@
       .tac-targeting-panel,
       .tac-solution-panel,
       .tac-fire-ctrl-panel,
+      .tac-hardpoints-panel,
       .tac-weapons-panel,
       .tac-torpedo-panel,
       .eng-thermal-panel,
@@ -565,7 +581,9 @@
       /* span-4 panels stay span-4 (half-width, 2-per-row in 8-col) */
       .helm-autopilot-status-panel,
       .helm-manual-flight-panel,
+      .helm-orientation-panel,
       .helm-rcs-panel,
+      .helm-rcs-thruster-panel,
       .helm-queue-panel,
       .helm-docking-panel,
       .tac-sensors-panel,
@@ -609,7 +627,9 @@
 
       /* Span-4 panels become span-3 so two fit side-by-side */
       .helm-autopilot-status-panel,
+      .helm-orientation-panel,
       .helm-rcs-panel,
+      .helm-rcs-thruster-panel,
       .helm-queue-panel,
       .helm-docking-panel,
       .helm-micro-rcs-panel,
@@ -722,6 +742,10 @@
             <manual-flight-panel></manual-flight-panel>
           </flaxos-panel>
 
+          <flaxos-panel title="Orientation" collapsible priority="primary" domain="helm" class="helm-orientation-panel">
+            <ship-orientation-display></ship-orientation-display>
+          </flaxos-panel>
+
           <flaxos-panel title="RCS / Attitude" collapsible domain="helm" class="helm-rcs-panel">
             <rcs-controls></rcs-controls>
           </flaxos-panel>
@@ -813,6 +837,10 @@
 
           <flaxos-panel title="Railgun Charge" collapsible priority="secondary" domain="weapons" class="tac-charge-game-panel">
             <weapons-charge-game></weapons-charge-game>
+          </flaxos-panel>
+
+          <flaxos-panel title="Hardpoints" collapsible priority="primary" domain="weapons" class="tac-hardpoints-panel">
+            <weapons-hardpoints-display></weapons-hardpoints-display>
           </flaxos-panel>
 
           <flaxos-panel title="Weapons / Ordnance" collapsible priority="secondary" domain="weapons" class="tac-weapons-panel">
@@ -972,8 +1000,8 @@
             <subsystem-status-panel></subsystem-status-panel>
           </flaxos-panel>
 
-          <flaxos-panel title="Power Draw" collapsible priority="secondary" domain="power" class="eng-power-panel">
-            <power-draw-display></power-draw-display>
+          <flaxos-panel title="Power Flow" collapsible priority="secondary" domain="power" class="eng-power-panel">
+            <power-flow-display></power-flow-display>
           </flaxos-panel>
         </div>
 

--- a/gui/js/main.js
+++ b/gui/js/main.js
@@ -135,6 +135,12 @@ import "../components/munition-programming-panel.js";
 import "../components/target-assessment.js";
 // MANUAL tier weapon aiming reticle
 import "../components/weapon-aiming-panel.js";
+// Weapons hardpoints schematic (live state per mount)
+import "../components/weapons-hardpoints-display.js";
+// Helm schematic with live RCS / drift state
+import "../components/ship-orientation-display.js";
+// Engineering power bus flow schematic
+import "../components/power-flow-display.js";
 // Damage visualization
 import { damageStateManager } from "./damage-state-manager.js";
 // Ship Class Editor

--- a/hybrid/telemetry.py
+++ b/hybrid/telemetry.py
@@ -157,11 +157,21 @@ def get_ship_telemetry(ship, sim_time: float = None) -> Dict[str, Any]:
         autopilot_state = nav_state.get("autopilot_state")
         course_info = nav_state.get("course")
 
-    # Get helm queue status
+    # Get helm queue and control state
     helm_queue = None
+    helm_state = None
     helm = ship.systems.get("helm")
-    if helm and hasattr(helm, "get_queue_state"):
-        helm_queue = helm.get_queue_state()
+    if helm:
+        if hasattr(helm, "get_queue_state"):
+            helm_queue = helm.get_queue_state()
+        if hasattr(helm, "get_state"):
+            helm_state = helm.get_state()
+
+    # Get live RCS telemetry for helm orientation/thruster displays
+    rcs_state = None
+    rcs = ship.systems.get("rcs")
+    if rcs and hasattr(rcs, "get_state"):
+        rcs_state = rcs.get_state()
 
     # Get weapons status
     weapons_status = get_weapons_status(ship)
@@ -264,6 +274,8 @@ def get_ship_telemetry(ship, sim_time: float = None) -> Dict[str, Any]:
         "autopilot_state": autopilot_state,
         "course": course_info,
         "helm_queue": helm_queue,
+        "helm": helm_state,
+        "rcs": rcs_state,
         "trajectory": trajectory,
         "flight_computer": flight_computer_status,
         "weapons": weapons_status,

--- a/server/stations/station_telemetry.py
+++ b/server/stations/station_telemetry.py
@@ -39,7 +39,7 @@ class StationTelemetryFilter:
             "autopilot_status": ["nav_mode", "autopilot_program",
                                  "autopilot_state", "course"],
             "helm_status": ["orientation", "angular_velocity", "velocity",
-                            "helm_queue"],
+                            "helm_queue", "helm", "rcs"],
             "propulsion_status": ["fuel", "systems"],
 
             # Tactical displays


### PR DESCRIPTION
## Summary

- add live schematic displays to the legacy GUI for tactical hardpoints, helm orientation, and engineering power flow
- wire `helm` and `rcs` state through station telemetry so the helm orientation display can render in station mode
- normalize `power-draw-display` against the current power draw profile payload shape

## Validation

- `node --check gui/components/weapons-hardpoints-display.js`
- `node --check gui/components/ship-orientation-display.js`
- `node --check gui/components/power-flow-display.js`
- `node --check gui/components/power-draw-display.js`
- `node --check gui/js/main.js`
- `python3 -m pytest tests/ -x -q`

## Notes

- this targets the legacy `gui/` fallback UI, not the default `gui-svelte/` frontend
- browser/UAT stack was not run for manual visual verification
