### PR TITLE
feat(gui-v3): V3 bridge interface — tier-aware controls, all weapons fireable

### DIFF
--- a/GUI-GUIDE.md
+++ b/GUI-GUIDE.md
@@ -1,5 +1,7 @@
 # GUI Guide
 
+> The supported web interface is the v3 bridge UI in `gui-svelte/`. If this guide conflicts with the live Svelte UI, follow [docs/USER_GUIDE.md](/home/flax/games/spaceship-sim/docs/USER_GUIDE.md) and the current in-app `Mission` flow.
+
 ## Overview
 
 The web GUI connects to the simulation server via a WebSocket bridge and

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd /path/to/spaceship-sim
 python tools/start_gui_stack.py --browser --rcon-password 'replace-this-with-a-strong-secret'
 ```
 
-This starts the current default Svelte stack and, with `--browser`, opens the GUI at `http://localhost:3100/`:
+This starts the current default **v3 bridge UI** and, with `--browser`, opens the GUI at `http://localhost:3100/`:
 
 | Process | Default Port |
 |---------|-------------|
@@ -59,7 +59,7 @@ python tools/start_gui_stack.py --tcp-port 9000 --ws-port 9001 --http-port 3200
 # Open a browser automatically
 python tools/start_gui_stack.py --browser
 
-# Set an explicit RCON password for Config > Server admin controls
+# Set an explicit RCON password for Mission > Server admin controls
 python tools/start_gui_stack.py --rcon-password 'replace-this'
 
 # Secure remote/LAN use: restrict browser origin, require WS auth, and set RCON
@@ -78,9 +78,9 @@ python -m server.main --port 9000      # Custom port
 ### Connect and play
 
 1. Open `http://localhost:3100/` in a browser
-2. The GUI connects to the WebSocket bridge automatically
-3. Select a bridge station (Helm, Tactical, OPS, etc.)
-4. You are on the bridge
+2. The v3 bridge UI connects to the WebSocket bridge automatically
+3. Open `Mission`, load a scenario, and join a bridge station
+4. Use the bridge header to move between the playable station workflows
 
 ### Server Admin / UAT
 
@@ -88,7 +88,7 @@ For repeatable UAT runs, start the stack with a non-default RCON password and us
 
 1. Launch with `python tools/start_gui_stack.py --browser --rcon-password 'replace-this'`
 2. Load a scenario and claim a station
-3. Open `Config > Server`
+3. Open `Mission > Server`
 4. Authenticate with the RCON password
 5. Use the panel for:
    - server uptime and mission uptime visibility
@@ -122,7 +122,7 @@ python3 tools/uat_monitor.py --follow --fail-on-critical
 For remote browser access over ZeroTier, use all three controls together:
 
 1. `--game-code` to gate the WebSocket bridge
-2. `--rcon-password` for admin actions in `Config > Server`
+2. `--rcon-password` for admin actions in `Mission > Server`
 3. `--allowed-origin-host <zerotier-ip-or-hostname>` to restrict browser origins hitting the bridge
 
 Recommended example:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,6 +1,6 @@
 # User Guide (Player)
 
-The default supported interface is the browser GUI served from `gui-svelte/`.
+The default supported interface is the **v3 browser bridge UI** served from `gui-svelte/`.
 
 ## Startup
 
@@ -8,7 +8,7 @@ The default supported interface is the browser GUI served from `gui-svelte/`.
 python3 tools/start_gui_stack.py --browser --rcon-password 'replace-this'
 ```
 
-Open the browser UI, load a scenario from `Config`, then claim a station.
+Open the browser UI, load a scenario from `Mission`, then claim a station.
 
 ## Main Views
 
@@ -19,21 +19,21 @@ Open the browser UI, load a scenario from `Config`, then claim a station.
 - `Science`: passive contacts and analysis
 - `Comms`: radio, incoming choices, station chat
 - `Fleet`: formation, orders, shared contacts, fleet fire control
-- `Config`: scenario loader, objectives, campaign, command console, server admin
+- `Mission`: scenario loader, objectives, campaign, command console, server admin
 
 ## Core Flow
 
-1. Load a scenario from `Config`.
+1. Load a scenario from `Mission`.
 2. Claim a station.
 3. Use the relevant station panels for that role.
-4. For repeatable UAT or multiplayer triage, authenticate in `Config > Server`.
+4. For repeatable UAT or multiplayer triage, authenticate in `Mission > Server`.
 
 ## Current Supported Controls
 
 - Use the contacts panels to select and lock targets.
 - Use the flight computer for intercept/rendezvous/match/hold programs.
 - Use tactical controls for railgun, PDC, launcher, and subsystem targeting.
-- Use `Config > Server` for pause/resume, time scale, mission reset, server reset, and client management.
+- Use `Mission > Server` for pause/resume, time scale, mission reset, server reset, and client management.
 
 ## UAT Tip
 

--- a/gui-svelte/src/App.svelte
+++ b/gui-svelte/src/App.svelte
@@ -8,10 +8,8 @@
   import { initializeConnection } from "./lib/stores/playerShip.js";
   import { playerShipId } from "./lib/stores/playerShip.js";
 
+  import BridgeHeader from "./components/layout/BridgeHeader.svelte";
   import StatusBar from "./components/layout/StatusBar.svelte";
-  import TierSelector from "./components/layout/TierSelector.svelte";
-  import StationSelector from "./components/layout/StationSelector.svelte";
-  import ViewTabs from "./components/layout/ViewTabs.svelte";
 
   import HelmView from "./views/HelmView.svelte";
   import TacticalView from "./views/TacticalView.svelte";
@@ -20,22 +18,22 @@
   import ScienceView from "./views/ScienceView.svelte";
   import CommsView from "./views/CommsView.svelte";
   import FleetView from "./views/FleetView.svelte";
-  import ConfigView from "./views/MissionView.svelte";
+  import MissionView from "./views/MissionView.svelte";
   import EditorView from "./views/EditorView.svelte";
 
   // Station → allowed views mapping (mirrors index.html logic)
   const STATION_VIEWS: Record<string, string[]> = {
-    captain:         ["helm", "tactical", "engineering", "ops", "science", "comms", "fleet", "config"],
-    helm:            ["helm", "tactical", "config"],
-    tactical:        ["tactical", "helm", "config"],
-    ops:             ["ops", "engineering", "config"],
-    engineering:     ["engineering", "ops", "config"],
-    comms:           ["comms", "config"],
-    science:         ["science", "tactical", "config"],
-    fleet_commander: ["fleet", "tactical", "config"],
+    captain:         ["mission", "helm", "tactical", "engineering", "ops", "science", "comms", "fleet"],
+    helm:            ["mission", "helm", "tactical"],
+    tactical:        ["mission", "tactical", "helm"],
+    ops:             ["mission", "ops", "engineering"],
+    engineering:     ["mission", "engineering", "ops"],
+    comms:           ["mission", "comms"],
+    science:         ["mission", "science", "tactical"],
+    fleet_commander: ["mission", "fleet", "tactical"],
   };
 
-  let activeView = "config";
+  let activeView = "mission";
   let allowedViews: string[] | null = null; // null = all (pre-station-claim)
 
   function onViewChange(e: CustomEvent<{ view: string }>) {
@@ -44,9 +42,9 @@
 
   function onStationClaimed(e: CustomEvent<{ station: string }>) {
     const station = e.detail.station;
-    allowedViews = STATION_VIEWS[station] ?? ["config"];
-    // Auto-switch to first allowed view that isn't config (if available)
-    const preferred = allowedViews.find((v) => v !== "config") ?? allowedViews[0];
+    allowedViews = STATION_VIEWS[station] ?? ["mission"];
+    // Auto-switch to first allowed view that isn't mission (if available)
+    const preferred = allowedViews.find((v) => v !== "mission") ?? allowedViews[0];
     if (preferred && !allowedViews.includes(activeView)) {
       activeView = preferred;
     }
@@ -56,7 +54,7 @@
     allowedViews = null; // unlock all views
   }
 
-  // Listen for scenario-loaded to switch to helm/config view
+  // Listen for scenario-loaded to switch to the first active bridge view
   function onScenarioLoaded(e: Event) {
     // Server returns player_ship_id / assigned_ship — check all possible keys
     type ScenarioDetail = Record<string, string | undefined>;
@@ -84,22 +82,14 @@
 
 <div id="app-shell">
   <!-- ── Top chrome ── -->
-  <StatusBar />
-
-  <div class="bridge-controls">
-    <StationSelector
-      on:station-claimed={onStationClaimed}
-      on:station-released={onStationReleased}
-    />
-    <span class="controls-spacer"></span>
-    <TierSelector />
-  </div>
-
-  <ViewTabs
+  <BridgeHeader
     bind:activeView
     {allowedViews}
+    on:station-claimed={onStationClaimed}
+    on:station-released={onStationReleased}
     on:view-change={onViewChange}
   />
+  <StatusBar />
 
   <!-- ── View stack ── -->
   <div class="view-stack">
@@ -124,8 +114,8 @@
     <div class="view-container" class:active={activeView === "fleet"}>
       <FleetView />
     </div>
-    <div class="view-container" class:active={activeView === "config"}>
-      <ConfigView />
+    <div class="view-container" class:active={activeView === "mission"}>
+      <MissionView />
     </div>
     <div class="view-container" class:active={activeView === "editor"}>
       <EditorView />
@@ -148,24 +138,6 @@
 
   /* Status bar */
   :global(.status-bar) {
-    flex: 0 0 32px;
-  }
-
-  .bridge-controls {
-    flex: 0 0 40px;
-    display: flex;
-    align-items: center;
-    padding: 0 var(--space-sm);
-    gap: var(--space-sm);
-    background: var(--bg-panel);
-    border-bottom: 2px solid var(--tier-accent, var(--border-default));
-    position: relative;
-    z-index: 99;
-  }
-
-  .controls-spacer { flex: 1; }
-
-  :global(.view-tabs) {
     flex: 0 0 36px;
   }
 

--- a/gui-svelte/src/components/engineering/EngineeringShipSchematic.svelte
+++ b/gui-svelte/src/components/engineering/EngineeringShipSchematic.svelte
@@ -1,0 +1,504 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import {
+    clamp,
+    getEngineeringShip,
+    getSubsystemRows,
+    getThermalState,
+    toNumber,
+    type SystemHealthRow,
+  } from "./engineeringData.js";
+  import { getArmorIntegrity, getArmorRows, getHullPercent, getRepairTargets } from "../ops/opsData.js";
+  import { getLauncherInventory, getWeaponMounts, type WeaponMountState } from "../tactical/tacticalData.js";
+
+  type ZoneLayout = {
+    id: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    radius: number;
+    labelX: number;
+    labelY: number;
+  };
+
+  type ArmorLayout = {
+    id: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    labelX: number;
+    labelY: number;
+  };
+
+  type MountLayout = { x: number; y: number; r: number };
+
+  const SUBSYSTEM_LAYOUTS: ZoneLayout[] = [
+    { id: "sensors", x: 108, y: 72, width: 78, height: 26, radius: 8, labelX: 147, labelY: 88 },
+    { id: "comms", x: 112, y: 136, width: 64, height: 24, radius: 8, labelX: 144, labelY: 151 },
+    { id: "weapons", x: 176, y: 100, width: 78, height: 38, radius: 10, labelX: 215, labelY: 120 },
+    { id: "reactor", x: 250, y: 92, width: 72, height: 52, radius: 12, labelX: 286, labelY: 118 },
+    { id: "radiators", x: 185, y: 60, width: 118, height: 18, radius: 7, labelX: 244, labelY: 72 },
+    { id: "life_support", x: 184, y: 148, width: 92, height: 26, radius: 8, labelX: 230, labelY: 164 },
+    { id: "propulsion", x: 320, y: 96, width: 76, height: 44, radius: 10, labelX: 358, labelY: 121 },
+  ];
+
+  const ARMOR_LAYOUTS: ArmorLayout[] = [
+    { id: "fore", x: 78, y: 106, width: 24, height: 28, labelX: 90, labelY: 102 },
+    { id: "aft", x: 404, y: 102, width: 22, height: 36, labelX: 415, labelY: 98 },
+    { id: "port", x: 126, y: 54, width: 106, height: 10, labelX: 179, labelY: 48 },
+    { id: "starboard", x: 126, y: 186, width: 106, height: 10, labelX: 179, labelY: 214 },
+    { id: "dorsal", x: 242, y: 46, width: 92, height: 10, labelX: 288, labelY: 40 },
+    { id: "ventral", x: 242, y: 194, width: 92, height: 10, labelX: 288, labelY: 222 },
+  ];
+
+  const HARDPOINT_LAYOUT: Record<string, MountLayout> = {
+    railgun_1: { x: 340, y: 72, r: 11 },
+    railgun_2: { x: 324, y: 58, r: 10 },
+    pdc_1: { x: 294, y: 58, r: 8 },
+    pdc_2: { x: 294, y: 150, r: 8 },
+    pdc_3: { x: 226, y: 52, r: 8 },
+    pdc_4: { x: 226, y: 156, r: 8 },
+  };
+
+  const FALLBACK_MOUNTS: MountLayout[] = [
+    { x: 180, y: 70, r: 8 },
+    { x: 180, y: 144, r: 8 },
+    { x: 150, y: 80, r: 8 },
+    { x: 150, y: 134, r: 8 },
+  ];
+
+  function statusColor(percent: number) {
+    if (percent < 35) return "#ff4f61";
+    if (percent < 65) return "#ffb547";
+    return "#33d17a";
+  }
+
+  function heatColor(percent: number) {
+    if (percent >= 85) return "#ff6942";
+    if (percent >= 60) return "#ffb547";
+    if (percent >= 35) return "#5fbaff";
+    return "#2f445d";
+  }
+
+  function mountColor(mount: WeaponMountState) {
+    if (!mount.enabled || /destroyed|offline|failed/i.test(mount.status)) return "#ff4f61";
+    if (mount.reloading) return "#59b6ff";
+    if (mount.chargeState === "charging") return "#ffb547";
+    if (mount.ammoCapacity > 0 && mount.ammo <= 0) return "#697284";
+    return "#33d17a";
+  }
+
+  function compactLabel(label: string) {
+    return label.replace(/_/g, " ").replace(/\s+/g, " ").trim().toUpperCase();
+  }
+
+  function damageMarks(row: SystemHealthRow) {
+    if (row.damagePercent < 15) return [];
+    const count = Math.min(4, Math.max(1, Math.round(row.damagePercent / 22)));
+    return Array.from({ length: count }, (_, index) => index);
+  }
+
+  function bankDots(loaded: unknown, capacity: unknown) {
+    const cap = Math.max(1, Math.min(8, Number(capacity ?? 0) || 1));
+    const filled = Math.min(cap, Math.max(0, Math.round(((Number(loaded ?? 0) || 0) / Math.max(1, Number(capacity ?? 0) || 1)) * cap)));
+    return Array.from({ length: cap }, (_, index) => index < filled);
+  }
+
+  $: ship = getEngineeringShip($gameState);
+  $: subsystemRows = getSubsystemRows(ship);
+  $: subsystemMap = new Map(subsystemRows.map((row) => [row.id, row]));
+  $: repairTargets = getRepairTargets(ship).slice(0, 3);
+  $: armorRows = getArmorRows(ship);
+  $: armorMap = new Map(armorRows.map((row) => [row.id, row]));
+  $: hullPercent = getHullPercent(ship);
+  $: armorPercent = getArmorIntegrity(ship);
+  $: thermal = getThermalState(ship);
+  $: mounts = getWeaponMounts(ship);
+  $: launcherInventory = getLauncherInventory(ship);
+  $: heatPercent = clamp(toNumber(thermal.temperature_percent, 0), 0, 100);
+  $: damagedSubsystems = subsystemRows.filter((row) => row.damagePercent > 0).length;
+  $: criticalSubsystems = subsystemRows.filter((row) => row.healthPercent < 35).length;
+  $: overallDamage = 100 - (subsystemRows.length ? subsystemRows.reduce((sum, row) => sum + row.healthPercent, 0) / subsystemRows.length : 100);
+</script>
+
+<Panel title="Ship Schematic" domain="power" priority="primary" className="engineering-ship-schematic-panel">
+  <div class="shell">
+    <div class="summary-row">
+      <div class="summary-card">
+        <span>Hull</span>
+        <strong style={`color:${statusColor(hullPercent)};`}>{Math.round(hullPercent)}%</strong>
+      </div>
+      <div class="summary-card">
+        <span>Armor</span>
+        <strong style={`color:${statusColor(armorPercent)};`}>{Math.round(armorPercent)}%</strong>
+      </div>
+      <div class="summary-card">
+        <span>Subsystem Damage</span>
+        <strong style={`color:${statusColor(100 - overallDamage)};`}>{Math.round(overallDamage)}%</strong>
+      </div>
+      <div class="summary-card">
+        <span>Thermal Load</span>
+        <strong style={`color:${heatColor(heatPercent)};`}>{Math.round(heatPercent)}%</strong>
+      </div>
+    </div>
+
+    <svg viewBox="0 0 460 244" aria-label="Engineering ship schematic">
+      <defs>
+        <linearGradient id="schematicHull" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stop-color="#121828" />
+          <stop offset="100%" stop-color="#0a0f18" />
+        </linearGradient>
+        <linearGradient id="schematicGlow" x1="0%" y1="0%" x2="0%" y2="100%">
+          <stop offset="0%" stop-color="rgba(255,255,255,0.32)" />
+          <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+        </linearGradient>
+      </defs>
+
+      <rect x="8" y="8" width="444" height="228" rx="12" class="frame" />
+
+      <circle
+        cx="286"
+        cy="118"
+        r="36"
+        class="reactor-glow"
+        style={`fill:${heatColor(Math.max(heatPercent, subsystemMap.get("reactor")?.heatPercent ?? 0))}; opacity:${0.08 + (subsystemMap.get("reactor")?.heatPercent ?? 0) / 220};`}
+      />
+
+      <polygon class="hull" points="68,122 114,74 280,66 372,96 402,122 372,148 280,178 114,170" />
+      <polygon class="hull-gloss" points="106,82 274,72 360,98 280,96 118,94" />
+      <line class="centerline" x1="68" y1="122" x2="402" y2="122" />
+
+      <path class="radiator-fin" d="M214 44 L236 66" />
+      <path class="radiator-fin" d="M230 40 L250 66" />
+      <path class="radiator-fin" d="M246 40 L266 66" />
+      <path class="radiator-fin" d="M262 44 L282 66" />
+      <path class="radiator-fin lower" d="M214 200 L236 178" />
+      <path class="radiator-fin lower" d="M230 204 L250 178" />
+      <path class="radiator-fin lower" d="M246 204 L266 178" />
+      <path class="radiator-fin lower" d="M262 200 L282 178" />
+
+      {#each ARMOR_LAYOUTS as layout}
+        {@const armor = armorMap.get(layout.id)}
+        {@const integrity = armor?.integrityPercent ?? 100}
+        <g>
+          <rect
+            x={layout.x}
+            y={layout.y}
+            width={layout.width}
+            height={layout.height}
+            rx="3"
+            class="armor-band"
+            style={`fill:${statusColor(integrity)}; opacity:${0.18 + integrity / 180};`}
+          />
+          <rect
+            x={layout.x}
+            y={layout.y}
+            width={(layout.width * integrity) / 100}
+            height={layout.height}
+            rx="3"
+            class="armor-track"
+            style={`fill:${statusColor(integrity)};`}
+          />
+          <text class="armor-label" x={layout.labelX} y={layout.labelY}>
+            {layout.id.slice(0, 3).toUpperCase()} {Math.round(integrity)}%
+          </text>
+        </g>
+      {/each}
+
+      {#each SUBSYSTEM_LAYOUTS as layout}
+        {@const row = subsystemMap.get(layout.id)}
+        {@const health = row?.healthPercent ?? 100}
+        {@const heat = row?.heatPercent ?? 0}
+        {@const repair = row?.repairStatus ?? "idle"}
+        <g>
+          <rect
+            x={layout.x}
+            y={layout.y}
+            width={layout.width}
+            height={layout.height}
+            rx={layout.radius}
+            class="zone"
+            style={`fill:${statusColor(health)}; opacity:${0.12 + health / 150}; stroke:${statusColor(health)};`}
+          />
+          <rect
+            x={layout.x + 4}
+            y={layout.y + 4}
+            width={Math.max(10, ((layout.width - 8) * heat) / 100)}
+            height="5"
+            rx="3"
+            class="zone-heat"
+            style={`fill:${heatColor(heat)}; opacity:${0.2 + heat / 150};`}
+          />
+          {#if repair !== "idle"}
+            <circle cx={layout.x + layout.width - 8} cy={layout.y + 8} r="5" class="repair-dot" />
+            <path d={`M ${layout.x + layout.width - 11} ${layout.y + 8} h 6 M ${layout.x + layout.width - 8} ${layout.y + 5} v 6`} class="repair-cross" />
+          {/if}
+          {#each damageMarks(row ?? { damagePercent: 0 } as SystemHealthRow) as mark}
+            <path
+              class="damage-mark"
+              d={`M ${layout.x + 12 + mark * 10} ${layout.y + layout.height - 8} l 9 -10 m -4 12 l 9 -10`}
+            />
+          {/each}
+          <text class="zone-label" x={layout.labelX} y={layout.labelY}>
+            {compactLabel(layout.id === "life_support" ? "life" : layout.id)}
+          </text>
+          <text class="zone-metric" x={layout.labelX} y={layout.labelY + 11}>{Math.round(health)}% / {Math.round(heat)}%</text>
+        </g>
+      {/each}
+
+      <g class="engine-cluster">
+        <ellipse cx="406" cy="106" rx="10" ry="6" class="engine-ring" />
+        <ellipse cx="406" cy="138" rx="10" ry="6" class="engine-ring" />
+        <path d="M416 106 h18" class="engine-plume" style={`stroke:${statusColor(subsystemMap.get("propulsion")?.healthPercent ?? 100)}; opacity:${0.35 + (subsystemMap.get("propulsion")?.healthPercent ?? 0) / 180};`} />
+        <path d="M416 138 h14" class="engine-plume" style={`stroke:${statusColor(subsystemMap.get("propulsion")?.healthPercent ?? 100)}; opacity:${0.25 + (subsystemMap.get("propulsion")?.healthPercent ?? 0) / 200};`} />
+      </g>
+
+      {#each mounts as mount, index}
+        {@const position = HARDPOINT_LAYOUT[mount.id] ?? FALLBACK_MOUNTS[index % FALLBACK_MOUNTS.length]}
+        {@const color = mountColor(mount)}
+        <g class="mount">
+          <circle cx={position.x} cy={position.y} r={position.r} class="mount-ring" style={`stroke:${color};`} />
+          <circle cx={position.x} cy={position.y} r={Math.max(4, position.r - 4)} class="mount-core" style={`fill:${color}; opacity:${mount.ready ? 0.95 : 0.72};`} />
+          <text class="mount-label" x={position.x} y={position.y + position.r + 10}>{mount.weaponType.toUpperCase()}</text>
+        </g>
+      {/each}
+
+      <g transform="translate(34 194)">
+        <text class="bank-title" x="0" y="-14">TORPEDO BAY</text>
+        {#each bankDots(launcherInventory.torpedoes.loaded, launcherInventory.torpedoes.capacity) as filled, index}
+          <circle cx={index * 12} cy="0" r="4.2" class="bank-dot" style={`fill:${filled ? "#59b6ff" : "rgba(255,255,255,0.1)"};`} />
+        {/each}
+      </g>
+
+      <g transform="translate(34 220)">
+        <text class="bank-title" x="0" y="-14">MISSILE CELL</text>
+        {#each bankDots(launcherInventory.missiles.loaded, launcherInventory.missiles.capacity) as filled, index}
+          <circle cx={index * 12} cy="0" r="4.2" class="bank-dot" style={`fill:${filled ? "#ffb547" : "rgba(255,255,255,0.1)"};`} />
+        {/each}
+      </g>
+
+      {#if repairTargets.length > 0}
+        {#each repairTargets as target, index}
+          {@const zone = SUBSYSTEM_LAYOUTS.find((entry) => entry.id === target.id)}
+          {@const zoneX = zone ? zone.x + zone.width : 310}
+          {@const zoneY = zone ? zone.y + zone.height / 2 : 90 + index * 28}
+          {@const calloutY = 42 + index * 32}
+          <g class="repair-callout">
+            <path d={`M ${zoneX} ${zoneY} C 340 ${zoneY}, 352 ${calloutY + 6}, 364 ${calloutY + 6}`} />
+            <rect x="364" y={calloutY - 6} width="76" height="20" rx="5" />
+            <text x="370" y={calloutY + 1}>{compactLabel(target.label).slice(0, 11)}</text>
+            <text class="repair-sub" x="370" y={calloutY + 10}>{Math.round(target.damagePercent)}% DMG</text>
+          </g>
+        {/each}
+      {/if}
+
+      <text class="footer" x="30" y="28">CRITICAL {criticalSubsystems}</text>
+      <text class="footer" x="120" y="28">DAMAGED {damagedSubsystems}</text>
+      <text class="footer" x="228" y="28">REPAIRS {repairTargets.length}</text>
+      <text class="footer" x="320" y="28">HULL TEMP {Math.round(toNumber(thermal.hull_temperature, 0))} K</text>
+    </svg>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .summary-row {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .summary-card {
+    display: grid;
+    gap: 4px;
+    padding: 8px 10px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .summary-card span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .summary-card strong {
+    font-family: var(--font-mono);
+    font-size: 1rem;
+  }
+
+  svg {
+    width: 100%;
+    height: auto;
+    display: block;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background:
+      radial-gradient(circle at 72% 50%, rgba(255, 102, 102, 0.08), transparent 28%),
+      radial-gradient(circle at 20% 50%, rgba(95, 186, 255, 0.05), transparent 30%),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 25%),
+      #081019;
+  }
+
+  .frame {
+    fill: rgba(4, 8, 14, 0.74);
+    stroke: rgba(255, 255, 255, 0.08);
+  }
+
+  .hull {
+    fill: url(#schematicHull);
+    stroke: rgba(126, 172, 255, 0.3);
+    stroke-width: 1.7;
+  }
+
+  .hull-gloss {
+    fill: rgba(255, 255, 255, 0.04);
+  }
+
+  .centerline {
+    stroke: rgba(255, 255, 255, 0.12);
+    stroke-dasharray: 4 4;
+  }
+
+  .radiator-fin {
+    fill: none;
+    stroke: rgba(130, 188, 255, 0.22);
+    stroke-width: 2.2;
+    stroke-linecap: round;
+  }
+
+  .radiator-fin.lower {
+    stroke: rgba(130, 188, 255, 0.16);
+  }
+
+  .armor-band {
+    stroke: rgba(255, 255, 255, 0.12);
+  }
+
+  .armor-track {
+    opacity: 0.88;
+  }
+
+  .armor-label,
+  .zone-label,
+  .zone-metric,
+  .mount-label,
+  .bank-title,
+  .footer,
+  .repair-callout text {
+    font-family: var(--font-mono);
+  }
+
+  .armor-label,
+  .zone-label,
+  .mount-label,
+  .bank-title,
+  .footer {
+    font-size: 8px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    fill: rgba(220, 232, 255, 0.78);
+  }
+
+  .zone-metric,
+  .repair-sub {
+    font-size: 7px;
+    letter-spacing: 0.05em;
+    fill: rgba(182, 196, 218, 0.72);
+  }
+
+  .zone {
+    stroke-width: 1.3;
+  }
+
+  .zone-heat {
+    stroke: none;
+  }
+
+  .repair-dot {
+    fill: rgba(255, 255, 255, 0.12);
+    stroke: rgba(95, 186, 255, 0.82);
+  }
+
+  .repair-cross {
+    stroke: rgba(95, 186, 255, 0.92);
+    stroke-width: 1.2;
+    stroke-linecap: round;
+  }
+
+  .damage-mark {
+    fill: none;
+    stroke: rgba(255, 92, 92, 0.9);
+    stroke-width: 1.2;
+    stroke-linecap: round;
+  }
+
+  .reactor-glow {
+    filter: blur(12px);
+  }
+
+  .engine-ring {
+    fill: none;
+    stroke: rgba(124, 168, 255, 0.24);
+    stroke-width: 1.2;
+  }
+
+  .engine-plume {
+    fill: none;
+    stroke-width: 2.4;
+    stroke-linecap: round;
+  }
+
+  .mount-ring {
+    fill: rgba(0, 0, 0, 0.4);
+    stroke-width: 1.4;
+  }
+
+  .mount-core {
+    stroke: rgba(255, 255, 255, 0.12);
+  }
+
+  .mount-label {
+    text-anchor: middle;
+    fill: rgba(204, 214, 232, 0.74);
+  }
+
+  .bank-dot {
+    stroke: rgba(255, 255, 255, 0.1);
+  }
+
+  .repair-callout path {
+    fill: none;
+    stroke: rgba(95, 186, 255, 0.42);
+    stroke-width: 1.1;
+    stroke-dasharray: 3 3;
+  }
+
+  .repair-callout rect {
+    fill: rgba(9, 18, 29, 0.9);
+    stroke: rgba(95, 186, 255, 0.34);
+  }
+
+  .repair-callout text {
+    font-size: 7.2px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    fill: rgba(220, 232, 255, 0.82);
+  }
+
+  @media (max-width: 920px) {
+    .summary-row {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+</style>

--- a/gui-svelte/src/components/engineering/PowerFlowDisplay.svelte
+++ b/gui-svelte/src/components/engineering/PowerFlowDisplay.svelte
@@ -1,0 +1,338 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { wsClient } from "../../lib/ws/wsClient.js";
+  import {
+    asRecord,
+    clamp,
+    formatKw,
+    getEngineeringShip,
+    getEngineeringState,
+    getThermalState,
+    toNumber,
+  } from "./engineeringData.js";
+
+  type DrawBus = Record<string, unknown>;
+
+  const POLL_MS = 2500;
+  const BUS_ORDER = ["primary", "secondary", "tertiary", "unassigned"];
+
+  let profile: Record<string, unknown> | null = null;
+  let intervalHandle: number | null = null;
+  let observer: IntersectionObserver | null = null;
+  let isVisible = true;
+  let root: HTMLDivElement;
+
+  function normalizeDrawProfile(raw: unknown) {
+    const record = asRecord(raw);
+    const payload = asRecord(record?.data) ?? record;
+    if (!payload) return null;
+
+    if (asRecord(payload.buses)) return payload;
+
+    const hasLegacy = BUS_ORDER.some((bus) => asRecord(payload[bus]));
+    if (!hasLegacy) return null;
+
+    const buses: Record<string, DrawBus> = {};
+    let availableTotal = 0;
+    let requestedTotal = 0;
+
+    for (const bus of BUS_ORDER) {
+      const entry = asRecord(payload[bus]);
+      if (!entry) continue;
+      const available = toNumber(entry.available_kw, toNumber(entry.supply));
+      const requested = toNumber(entry.requested_kw, toNumber(entry.requested));
+      buses[bus] = {
+        available_kw: available,
+        requested_kw: requested,
+        delta_kw: toNumber(entry.delta_kw, available - requested),
+        status: entry.status ?? "balanced",
+        systems: Array.isArray(entry.systems) ? entry.systems : [],
+        top_consumers: Array.isArray(entry.top_consumers) ? entry.top_consumers : [],
+      };
+      availableTotal += available;
+      requestedTotal += requested;
+    }
+
+    return {
+      active_profile: payload.active_profile ?? null,
+      buses,
+      totals: {
+        available_kw: availableTotal,
+        requested_kw: requestedTotal,
+        delta_kw: availableTotal - requestedTotal,
+      },
+    };
+  }
+
+  function busColor(available: number, requested: number) {
+    if (available <= 0 && requested <= 0) return "#445063";
+    if (available <= 0) return "#ff5b5b";
+    const ratio = requested / available;
+    if (ratio > 1) return "#ff5b5b";
+    if (ratio >= 0.8) return "#ffb020";
+    return "#35c56f";
+  }
+
+  function lineWidth(value: number, maxValue: number) {
+    if (maxValue <= 0) return 2;
+    return clamp(1.5 + (value / maxValue) * 6, 1.5, 7.5);
+  }
+
+  function shortName(name: unknown) {
+    return String(name ?? "")
+      .replace(/[_.-]/g, " ")
+      .replace(/\bpower\b/ig, "")
+      .trim()
+      .toUpperCase()
+      .slice(0, 9);
+  }
+
+  function consumerList(bus: DrawBus) {
+    const systems = Array.isArray(bus.systems) ? bus.systems : [];
+    const topConsumers = Array.isArray(bus.top_consumers) ? bus.top_consumers : [];
+    return (systems.length ? systems : topConsumers).slice(0, 4).map((item) => asRecord(item) ?? {});
+  }
+
+  async function refresh() {
+    if (!isVisible || document.hidden) return;
+    try {
+      const response = await wsClient.sendShipCommand("get_draw_profile", {});
+      profile = normalizeDrawProfile(response) as Record<string, unknown> | null;
+    } catch {
+      // best effort
+    }
+  }
+
+  onMount(() => {
+    if (typeof IntersectionObserver !== "undefined") {
+      observer = new IntersectionObserver((entries) => {
+        isVisible = entries.some((entry) => entry.isIntersecting);
+        if (isVisible) void refresh();
+      });
+      if (root) observer.observe(root);
+    }
+
+    void refresh();
+    intervalHandle = window.setInterval(() => void refresh(), POLL_MS);
+
+    return () => {
+      observer?.disconnect();
+      if (intervalHandle != null) window.clearInterval(intervalHandle);
+    };
+  });
+
+  $: ship = getEngineeringShip($gameState);
+  $: engineering = getEngineeringState(ship);
+  $: thermal = getThermalState(ship);
+  $: busesRecord = (asRecord(profile?.buses) as Record<string, DrawBus> | null) ?? {};
+  $: busEntries = BUS_ORDER
+    .filter((bus) => busesRecord[bus])
+    .map((bus) => [bus, busesRecord[bus]] as [string, DrawBus]);
+  $: totals = asRecord(profile?.totals) ?? {};
+  $: maxBusRequest = Math.max(1, ...busEntries.map(([, bus]) => toNumber(bus.requested_kw, 0)));
+  $: reactorTelemetry = toNumber(
+    engineering.reactor_output,
+    engineering.reactor_percent == null ? Number.NaN : toNumber(engineering.reactor_percent) / 100
+  );
+  $: reactorPct = clamp(
+    Number.isFinite(reactorTelemetry)
+      ? reactorTelemetry
+      : toNumber(totals.available_kw, 0) > 0
+        ? toNumber(totals.requested_kw, 0) / Math.max(1, toNumber(totals.available_kw, 1))
+        : 0,
+    0,
+    1
+  );
+  $: reactorRing = 2 * Math.PI * 20;
+  $: reactorColor = busColor(toNumber(totals.available_kw, 0), toNumber(totals.requested_kw, 0));
+  $: heatPercent = clamp(toNumber(thermal.temperature_percent, 0) / 100, 0, 1);
+  $: heatColor = Boolean(thermal.is_emergency)
+    ? "#ff5b5b"
+    : Boolean(thermal.is_overheating)
+      ? "#ffb020"
+      : heatPercent > 0.45
+        ? "#59b6ff"
+        : "#35c56f";
+  $: busXs = busEntries.map((_, index) => {
+    if (busEntries.length === 1) return 160;
+    const spacing = 176 / Math.max(1, busEntries.length - 1);
+    return 72 + index * spacing;
+  });
+</script>
+
+<Panel title="Power Flow" domain="power" priority="primary" className="power-flow-panel">
+  <div bind:this={root} class="shell">
+    {#if busEntries.length === 0}
+      <div class="empty">Waiting for power telemetry…</div>
+    {:else}
+      <svg viewBox="0 0 320 210" aria-label="Power flow display">
+        <rect class="frame" x="8" y="8" width="304" height="194" rx="8" />
+        <text class="title" x="18" y="22">Power Flow</text>
+
+        <circle cx="160" cy="42" r="21" class="reactor-core" />
+        <circle
+          cx="160"
+          cy="42"
+          r="20"
+          fill="none"
+          stroke={reactorColor}
+          stroke-width="4"
+          stroke-dasharray={`${(reactorPct * reactorRing).toFixed(1)} ${reactorRing.toFixed(1)}`}
+          transform="rotate(-90 160 42)"
+        />
+        <text class="reactor-text" x="160" y="39">REACTOR</text>
+        <text class="reactor-text" x="160" y="49">{Math.round(reactorPct * 100)}%</text>
+        <text class="footer" x="160" y="62">{formatKw(toNumber(totals.available_kw, 0))} avail</text>
+
+        {#each busEntries as [busName, bus], index}
+          {@const x = busXs[index] ?? 160}
+          {@const available = toNumber(bus.available_kw, 0)}
+          {@const requested = toNumber(bus.requested_kw, 0)}
+          {@const color = busColor(available, requested)}
+          {@const width = lineWidth(requested, maxBusRequest)}
+          <line
+            x1="160"
+            y1="63"
+            x2={x}
+            y2="88"
+            stroke={color}
+            stroke-width={width}
+            opacity="0.8"
+          />
+          <rect
+            x={x - 28}
+            y="88"
+            width="56"
+            height="28"
+            rx="5"
+            class="bus-card"
+            stroke={color}
+          />
+          <text class="bus-name" x={x} y="101">{busName.toUpperCase()}</text>
+          <text class="bus-meta" x={x} y="112">
+            {formatKw(requested).replace(" kW", "")} / {formatKw(available).replace(" kW", "")}
+          </text>
+
+          {#each consumerList(bus) as consumer, cIndex}
+            {@const cy = 142 + cIndex * 15}
+            {@const draw = toNumber(consumer.draw_kw, 0)}
+            {@const drawWidth = lineWidth(draw, requested || maxBusRequest)}
+            {@const radius = clamp(4 + (draw / Math.max(1, requested || maxBusRequest)) * 10, 4, 10)}
+            <line
+              x1={x}
+              y1="116"
+              x2={x}
+              y2={cy - 6}
+              stroke={color}
+              stroke-width={drawWidth}
+              opacity="0.55"
+            />
+            <circle
+              cx={x}
+              cy={cy}
+              r={radius}
+              class="consumer-node"
+              stroke={color}
+            />
+            <text class="consumer-meta" x={x} y={cy + 2}>{shortName(consumer.name)}</text>
+            <text class="consumer-meta" x={x} y={cy + 10}>{formatKw(draw).replace(" kW", "")}</text>
+          {/each}
+        {/each}
+
+        <g transform="translate(128 184)">
+          <rect x="0" y="-6" width="64" height="12" rx="3" fill="none" stroke={heatColor} stroke-width="1.1" />
+          <line x1="6" y1="-10" x2="6" y2="10" stroke={heatColor} stroke-width="1" />
+          <line x1="16" y1="-10" x2="16" y2="10" stroke={heatColor} stroke-width="1" />
+          <line x1="26" y1="-10" x2="26" y2="10" stroke={heatColor} stroke-width="1" />
+          <line x1="38" y1="-10" x2="38" y2="10" stroke={heatColor} stroke-width="1" />
+          <line x1="48" y1="-10" x2="48" y2="10" stroke={heatColor} stroke-width="1" />
+          <line x1="58" y1="-10" x2="58" y2="10" stroke={heatColor} stroke-width="1" />
+        </g>
+
+        <text class="footer" x="160" y="197">
+          THERMAL {Math.round(toNumber(thermal.temperature_percent, 0))}% • {Math.round(toNumber(thermal.hull_temperature, 0))} K
+        </text>
+
+        {#if profile?.active_profile}
+          <text class="footer" x="286" y="22">PROFILE {String(profile.active_profile).toUpperCase()}</text>
+        {/if}
+      </svg>
+    {/if}
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    padding: var(--space-sm);
+  }
+
+  svg {
+    width: 100%;
+    height: auto;
+    display: block;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background:
+      radial-gradient(circle at 50% 20%, rgba(89, 182, 255, 0.12), transparent 30%),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0)),
+      #091018;
+  }
+
+  .empty {
+    padding: 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: rgba(255, 255, 255, 0.02);
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .frame {
+    fill: rgba(9, 12, 18, 0.6);
+    stroke: #263042;
+    stroke-width: 1;
+  }
+
+  .reactor-core,
+  .bus-card,
+  .consumer-node {
+    fill: #111722;
+    stroke: #30405a;
+    stroke-width: 1.2;
+  }
+
+  .title,
+  .bus-name,
+  .bus-meta,
+  .consumer-meta,
+  .reactor-text,
+  .footer {
+    font-family: var(--font-mono);
+  }
+
+  .title {
+    font-size: 7px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    fill: #708097;
+  }
+
+  .bus-name,
+  .reactor-text {
+    font-size: 7px;
+    fill: #d5deea;
+    text-anchor: middle;
+  }
+
+  .bus-meta,
+  .consumer-meta,
+  .footer {
+    font-size: 6px;
+    fill: #8896a9;
+    text-anchor: middle;
+  }
+</style>

--- a/gui-svelte/src/components/games/MunitionProgrammingPanel.svelte
+++ b/gui-svelte/src/components/games/MunitionProgrammingPanel.svelte
@@ -8,6 +8,8 @@
     WARHEAD_OPTIONS,
   } from "../tactical/tacticalActions.js";
 
+  export let embedded = false;
+
   let guidanceMode = "guided";
   let warheadType = "fragmentation";
   let flightProfile = "direct";
@@ -16,6 +18,7 @@
   let terminalRange = "4000";
   let boostDuration = "6";
   let datalink = true;
+
   $: profileOptions = getMunitionProfileOptions($selectedLauncherType);
   $: if (!profileOptions.includes(flightProfile)) {
     flightProfile = profileOptions[0] ?? "direct";
@@ -36,8 +39,12 @@
   }
 </script>
 
-<Panel title="Munition Programming" domain="weapons" priority="secondary" className="munition-programming-panel">
-  <div class="shell">
+{#if embedded}
+  <div class="shell embedded-shell">
+    <div class="program-note">
+      <span>Programming {$selectedLauncherType.toUpperCase()}</span>
+      <strong>Next matching launch consumes this profile.</strong>
+    </div>
     <div class="grid">
       <label>
         <span>Guidance</span>
@@ -63,28 +70,88 @@
           {/each}
         </select>
       </label>
-      <label><span>PN gain</span><input bind:value={pnGain} /></label>
-      <label><span>Fuse distance</span><input bind:value={fuseDistance} /></label>
-      <label><span>Terminal range</span><input bind:value={terminalRange} /></label>
-      <label><span>Boost duration</span><input bind:value={boostDuration} /></label>
+      <label><span>PN Gain</span><input type="number" step="0.1" bind:value={pnGain} /></label>
+      <label><span>Fuse Distance</span><input type="number" step="1" bind:value={fuseDistance} /></label>
+      <label><span>Terminal Range</span><input type="number" step="100" bind:value={terminalRange} /></label>
+      <label><span>Boost Duration</span><input type="number" step="0.5" bind:value={boostDuration} /></label>
     </div>
     <label class="toggle"><input type="checkbox" bind:checked={datalink} /> Datalink</label>
     <button on:click={program}>PROGRAM MUNITION</button>
   </div>
-</Panel>
+{:else}
+  <Panel title="Munition Programming" domain="weapons" priority="secondary" className="munition-programming-panel">
+    <div class="shell">
+      <div class="program-note">
+        <span>Programming {$selectedLauncherType.toUpperCase()}</span>
+        <strong>Next matching launch consumes this profile.</strong>
+      </div>
+      <div class="grid">
+        <label>
+          <span>Guidance</span>
+          <select bind:value={guidanceMode}>
+            {#each GUIDANCE_OPTIONS as option}
+              <option value={option}>{option}</option>
+            {/each}
+          </select>
+        </label>
+        <label>
+          <span>Warhead</span>
+          <select bind:value={warheadType}>
+            {#each WARHEAD_OPTIONS as option}
+              <option value={option}>{option}</option>
+            {/each}
+          </select>
+        </label>
+        <label>
+          <span>Profile</span>
+          <select bind:value={flightProfile}>
+            {#each profileOptions as option}
+              <option value={option}>{option}</option>
+            {/each}
+          </select>
+        </label>
+        <label><span>PN Gain</span><input type="number" step="0.1" bind:value={pnGain} /></label>
+        <label><span>Fuse Distance</span><input type="number" step="1" bind:value={fuseDistance} /></label>
+        <label><span>Terminal Range</span><input type="number" step="100" bind:value={terminalRange} /></label>
+        <label><span>Boost Duration</span><input type="number" step="0.5" bind:value={boostDuration} /></label>
+      </div>
+      <label class="toggle"><input type="checkbox" bind:checked={datalink} /> Datalink</label>
+      <button on:click={program}>PROGRAM MUNITION</button>
+    </div>
+  </Panel>
+{/if}
 
 <style>
   .shell,
   .grid,
-  label {
+  label,
+  .program-note {
     display: grid;
     gap: var(--space-sm);
+  }
+
+  .shell {
     padding: var(--space-sm);
+  }
+
+  .embedded-shell {
+    padding: 0;
+  }
+
+  .program-note {
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(var(--tier-accent-rgb), 0.28);
+    background: rgba(var(--tier-accent-rgb), 0.06);
+  }
+
+  .program-note strong {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
   }
 
   .grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    padding: 0;
   }
 
   span {
@@ -98,6 +165,11 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 0;
+  }
+
+  @media (max-width: 720px) {
+    .grid {
+      grid-template-columns: 1fr;
+    }
   }
 </style>

--- a/gui-svelte/src/components/helm/AttitudeIndicator.svelte
+++ b/gui-svelte/src/components/helm/AttitudeIndicator.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  /**
+   * AttitudeIndicator — SVG artificial horizon (roll + pitch) with heading readout.
+   *
+   * Mirrors prototype design_reference_v2 (lines 569-609):
+   *   - Dark sky/ground halves, rotated by `roll`, shifted by `pitch`.
+   *   - Pitch ladder labels at ±10°, ±20°.
+   *   - Fixed yellow reticle (waterline + dot) in front of the rotating horizon.
+   *   - Roll pointer (yellow tick) rotated with roll.
+   *   - Heading readout (3-digit padded) below the dial.
+   *
+   * Props:
+   *   heading: yaw in degrees (0..360)
+   *   pitch:   degrees above horizon (+ up, − down)
+   *   roll:    degrees (+ starboard-down, − port-down)
+   *   size:    px (default 120)
+   */
+  export let heading: number = 0;
+  export let pitch: number = 0;
+  export let roll: number = 0;
+  export let size: number = 120;
+
+  $: c = size / 2;
+  $: pitchPx = (pitch * size) / 90;
+  $: groundY = c - pitchPx;
+  $: hdgLabel = String(Math.round(((heading % 360) + 360) % 360)).padStart(3, "0");
+  $: clipId = `aci-${size}-${Math.floor(Math.random() * 100000)}`;
+
+  // Pitch ladder entries
+  const LADDER = [-20, -10, 10, 20];
+</script>
+
+<svg class="attitude-indicator" width={size} height={size} viewBox="0 0 {size} {size}" role="img" aria-label="Attitude indicator">
+  <defs>
+    <clipPath id={clipId}>
+      <circle cx={c} cy={c} r={c - 4} />
+    </clipPath>
+  </defs>
+
+  <g clip-path="url(#{clipId})">
+    <!-- Sky background -->
+    <rect x="0" y="0" width={size} height={size} fill="#0a1528" />
+
+    <!-- Rolling horizon group -->
+    <g transform="rotate({roll} {c} {c})">
+      <!-- Ground -->
+      <rect x={-size} y={groundY} width={size * 3} height={size * 2} fill="#1a0e00" />
+      <!-- Horizon line -->
+      <rect x={-size} y={groundY - 1} width={size * 3} height="2" fill="#555" />
+      <!-- Pitch ladder -->
+      {#each LADDER as p}
+        <g transform="translate(0, {(-p * size) / 90 + pitchPx})">
+          <line x1={c - 15} y1="0" x2={c + 15} y2="0" stroke="#ffffff44" stroke-width="1" />
+          <text x={c + 18} y="4" font-size="7" fill="#ffffff66" font-family="var(--font-mono)">{Math.abs(p)}</text>
+        </g>
+      {/each}
+    </g>
+
+    <!-- Fixed reticle (yellow waterline) -->
+    <line x1={c - 30} y1={c} x2={c - 10} y2={c} stroke="#ffcc00" stroke-width="2" />
+    <line x1={c + 10} y1={c} x2={c + 30} y2={c} stroke="#ffcc00" stroke-width="2" />
+    <line x1={c} y1={c - 4} x2={c} y2={c + 4} stroke="#ffcc00" stroke-width="1.5" />
+
+    <!-- Roll pointer -->
+    <g transform="rotate({roll} {c} {c})">
+      <line x1={c} y1="6" x2={c} y2="14" stroke="#ffcc00" stroke-width="1.5" />
+    </g>
+  </g>
+
+  <!-- Outer ring -->
+  <circle cx={c} cy={c} r={c - 4} fill="none" stroke="var(--bd-active)" stroke-width="1.5" />
+
+  <!-- Heading readout -->
+  <text x={c} y={size - 3} text-anchor="middle" font-size="7" fill="var(--tx-dim)" font-family="var(--font-mono)">
+    {hdgLabel}°
+  </text>
+</svg>
+
+<style>
+  .attitude-indicator {
+    flex-shrink: 0;
+    display: block;
+  }
+</style>

--- a/gui-svelte/src/components/helm/FlightDataPanel.svelte
+++ b/gui-svelte/src/components/helm/FlightDataPanel.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import Panel from "../layout/Panel.svelte";
+  import AttitudeIndicator from "./AttitudeIndicator.svelte";
   import { gameState } from "../../lib/stores/gameState.js";
   import { tier } from "../../lib/stores/tier.js";
   import {
+    asRecord,
     computeRelativeSpeed,
     extractShipState,
     formatDistance,
@@ -13,6 +15,7 @@
     getOrientation,
     getPONR,
     getPosition,
+    getSystem,
     getVelocity,
     magnitude,
     signed,
@@ -34,6 +37,8 @@
   $: manualLike = $tier === "manual" || $tier === "raw";
   $: showRawVectors = manualLike;
   $: stopMargin = toNumber(ponr.dv_margin);
+  $: propulsion = getSystem(ship, "propulsion");
+  $: fuelPct = toNumber(asRecord(propulsion)?.fuel_pct, toNumber(asRecord(ship)?.fuel_pct, 0));
 </script>
 
 <Panel title="Flight Data" domain="helm" priority={$tier === "manual" ? "primary" : "secondary"} className="flight-data-panel">
@@ -43,6 +48,34 @@
     {:else if toNumber(ponr.margin_percent, 100) < 25 && toNumber(ponr.dv_to_stop) > 0}
       <div class="alert warning">Brake margin {toPercent(toNumber(ponr.margin_percent), 0)} · reserve {formatSpeed(stopMargin)}</div>
     {/if}
+
+    <section class="section">
+      <div class="hero-dial">
+        <AttitudeIndicator heading={heading.yaw} pitch={heading.pitch} roll={heading.roll} size={116} />
+      </div>
+      <div class="hero-grid">
+        <div class="hero-metric">
+          <span>Speed</span>
+          <strong>{speed.toFixed(1)}</strong>
+          <em>m/s</em>
+        </div>
+        <div class="hero-metric">
+          <span>Heading</span>
+          <strong>{String(Math.round(heading.yaw < 0 ? heading.yaw + 360 : heading.yaw)).padStart(3, "0")}</strong>
+          <em>deg</em>
+        </div>
+        <div class="hero-metric">
+          <span>Delta-V</span>
+          <strong>{deltaV.toFixed(0)}</strong>
+          <em>m/s</em>
+        </div>
+        <div class="hero-metric">
+          <span>Fuel</span>
+          <strong>{fuelPct.toFixed(1)}</strong>
+          <em>%</em>
+        </div>
+      </div>
+    </section>
 
     <section class="section">
       <div class="section-title">Position</div>
@@ -169,6 +202,39 @@
   .hero {
     font-size: 1.25rem;
     color: var(--tier-accent);
+  }
+
+  .hero-dial {
+    display: flex;
+    justify-content: center;
+    padding-bottom: 2px;
+  }
+
+  .hero-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px 12px;
+  }
+
+  .hero-metric {
+    display: grid;
+    gap: 2px;
+  }
+
+  .hero-metric span,
+  .hero-metric em {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    font-style: normal;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .hero-metric strong {
+    font-family: var(--font-mono);
+    color: var(--text-bright);
+    font-size: 0.95rem;
+    line-height: 1.1;
   }
 
   .accent {

--- a/gui-svelte/src/components/helm/HelmNavigationPanel.svelte
+++ b/gui-svelte/src/components/helm/HelmNavigationPanel.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import {
+    extractShipState,
+    formatDistance,
+    formatDuration,
+    formatSpeed,
+    getAutopilotSnapshot,
+    getPosition,
+    getVelocity,
+  } from "./helmData.js";
+
+  $: ship = extractShipState($gameState);
+  $: position = getPosition(ship);
+  $: velocity = getVelocity(ship);
+  $: autopilot = getAutopilotSnapshot(ship);
+  $: progressWidth = `${Math.max(0, Math.min(100, autopilot.progress)).toFixed(0)}%`;
+</script>
+
+<Panel title="Navigation" domain="nav" priority="secondary" className="helm-navigation-panel">
+  <div class="shell">
+    <div class="grid">
+      <div><span>Pos X</span><strong>{formatDistance(position.x)}</strong></div>
+      <div><span>Pos Z</span><strong>{formatDistance(position.z)}</strong></div>
+      <div><span>Vel X</span><strong>{formatSpeed(velocity.x)}</strong></div>
+      <div><span>Vel Z</span><strong>{formatSpeed(velocity.z)}</strong></div>
+    </div>
+
+    <div class="intercept">
+      <span>Time To {autopilot.targetId ? `Intercept ${autopilot.targetId}` : "Destination"}</span>
+      <strong>{autopilot.eta != null && autopilot.eta > 0 ? formatDuration(autopilot.eta) : "--"}</strong>
+    </div>
+
+    <div class="progress-track">
+      <div class="progress-fill" style={`width:${progressWidth};`}></div>
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    gap: var(--space-sm);
+    padding: var(--space-sm);
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px 12px;
+  }
+
+  .grid div,
+  .intercept {
+    display: grid;
+    gap: 2px;
+  }
+
+  span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  strong {
+    font-family: var(--font-mono);
+    color: var(--text-primary);
+  }
+
+  .intercept strong {
+    font-size: 1.05rem;
+    color: var(--text-bright);
+  }
+
+  .progress-track {
+    height: 6px;
+    border-radius: 999px;
+    overflow: hidden;
+    background: var(--bg-input);
+    border: 1px solid var(--border-subtle);
+  }
+
+  .progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, rgba(30, 140, 255, 0.3), var(--status-info));
+  }
+</style>

--- a/gui-svelte/src/components/helm/HelmSupportDrawer.svelte
+++ b/gui-svelte/src/components/helm/HelmSupportDrawer.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import { tier } from "../../lib/stores/tier.js";
+
+  import HelmNavigationPanel from "./HelmNavigationPanel.svelte";
+  import ManualFlightPanel from "./ManualFlightPanel.svelte";
+  import ShipOrientationDisplay from "./ShipOrientationDisplay.svelte";
+  import RcsControls from "./RcsControls.svelte";
+  import RcsThrusterDisplay from "./RcsThrusterDisplay.svelte";
+  import HelmQueuePanel from "./HelmQueuePanel.svelte";
+  import DockingPanel from "./DockingPanel.svelte";
+  import ManeuverPlanner from "./ManeuverPlanner.svelte";
+  import AutopilotStatus from "./AutopilotStatus.svelte";
+  import HelmBalanceGame from "../games/HelmBalanceGame.svelte";
+
+  type DrawerTab = "nav" | "manual" | "systems" | "arcade" | null;
+
+  let activeTab: DrawerTab = null;
+
+  $: arcadeTier = $tier === "arcade";
+
+  function toggle(tab: Exclude<DrawerTab, null>) {
+    activeTab = activeTab === tab ? null : tab;
+  }
+</script>
+
+<div class="support-drawer">
+  <div class="toolbar">
+    <button class:active={activeTab === "nav"} type="button" on:click={() => toggle("nav")}>Nav Tools</button>
+    <button class:active={activeTab === "manual"} type="button" on:click={() => toggle("manual")}>Manual</button>
+    <button class:active={activeTab === "systems"} type="button" on:click={() => toggle("systems")}>Systems</button>
+    {#if arcadeTier}
+      <button class:active={activeTab === "arcade"} type="button" on:click={() => toggle("arcade")}>Arcade</button>
+    {/if}
+  </div>
+
+  {#if activeTab !== null}
+    <div class="drawer-body">
+      {#if activeTab === "nav"}
+        <HelmNavigationPanel />
+        <DockingPanel />
+      {:else if activeTab === "manual"}
+        <ManualFlightPanel />
+        <RcsControls />
+        <ManeuverPlanner />
+      {:else if activeTab === "systems"}
+        <AutopilotStatus />
+        <HelmQueuePanel />
+        <ShipOrientationDisplay />
+        <RcsThrusterDisplay />
+      {:else if activeTab === "arcade"}
+        <HelmBalanceGame />
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .support-drawer {
+    display: grid;
+    gap: var(--space-xs);
+  }
+
+  .toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding-top: var(--space-xs);
+    border-top: 1px solid var(--bd-subtle);
+  }
+
+  .toolbar button.active {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+    color: var(--text-primary);
+  }
+
+  .drawer-body {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: var(--space-xs);
+    overflow: auto;
+    max-height: 360px;
+    padding-bottom: var(--space-xs);
+  }
+</style>

--- a/gui-svelte/src/components/helm/ShipOrientationDisplay.svelte
+++ b/gui-svelte/src/components/helm/ShipOrientationDisplay.svelte
@@ -1,0 +1,315 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import {
+    asRecord,
+    clamp,
+    extractShipState,
+    getOrientation,
+    getSystem,
+    getThrottle,
+    getThrusters,
+    getVelocity,
+    magnitude,
+    normalizeAngle,
+    toNumber,
+  } from "./helmData.js";
+
+  interface ArrowGeometry {
+    x2: number;
+    y2: number;
+  }
+
+  const THRUSTER_POS: Record<string, { x: number; y: number }> = {
+    pitch_up: { x: 211, y: 54 },
+    pitch_down: { x: 211, y: 110 },
+    yaw_left: { x: 222, y: 66 },
+    yaw_right: { x: 222, y: 98 },
+    pitch_up_aft: { x: 57, y: 54 },
+    pitch_down_aft: { x: 57, y: 110 },
+    yaw_left_aft: { x: 46, y: 66 },
+    yaw_right_aft: { x: 46, y: 98 },
+    roll_cw: { x: 146, y: 124 },
+    roll_ccw: { x: 122, y: 40 },
+    roll_cw_2: { x: 122, y: 124 },
+    roll_ccw_2: { x: 146, y: 40 },
+  };
+
+  const SHIP_CENTER = { x: 134, y: 82 };
+  const SIDE_CENTER = { x: 269, y: 68 };
+
+  function shortestAngle(targetDeg: number, currentDeg: number) {
+    return ((targetDeg - currentDeg + 540) % 360) - 180;
+  }
+
+  function thrusterColor(throttle: number) {
+    if (throttle < 0.02) return "#1a1d28";
+    if (throttle < 0.25) return "#1d6f4f";
+    if (throttle < 0.6) return "#35b46e";
+    if (throttle < 0.85) return "#ffb020";
+    return "#ff5a36";
+  }
+
+  function yawFromVelocity(velocity: { x: number; y: number; z: number }) {
+    if (Math.abs(velocity.x) < 0.001 && Math.abs(velocity.y) < 0.001) return null;
+    return Math.atan2(velocity.y, velocity.x) * 180 / Math.PI;
+  }
+
+  function formatSignedAngle(angle: number, positiveLabel: string, negativeLabel: string) {
+    if (Math.abs(angle) < 0.5) return "0°";
+    return `${Math.abs(angle).toFixed(0)}° ${angle >= 0 ? positiveLabel : negativeLabel}`;
+  }
+
+  function arrowFromAngle(angleDeg: number, length: number): ArrowGeometry {
+    const angleRad = angleDeg * Math.PI / 180;
+    return {
+      x2: SHIP_CENTER.x + length * Math.cos(angleRad),
+      y2: SHIP_CENTER.y - length * Math.sin(angleRad),
+    };
+  }
+
+  $: ship = extractShipState($gameState);
+  $: helm = asRecord(ship.helm) ?? getSystem(ship, "helm");
+  $: rcs = asRecord(ship.rcs) ?? getSystem(ship, "rcs");
+  $: trajectory = asRecord(ship.trajectory) ?? {};
+  $: heading = getOrientation(ship);
+  $: velocity = getVelocity(ship);
+  $: speed = magnitude(velocity);
+  $: velocityHeading = asRecord(trajectory.velocity_heading);
+  $: velocityYaw = velocityHeading ? toNumber(velocityHeading.yaw, yawFromVelocity(velocity) ?? 0) : yawFromVelocity(velocity);
+  $: driftYaw = velocityYaw == null ? 0 : shortestAngle(velocityYaw, heading.yaw);
+  $: target = asRecord(helm.attitude_target) ?? asRecord(rcs.attitude_target);
+  $: yawError = target ? shortestAngle(toNumber(target.yaw, heading.yaw), heading.yaw) : 0;
+  $: pitchError = target ? shortestAngle(toNumber(target.pitch, heading.pitch), heading.pitch) : 0;
+  $: angularVelocity = asRecord(ship.angular_velocity) ?? {};
+  $: omegaMag = Math.sqrt(
+    toNumber(angularVelocity.pitch, 0) ** 2 +
+    toNumber(angularVelocity.yaw, 0) ** 2 +
+    toNumber(angularVelocity.roll, 0) ** 2
+  );
+  $: thrust = clamp(getThrottle(ship), 0, 1);
+  $: drivePlume = {
+    opacity: thrust * 0.88,
+    rx: 8 + thrust * 18,
+    ry: 5 + thrust * 13,
+  };
+  $: velocityArrow = speed > 1 && velocityYaw != null
+    ? arrowFromAngle(driftYaw, Math.min(48, 20 + speed * 0.015))
+    : null;
+  $: targetArrow = target && Math.abs(yawError) > 0.5
+    ? arrowFromAngle(yawError, 38)
+    : null;
+  $: targetPitch = clamp(target ? toNumber(target.pitch, heading.pitch) : heading.pitch, -60, 60);
+  $: thrusters = getThrusters(ship);
+  $: thrusterDots = Object.entries(THRUSTER_POS).map(([id, pos]) => {
+    const thruster = thrusters.find((entry) => entry.id === id);
+    const throttle = thruster?.throttle ?? 0;
+    return {
+      id,
+      x: pos.x,
+      y: pos.y,
+      fill: thrusterColor(throttle),
+      stroke: throttle > 0.02 ? "#8df4b7" : "#273046",
+      radius: throttle > 0.02 ? 5 : 4,
+      opacity: throttle > 0.02 ? 1 : 0.78,
+    };
+  });
+</script>
+
+<Panel title="Orientation" domain="helm" priority="primary" className="ship-orientation-panel">
+  <div class="shell">
+    <svg viewBox="0 0 320 180" aria-label="Ship orientation display">
+      <defs>
+        <radialGradient id="plume-grad" cx="80%" cy="50%" r="80%" fx="80%" fy="50%">
+          <stop offset="0%" stop-color="#ffb020" stop-opacity="0.95" />
+          <stop offset="55%" stop-color="#ff5a36" stop-opacity="0.45" />
+          <stop offset="100%" stop-color="#250000" stop-opacity="0" />
+        </radialGradient>
+        <marker id="vel-head" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+          <polygon points="0 0, 6 3, 0 6" fill="#44aaff" opacity="0.85" />
+        </marker>
+        <marker id="target-head" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+          <polygon points="0 0, 6 3, 0 6" fill="#ffb020" opacity="0.85" />
+        </marker>
+      </defs>
+
+      <rect class="frame" x="8" y="8" width="304" height="164" rx="8" />
+
+      <text class="label" x="16" y="22">Drift / Attitude</text>
+      <text class="label" x="236" y="22">Pitch</text>
+
+      <ellipse
+        cx="30"
+        cy="82"
+        fill="url(#plume-grad)"
+        opacity={drivePlume.opacity}
+        rx={drivePlume.rx}
+        ry={drivePlume.ry}
+      />
+
+      <polygon class="hull" points="48,82 68,52 214,54 244,82 214,110 68,112" />
+      <line class="centerline" x1="44" y1={SHIP_CENTER.y} x2="246" y2={SHIP_CENTER.y} />
+      <ellipse cx="57" cy="70" rx="5" ry="3" class="engine-ring" />
+      <ellipse cx="57" cy="94" rx="5" ry="3" class="engine-ring" />
+      <polygon points="239,82 229,76 229,88" class="nose" />
+
+      {#if velocityArrow}
+        <line
+          x1={SHIP_CENTER.x}
+          y1={SHIP_CENTER.y}
+          x2={velocityArrow.x2}
+          y2={velocityArrow.y2}
+          class="velocity-arrow"
+          marker-end="url(#vel-head)"
+        />
+      {/if}
+
+      {#if targetArrow}
+        <line
+          x1={SHIP_CENTER.x}
+          y1={SHIP_CENTER.y}
+          x2={targetArrow.x2}
+          y2={targetArrow.y2}
+          class="target-arrow"
+          marker-end="url(#target-head)"
+        />
+      {/if}
+
+      {#each thrusterDots as thruster}
+        <circle
+          cx={thruster.x}
+          cy={thruster.y}
+          r={thruster.radius}
+          fill={thruster.fill}
+          stroke={thruster.stroke}
+          opacity={thruster.opacity}
+          class="thruster-dot"
+        />
+      {/each}
+
+      <line class="side-axis" x1="236" y1={SIDE_CENTER.y} x2="302" y2={SIDE_CENTER.y} />
+      <line class="side-axis" x1={SIDE_CENTER.x} y1="32" x2={SIDE_CENTER.x} y2="106" />
+
+      <g transform={`rotate(${-targetPitch} ${SIDE_CENTER.x} ${SIDE_CENTER.y})`} opacity={target ? 1 : 0.2}>
+        <polygon
+          points="250,68 264,61 287,61 294,68 287,75 264,75"
+          class="pitch-target"
+        />
+      </g>
+      <g transform={`rotate(${-clamp(heading.pitch, -60, 60)} ${SIDE_CENTER.x} ${SIDE_CENTER.y})`}>
+        <polygon
+          points="250,68 264,60 288,60 297,68 288,76 264,76"
+          class="pitch-ship"
+        />
+      </g>
+
+      <text class="readout" x="16" y="142">SPD {speed.toFixed(0)} m/s</text>
+      <text class="readout accent" x="16" y="154">DRIFT {formatSignedAngle(driftYaw, "PORT", "STBD")}</text>
+      <text class="readout warn" x="16" y="166">YAW ERR {target ? formatSignedAngle(yawError, "PORT", "STBD") : "—"}</text>
+      <text class="readout" x="236" y="118">PITCH {heading.pitch.toFixed(0)}°</text>
+      <text class="readout warn" x="236" y="130">PITCH ERR {target ? formatSignedAngle(pitchError, "UP", "DN") : "—"}</text>
+      <text class="readout dim" x="236" y="142">OMEGA {omegaMag.toFixed(1)}°/s</text>
+    </svg>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    padding: var(--space-sm);
+  }
+
+  svg {
+    width: 100%;
+    height: auto;
+    display: block;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background:
+      radial-gradient(circle at 24% 30%, rgba(68, 170, 255, 0.12), transparent 28%),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0)),
+      #091018;
+  }
+
+  .frame {
+    fill: rgba(9, 12, 18, 0.55);
+    stroke: #263042;
+    stroke-width: 1;
+  }
+
+  .hull {
+    fill: #171b26;
+    stroke: #3a455a;
+    stroke-width: 1.5;
+  }
+
+  .centerline,
+  .side-axis {
+    stroke: #334057;
+    stroke-width: 0.7;
+    stroke-dasharray: 4 3;
+  }
+
+  .engine-ring {
+    fill: none;
+    stroke: #31415a;
+    stroke-width: 1;
+  }
+
+  .nose {
+    fill: #52617b;
+  }
+
+  .label {
+    font-size: 7px;
+    letter-spacing: 0.12em;
+    fill: #6f7f98;
+    text-transform: uppercase;
+  }
+
+  .readout {
+    font-size: 8px;
+    fill: #b7c5d8;
+  }
+
+  .dim {
+    fill: #7a889b;
+  }
+
+  .accent {
+    fill: #44aaff;
+  }
+
+  .warn {
+    fill: #ffb020;
+  }
+
+  .velocity-arrow {
+    stroke: #44aaff;
+    stroke-width: 1.8;
+    opacity: 0.9;
+  }
+
+  .target-arrow {
+    stroke: #ffb020;
+    stroke-width: 1.4;
+    stroke-dasharray: 5 3;
+    opacity: 0.9;
+  }
+
+  .pitch-target {
+    fill: none;
+    stroke: #ffb020;
+    stroke-width: 1;
+    stroke-dasharray: 4 2;
+  }
+
+  .pitch-ship {
+    fill: #171b26;
+    stroke: #4d5a71;
+    stroke-width: 1.2;
+  }
+
+  .thruster-dot {
+    transition: fill var(--transition-fast), stroke var(--transition-fast), r var(--transition-fast);
+  }
+</style>

--- a/gui-svelte/src/components/layout/BridgeHeader.svelte
+++ b/gui-svelte/src/components/layout/BridgeHeader.svelte
@@ -1,0 +1,239 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import ConnectionStatus from "./ConnectionStatus.svelte";
+  import StationSelector from "./StationSelector.svelte";
+  import TierSelector from "./TierSelector.svelte";
+
+  const dispatch = createEventDispatcher<{
+    "view-change": { view: string };
+    "station-claimed": { station: string };
+    "station-released": { station: string };
+  }>();
+
+  export let activeView = "mission";
+  export let allowedViews: string[] | null = null;
+
+  const VIEWS: Array<{
+    id: string;
+    label: string;
+    key: string;
+    domain: "nav" | "helm" | "weapons" | "power" | "sensor" | "comms" | "ops" | "fleet";
+  }> = [
+    { id: "mission", label: "MISSION", key: "0", domain: "nav" },
+    { id: "helm", label: "HELM", key: "1", domain: "helm" },
+    { id: "tactical", label: "TACTICAL", key: "2", domain: "weapons" },
+    { id: "engineering", label: "ENGINEERING", key: "3", domain: "power" },
+    { id: "ops", label: "OPS", key: "4", domain: "ops" },
+    { id: "science", label: "SCIENCE", key: "5", domain: "sensor" },
+    { id: "comms", label: "COMMS", key: "6", domain: "comms" },
+    { id: "fleet", label: "FLEET", key: "7", domain: "fleet" },
+  ];
+
+  const DOMAIN_VAR: Record<string, string> = {
+    nav: "var(--domain-nav)",
+    helm: "var(--domain-helm)",
+    weapons: "var(--domain-weapons)",
+    power: "var(--domain-power)",
+    sensor: "var(--domain-sensor)",
+    comms: "var(--domain-comms)",
+    ops: "var(--domain-ops)",
+    fleet: "var(--domain-fleet)",
+  };
+
+  function isAllowed(viewId: string): boolean {
+    if (!allowedViews) return true;
+    return allowedViews.includes(viewId);
+  }
+
+  function selectView(viewId: string) {
+    if (!isAllowed(viewId)) return;
+    activeView = viewId;
+    dispatch("view-change", { view: viewId });
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.altKey) return;
+
+    const target = e.target as HTMLElement | null;
+    if (!target) return;
+    const tag = target.tagName;
+    if (
+      tag === "INPUT"
+      || tag === "TEXTAREA"
+      || tag === "SELECT"
+      || target.isContentEditable
+      || target.closest("[contenteditable='true'], [role='textbox']")
+    ) {
+      return;
+    }
+
+    if (e.key === "0") {
+      e.preventDefault();
+      selectView("mission");
+      return;
+    }
+
+    const idx = parseInt(e.key, 10);
+    if (idx >= 1 && idx <= 7) {
+      const view = VIEWS.find((entry) => entry.key === e.key);
+      if (view && isAllowed(view.id)) {
+        e.preventDefault();
+        selectView(view.id);
+      }
+    }
+  }
+</script>
+
+<svelte:window on:keydown={onKeydown} />
+
+<div class="bridge-header">
+  <div class="bridge-header__left">
+    <ConnectionStatus />
+  </div>
+
+  <div class="bridge-header__nav" role="tablist" aria-label="Bridge stations and mission views">
+    {#each VIEWS as view}
+      {@const allowed = isAllowed(view.id)}
+      <button
+        class="nav-tab"
+        class:active={activeView === view.id}
+        class:disabled={!allowed}
+        style="--tab-accent: {DOMAIN_VAR[view.domain]}"
+        role="tab"
+        aria-selected={activeView === view.id}
+        aria-disabled={!allowed}
+        tabindex={!allowed ? -1 : 0}
+        title="{view.label} [{view.key}]{!allowed ? ' — unavailable at this station' : ''}"
+        on:click={() => selectView(view.id)}
+      >
+        <span class="nav-tab__key">{view.key}</span>
+        <span class="nav-tab__label">{view.label}</span>
+      </button>
+    {/each}
+  </div>
+
+  <div class="bridge-header__right">
+    <StationSelector
+      on:station-claimed={(event) => dispatch("station-claimed", event.detail)}
+      on:station-released={(event) => dispatch("station-released", event.detail)}
+    />
+    <TierSelector />
+  </div>
+</div>
+
+<style>
+  .bridge-header {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 8px;
+    min-height: 36px;
+    padding: 0 6px;
+    background: var(--bg-raised);
+    border-bottom: 1px solid var(--bd-default);
+    position: relative;
+    z-index: 100;
+  }
+
+  .bridge-header__left,
+  .bridge-header__right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .bridge-header__nav {
+    display: flex;
+    align-items: stretch;
+    gap: 2px;
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .bridge-header__nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .nav-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: 30px;
+    padding: 0 10px;
+    border: none;
+    border-bottom: 2px solid transparent;
+    border-radius: 0;
+    background: transparent;
+    color: var(--tx-dim);
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    transition: color var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast);
+  }
+
+  .nav-tab:hover:not(.disabled):not(.active) {
+    color: var(--tx-primary);
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .nav-tab.active {
+    color: var(--tx-bright);
+    border-bottom-color: var(--tier-accent);
+    background:
+      linear-gradient(180deg, color-mix(in srgb, var(--tab-accent) 16%, transparent), transparent 80%),
+      rgba(255, 255, 255, 0.02);
+  }
+
+  .nav-tab.disabled {
+    opacity: 0.32;
+    cursor: not-allowed;
+  }
+
+  .nav-tab__key {
+    min-width: 15px;
+    padding: 0 3px;
+    border: 1px solid var(--bd-subtle);
+    border-radius: 2px;
+    background: var(--bg-input);
+    color: var(--tx-dim);
+    font-size: 0.58rem;
+    text-align: center;
+  }
+
+  .nav-tab.active .nav-tab__key {
+    color: var(--tab-accent);
+    border-color: color-mix(in srgb, var(--tab-accent) 55%, var(--bd-active));
+  }
+
+  .nav-tab__label {
+    line-height: 1;
+  }
+
+  @media (max-width: 980px) {
+    .bridge-header {
+      grid-template-columns: minmax(0, 1fr);
+      gap: 6px;
+      padding: 6px;
+    }
+
+    .bridge-header__left,
+    .bridge-header__right {
+      justify-content: space-between;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .nav-tab__label {
+      display: none;
+    }
+
+    .nav-tab {
+      padding: 0 8px;
+    }
+  }
+</style>

--- a/gui-svelte/src/components/layout/Panel.svelte
+++ b/gui-svelte/src/components/layout/Panel.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-
   export let title = "";
   export let priority: "primary" | "secondary" | "tertiary" = "secondary";
   export let domain: "nav" | "sensor" | "weapons" | "power" | "comms" | "helm" | "" = "";
@@ -70,6 +68,40 @@
     overflow: hidden;
     min-width: 0;
     position: relative;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.36);
+  }
+
+  .panel::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--panel-accent);
+    opacity: 0.45;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .panel-priority-primary {
+    background: var(--bg-raised);
+    border-color: var(--border-active);
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.52);
+  }
+
+  .panel-priority-tertiary {
+    background: color-mix(in srgb, var(--bg-panel) 82%, var(--bg-void));
+  }
+
+  .panel.disabled::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+      linear-gradient(180deg, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.24)),
+      rgba(10, 10, 15, 0.28);
+    pointer-events: none;
   }
 
   .panel.disabled {
@@ -80,11 +112,17 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 5px 10px;
-    background: var(--bg-glass);
+    min-height: 28px;
+    padding: 6px 10px 5px;
+    background:
+      linear-gradient(135deg, rgba(255, 255, 255, 0.03) 0%, rgba(255, 255, 255, 0.008) 100%),
+      var(--bg-glass);
     border-bottom: 1px solid var(--border-subtle);
     flex-shrink: 0;
     user-select: none;
+    gap: 8px;
+    position: relative;
+    z-index: 2;
   }
 
   .panel-header[role="button"] {
@@ -92,42 +130,53 @@
   }
 
   .panel-header[role="button"]:hover {
-    background: var(--bg-hover);
+    background:
+      linear-gradient(135deg, rgba(255, 255, 255, 0.05) 0%, rgba(255, 255, 255, 0.012) 100%),
+      var(--bg-hover);
   }
 
   .panel-title {
     font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
-    font-weight: 600;
+    font-size: 0.6rem;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: var(--text-secondary);
+    letter-spacing: 0.1em;
+    color: color-mix(in srgb, var(--panel-accent) 78%, var(--text-secondary));
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .panel-priority-primary .panel-title {
-    color: var(--text-primary);
+    color: color-mix(in srgb, var(--panel-accent) 55%, var(--text-bright));
   }
 
   .panel-toggle {
-    font-size: 0.65rem;
+    font-size: 0.62rem;
     color: var(--text-dim);
     transition: transform var(--transition-fast);
+  }
+
+  .panel.collapsed .panel-toggle {
+    transform: rotate(-90deg);
   }
 
   .panel-body {
     flex: 1;
     overflow: auto;
     position: relative;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.008), transparent 18%);
   }
 
   .disabled-overlay {
     position: absolute;
     inset: 0;
-    background: rgba(10, 10, 15, 0.6);
+    background: rgba(10, 10, 15, 0.64);
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: not-allowed;
+    z-index: 3;
   }
 
   .disabled-reason {

--- a/gui-svelte/src/components/layout/StationSelector.svelte
+++ b/gui-svelte/src/components/layout/StationSelector.svelte
@@ -9,14 +9,14 @@
   }>();
 
   const STATIONS = [
-    { id: "captain",         label: "CAPTAIN",         color: "#ffcc00" },
-    { id: "helm",            label: "HELM",            color: "#00aaff" },
-    { id: "tactical",        label: "TACTICAL",        color: "#ff4444" },
-    { id: "ops",             label: "OPS",             color: "#00ff88" },
-    { id: "engineering",     label: "ENGINEERING",     color: "#ff8800" },
-    { id: "comms",           label: "COMMS",           color: "#aa88ff" },
-    { id: "science",         label: "SCIENCE",         color: "#44ddff" },
-    { id: "fleet_commander", label: "FLEET CMDR",      color: "#ff66cc" },
+    { id: "captain",         label: "CAPTAIN",         icon: "✦", desc: "Full command authority", color: "#ffcc00" },
+    { id: "helm",            label: "HELM",            icon: "⛵", desc: "Flight and navigation", color: "#00aaff" },
+    { id: "tactical",        label: "TACTICAL",        icon: "⊕", desc: "Weapons and fire control", color: "#ff4444" },
+    { id: "ops",             label: "OPS",             icon: "⚙", desc: "Crew and ship operations", color: "#00ff88" },
+    { id: "engineering",     label: "ENGINEERING",     icon: "⚛", desc: "Reactor and thermal control", color: "#ff8800" },
+    { id: "comms",           label: "COMMS",           icon: "◈", desc: "Hailing and traffic", color: "#aa88ff" },
+    { id: "science",         label: "SCIENCE",         icon: "◎", desc: "Sensor analysis", color: "#44ddff" },
+    { id: "fleet_commander", label: "FLEET CMDR",      icon: "◇", desc: "Fleet coordination", color: "#ff66cc" },
   ];
 
   let registered = false;
@@ -87,6 +87,7 @@
       if (resp && resp.ok !== false) {
         claimedStation = stationId;
         setStatus(`Station: ${stationId.toUpperCase()}`, "success");
+        expanded = false;
         dispatch("station-claimed", { station: stationId });
       } else {
         setStatus(`Claim failed: ${resp?.error ?? "rejected"}`, "error");
@@ -178,6 +179,10 @@
   function stationColor(id: string): string {
     return STATIONS.find((s) => s.id === id)?.color ?? "#888899";
   }
+
+  function stationMeta(id: string) {
+    return STATIONS.find((s) => s.id === id);
+  }
 </script>
 
 <div class="station-selector">
@@ -200,9 +205,30 @@
 
   {#if expanded}
     <div class="station-panel">
+      <div class="panel-summary">
+        <div class="summary-chip" class:ok={registered}>
+          <span class="chip-label">Link</span>
+          <span class="chip-value">{registered ? "READY" : "OFFLINE"}</span>
+        </div>
+        <div class="summary-chip" class:ok={!!assignedShipId}>
+          <span class="chip-label">Ship</span>
+          <span class="chip-value">{assignedShipId ?? "UNASSIGNED"}</span>
+        </div>
+        <div class="summary-chip" class:ok={!!claimedStation}>
+          <span class="chip-label">Role</span>
+          <span class="chip-value">{claimedStation ? (stationMeta(claimedStation)?.label ?? claimedStation.toUpperCase()) : "OPEN"}</span>
+        </div>
+      </div>
       <div class="status-row status-{statusVariant}">{statusText}</div>
 
       {#if claimedStation}
+        <div class="claimed-card" style="--claimed-color: {stationColor(claimedStation)};">
+          <div class="claimed-icon">{stationMeta(claimedStation)?.icon ?? "•"}</div>
+          <div class="claimed-copy">
+            <div class="claimed-label">{stationMeta(claimedStation)?.label ?? claimedStation}</div>
+            <div class="claimed-desc">{stationMeta(claimedStation)?.desc ?? "Active bridge assignment"}</div>
+          </div>
+        </div>
         <button class="release-btn" disabled={isProcessing} on:click={releaseStation}>
           Release Station
         </button>
@@ -214,10 +240,14 @@
               class:full-width={i === STATIONS.length - 1 && STATIONS.length % 2 !== 0}
               disabled={!canClaim || claimedStation === s.id}
               class:active={claimedStation === s.id}
-              style={claimedStation === s.id ? `border-color: ${s.color}; color: ${s.color}; background: rgba(${hexToRgb(s.color)}, 0.12)` : ""}
+              style="--station-color: {s.color}; --station-rgb: {hexToRgb(s.color)}"
               on:click={() => claimStation(s.id)}
             >
-              {s.label}
+              <span class="station-btn-icon" aria-hidden="true">{s.icon}</span>
+              <span class="station-btn-copy">
+                <span class="station-btn-label">{s.label}</span>
+                <span class="station-btn-desc">{s.desc}</span>
+              </span>
             </button>
           {/each}
         </div>
@@ -260,12 +290,58 @@
     top: calc(100% + 6px);
     left: 0;
     z-index: 200;
-    background: var(--bg-panel);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent 18%),
+      var(--bg-panel);
     border: 1px solid var(--border-default);
     border-radius: var(--radius-sm);
     padding: var(--space-sm);
-    min-width: 220px;
-    box-shadow: 0 4px 16px rgba(0,0,0,0.5);
+    min-width: 320px;
+    box-shadow: 0 10px 34px rgba(0,0,0,0.58);
+  }
+
+  .panel-summary {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 6px;
+    margin-bottom: var(--space-sm);
+  }
+
+  .summary-chip {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 7px 8px;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    background: var(--bg-input);
+    min-width: 0;
+  }
+
+  .summary-chip.ok {
+    border-color: rgba(var(--tier-accent-rgb, 30, 140, 255), 0.3);
+    background: rgba(var(--tier-accent-rgb, 30, 140, 255), 0.08);
+  }
+
+  .chip-label,
+  .chip-value {
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+  }
+
+  .chip-label {
+    font-size: 0.52rem;
+    letter-spacing: 0.1em;
+    color: var(--text-dim);
+  }
+
+  .chip-value {
+    font-size: 0.58rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .status-row {
@@ -281,26 +357,119 @@
   .station-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 5px;
+    gap: 6px;
+  }
+
+  .claimed-card {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: var(--space-sm);
+    padding: 10px;
+    border: 1px solid rgba(var(--tier-accent-rgb, 30, 140, 255), 0.24);
+    border-left: 3px solid var(--claimed-color, var(--tier-accent));
+    border-radius: var(--radius-sm);
+    background: rgba(var(--tier-accent-rgb, 30, 140, 255), 0.08);
+  }
+
+  .claimed-icon {
+    width: 28px;
+    height: 28px;
+    display: grid;
+    place-items: center;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--claimed-color, var(--tier-accent));
+    font-size: 0.95rem;
+    flex-shrink: 0;
+  }
+
+  .claimed-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .claimed-label,
+  .claimed-desc {
+    font-family: var(--font-mono);
+  }
+
+  .claimed-label {
+    font-size: 0.68rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    letter-spacing: 0.06em;
+  }
+
+  .claimed-desc {
+    font-size: 0.55rem;
+    color: var(--text-secondary);
   }
 
   .station-btn {
-    padding: 8px 6px;
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    text-align: center;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 10px 9px;
+    text-align: left;
     border-radius: var(--radius-sm);
     cursor: pointer;
     min-height: unset;
     transition: all var(--transition-fast);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent 70%),
+      var(--bg-input);
+    border: 1px solid rgba(var(--station-rgb, 136, 136, 153), 0.22);
   }
 
   .station-btn:disabled { opacity: 0.35; cursor: not-allowed; }
-  .station-btn:hover:not(:disabled) { background: var(--bg-hover); }
+  .station-btn:hover:not(:disabled) {
+    background:
+      linear-gradient(180deg, rgba(var(--station-rgb, 136, 136, 153), 0.12), transparent 70%),
+      var(--bg-hover);
+    border-color: rgba(var(--station-rgb, 136, 136, 153), 0.58);
+    transform: translateY(-1px);
+  }
   .station-btn.full-width { grid-column: 1 / -1; }
+
+  .station-btn-icon {
+    width: 22px;
+    display: grid;
+    place-items: center;
+    color: var(--station-color, var(--tier-accent));
+    font-size: 0.95rem;
+    line-height: 1;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  .station-btn-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+  }
+
+  .station-btn-label,
+  .station-btn-desc {
+    font-family: var(--font-mono);
+  }
+
+  .station-btn-label {
+    font-size: 0.61rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: var(--text-primary);
+    text-transform: uppercase;
+  }
+
+  .station-btn-desc {
+    font-size: 0.54rem;
+    color: var(--text-secondary);
+    line-height: 1.35;
+  }
 
   .release-btn {
     width: 100%;
@@ -333,7 +502,7 @@
       left: 0;
       right: 0;
       min-width: 0;
-      max-width: min(100vw - 12px, 360px);
+      max-width: min(100vw - 12px, 420px);
       max-height: min(60vh, 420px);
       overflow-y: auto;
     }

--- a/gui-svelte/src/components/layout/StatusBar.svelte
+++ b/gui-svelte/src/components/layout/StatusBar.svelte
@@ -3,42 +3,93 @@
   import { shipState } from "../../lib/stores/gameState.js";
   import { tier } from "../../lib/stores/tier.js";
   import { proposals, type Proposal } from "../../lib/stores/proposals.js";
-  import ConnectionStatus from "./ConnectionStatus.svelte";
+  import { extractShipState, getOrientation, getVelocity, magnitude, toNumber, toStringValue, asRecord, getSystem } from "../helm/helmData.js";
 
+  // Mission clock (local time for now; server mission time can replace this)
+  let missionTime = "00:00:00";
+  setInterval(() => {
+    const d = new Date();
+    missionTime = `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}`;
+  }, 500);
+
+  // Hull integrity (supports both nested systems.hull and top-level)
   const hull = derived(shipState, ($s) => {
     if (!$s) return null;
     const h = $s?.systems?.hull?.integrity ?? $s?.hull_integrity ?? $s?.hull ?? null;
-    if (typeof h === "number") return Math.round(h * 100);
+    if (typeof h === "number") return h > 1 ? Math.round(h) : Math.round(h * 100);
     return null;
   });
 
+  // Fuel percentage
   const fuel = derived(shipState, ($s) => {
     if (!$s) return null;
     const f = $s?.systems?.propulsion?.fuel_pct ?? $s?.fuel_pct ?? null;
-    if (typeof f === "number") return Math.round(f * 100);
+    if (typeof f === "number") return f > 1 ? Math.round(f) : Math.round(f * 100);
     return null;
   });
 
-  const driveStatus = derived(shipState, ($s) => {
-    if (!$s) return "—";
-    return $s?.systems?.propulsion?.status ?? $s?.drive_status ?? "nominal";
+  // Reactor output percent
+  const reactor = derived(shipState, ($s) => {
+    if (!$s) return null;
+    const r = $s?.systems?.reactor?.output_pct ?? $s?.systems?.power?.reactor_output ?? null;
+    if (typeof r === "number") return Math.round(r > 1 ? r : r * 100);
+    return null;
   });
 
-  function hullColor(pct: number | null): string {
-    if (pct === null) return "var(--text-dim)";
-    if (pct > 70) return "var(--status-nominal)";
-    if (pct > 35) return "var(--status-warning)";
-    return "var(--status-critical)";
+  // Speed (m/s)
+  // shipState is already extracted; passing through extractShipState is a no-op guard
+  // that also normalizes undefined → {} so downstream helpers don't crash.
+  const speed = derived(shipState, ($s) => {
+    const vel = getVelocity(extractShipState($s as Record<string, unknown>));
+    return magnitude(vel);
+  });
+
+  // Heading (yaw, deg)
+  const heading = derived(shipState, ($s) => {
+    const ship = extractShipState($s as Record<string, unknown>);
+    return getOrientation(ship).yaw;
+  });
+
+  // Heat state (K current / K max)
+  const heat = derived(shipState, ($s) => {
+    if (!$s) return { current: 0, max: 500 };
+    const thermal = asRecord($s)?.thermal ?? getSystem($s as never, "thermal");
+    const current = toNumber(asRecord(thermal)?.heat, toNumber(asRecord($s)?.heat, 0));
+    const max = toNumber(asRecord(thermal)?.heat_max, toNumber(asRecord($s)?.heat_max, 500));
+    return { current, max };
+  });
+
+  // Any impaired subsystems → alert indicator
+  const subsystemAlert = derived(shipState, ($s) => {
+    const sys = asRecord($s)?.systems ?? {};
+    for (const [name, value] of Object.entries(sys as Record<string, unknown>)) {
+      const status = asRecord(value)?.status;
+      if (typeof status === "string" && /impair|damag|critical/i.test(status)) return name;
+    }
+    return null;
+  });
+
+  // Ship identity
+  const shipInfo = derived(shipState, ($s) => {
+    const ship = asRecord($s) ?? {};
+    return {
+      name: toStringValue(ship.name, toStringValue(ship.id, "MCRN Rocinante")),
+      cls: toStringValue(ship.class_name, toStringValue(ship.ship_class, "Corvette")),
+    };
+  });
+
+  function normPct(x: number | null): number {
+    if (x === null) return 0;
+    return Math.max(0, Math.min(100, x));
   }
 
-  const TIER_LABELS: Record<string, string> = {
-    manual:       "MANUAL",
-    raw:          "RAW",
-    arcade:       "ARCADE",
-    "cpu-assist": "CPU-ASSIST",
-  };
+  function heatColor(pct: number): string {
+    if (pct > 80) return "var(--crit)";
+    if (pct > 60) return "var(--warn)";
+    return "#1e8cff";
+  }
 
-  // Per-station proposal counts (cpu-assist only)
+  // Proposal counts (preserved from prior design)
   const STATION_LABELS: Array<[keyof typeof $proposals, string]> = [
     ["tactical", "TAC"],
     ["engineering", "ENG"],
@@ -54,28 +105,80 @@
   $: anyUrgent = (Object.values($proposals) as Proposal[][])
     .flat()
     .some((p) => p.urgent);
+
+  $: heatPct = $heat.max > 0 ? ($heat.current / $heat.max) * 100 : 0;
+  $: hc = heatColor(heatPct);
 </script>
 
 <header class="status-bar">
-  <span class="stat-item">
-    HULL:
-    <span style="color: {hullColor($hull)}">
-      {$hull !== null ? `${$hull}%` : "—"}
+  <!-- Ship identity -->
+  <div class="cell identity">
+    <span class="dot nominal" aria-hidden="true"></span>
+    <div class="ident-text">
+      <div class="ship-name">{$shipInfo.name.toUpperCase()}</div>
+      <div class="ship-cls">{$shipInfo.cls.toUpperCase()}</div>
+    </div>
+  </div>
+
+  <!-- SPD -->
+  <div class="cell vital">
+    <span class="lbl">SPD</span>
+    <span class="val">
+      {$speed.toFixed(1)}<span class="unit">m/s</span>
     </span>
-  </span>
+  </div>
 
-  <span class="stat-item">
-    FUEL: <span class="stat-val">{$fuel !== null ? `${$fuel}%` : "—"}</span>
-  </span>
+  <!-- HDG -->
+  <div class="cell vital">
+    <span class="lbl">HDG</span>
+    <span class="val">{String(Math.round($heading < 0 ? $heading + 360 : $heading)).padStart(3, "0")}°</span>
+  </div>
 
-  <span class="stat-item">
-    DRIVE: <span class="stat-val">{$driveStatus}</span>
-  </span>
+  <!-- FUEL -->
+  <div class="cell vital">
+    <span class="lbl">FUEL</span>
+    <span class="val" class:crit={$fuel !== null && $fuel < 20}>
+      {$fuel !== null ? $fuel : "--"}<span class="unit">%</span>
+    </span>
+  </div>
 
-  <span class="spacer"></span>
+  <!-- HULL -->
+  <div class="cell vital">
+    <span class="lbl">HULL</span>
+    <span class="val" class:crit={$hull !== null && $hull < 60}>
+      {$hull !== null ? $hull : "--"}<span class="unit">%</span>
+    </span>
+  </div>
 
+  <!-- REACTOR -->
+  <div class="cell vital">
+    <span class="lbl">RCT</span>
+    <span class="val">
+      {$reactor !== null ? $reactor : "--"}<span class="unit">%</span>
+    </span>
+  </div>
+
+  <!-- Thermal bar -->
+  <div class="cell thermal">
+    <div class="thermal-head">
+      <span class="lbl">THERMAL</span>
+      <span class="thermal-k" style="color: {hc}">{Math.round($heat.current)}K</span>
+    </div>
+    <div class="bar-track">
+      <div class="bar-fill" style="width: {normPct(heatPct)}%; background: {hc}; box-shadow: {heatPct > 65 ? `0 0 6px ${hc}55` : 'none'};"></div>
+    </div>
+  </div>
+
+  {#if $subsystemAlert}
+    <div class="cell alert">
+      <span class="dot impaired" aria-hidden="true"></span>
+      <span class="alert-text">SUBSYS IMPAIRED</span>
+    </div>
+  {/if}
+
+  <!-- CPU proposals (cpu-assist tier) -->
   {#if $tier === "cpu-assist"}
-    <span class="proposal-counts" class:urgent={anyUrgent}>
+    <div class="cell proposals" class:urgent={anyUrgent}>
       {#if proposalCounts.length === 0}
         <span class="count-idle">AI IDLE</span>
       {:else}
@@ -83,100 +186,209 @@
           <span class="count-badge">{entry.label}:{entry.count}</span>
         {/each}
       {/if}
-    </span>
+    </div>
   {/if}
 
-  <span class="tier-badge tier-badge-{$tier}">{TIER_LABELS[$tier] ?? $tier}</span>
+  <span class="spacer"></span>
 
-  <ConnectionStatus />
+  <!-- Mission clock -->
+  <div class="cell mission">
+    <span class="lbl">MISSION</span>
+    <span class="clock">{missionTime}</span>
+  </div>
 </header>
 
 <style>
   .status-bar {
     display: flex;
     align-items: center;
-    gap: var(--space-sm);
-    padding: 0 var(--space-sm);
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
+    gap: 0;
+    padding: 0 2px;
+    height: 36px;
     flex-shrink: 0;
-    height: 32px;
+    background: var(--bg-raised);
+    border-bottom: 2px solid var(--tier-accent, #1e8cff);
   }
 
-  .stat-item {
-    color: var(--text-dim);
-    white-space: nowrap;
+  .cell {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+    border-right: 1px solid var(--bd-subtle);
+    font-family: var(--font-mono);
   }
 
-  .stat-val { color: var(--text-secondary); }
+  .cell.identity {
+    padding: 0 12px;
+    border-right: 1px solid var(--bd-default);
+    gap: 7px;
+  }
+
+  .cell.mission {
+    padding: 0 12px;
+    border-right: none;
+    border-left: 1px solid var(--bd-default);
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: center;
+  }
+
+  .cell.vital {
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    min-width: 52px;
+  }
+
+  .cell.thermal {
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: center;
+    gap: 3px;
+    min-width: 110px;
+  }
+
+  .cell.alert {
+    gap: 5px;
+  }
+
+  .cell.proposals {
+    gap: 6px;
+  }
 
   .spacer { flex: 1; }
 
-  .proposal-counts {
+  .ident-text {
     display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 0.65rem;
+    flex-direction: column;
+  }
+
+  .ship-name {
+    font-size: 0.7rem;
     font-weight: 700;
-    letter-spacing: 0.5px;
+    color: var(--tx-bright);
+    letter-spacing: 0.06em;
+  }
+
+  .ship-cls {
+    font-size: 0.52rem;
+    color: var(--tx-dim);
+    letter-spacing: 0.06em;
+  }
+
+  .lbl {
+    font-size: 0.48rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--tx-dim);
+  }
+
+  .val {
+    font-size: 0.76rem;
+    font-weight: 600;
+    color: var(--tx-bright);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .val.crit {
+    color: var(--crit);
+    animation: critFlicker 1.8s step-end infinite;
+  }
+
+  .unit {
+    font-size: 0.5rem;
+    color: var(--tx-dim);
+    margin-left: 1px;
+  }
+
+  .thermal-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
+  .thermal-k {
+    font-size: 0.55rem;
+  }
+
+  .bar-track {
+    height: 4px;
+    background: var(--bg-input);
+    border-radius: 1px;
+    overflow: hidden;
+    width: 100%;
+  }
+
+  .bar-fill {
+    height: 100%;
+    transition: width .4s ease, background .4s ease;
+  }
+
+  .dot {
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .dot.nominal {
+    background: var(--nom);
+    box-shadow: 0 0 9px rgba(0, 221, 106, 0.7);
+  }
+
+  .dot.impaired {
+    background: var(--warn);
+    box-shadow: 0 0 9px rgba(239, 160, 32, 0.7);
+    animation: pulse 2s ease-in-out infinite;
+  }
+
+  .alert-text {
+    font-size: 0.58rem;
+    color: var(--warn);
+    font-weight: 700;
+    letter-spacing: 0.06em;
+  }
+
+  .clock {
+    font-size: 0.7rem;
+    color: var(--tx-bright);
   }
 
   .count-badge {
+    font-size: 0.58rem;
+    font-weight: 700;
     padding: 2px 6px;
     border-radius: 3px;
-    border: 1px solid rgba(192, 160, 255, 0.45);
-    color: #c0a0ff;
-    background: rgba(192, 160, 255, 0.1);
+    border: 1px solid rgba(170, 136, 255, 0.45);
+    color: #aa88ff;
+    background: rgba(170, 136, 255, 0.1);
   }
 
   .count-idle {
+    font-size: 0.58rem;
+    font-weight: 700;
     padding: 2px 6px;
     border-radius: 3px;
-    border: 1px solid var(--border-default);
-    color: var(--text-dim);
+    border: 1px solid var(--bd-default);
+    color: var(--tx-dim);
   }
 
-  .proposal-counts.urgent .count-badge {
-    border-color: rgba(255, 170, 0, 0.6);
-    color: #ffaa00;
-    background: rgba(255, 170, 0, 0.1);
-    animation: urgentFlash 0.8s ease-in-out infinite;
+  .cell.proposals.urgent .count-badge {
+    border-color: rgba(239, 160, 32, 0.6);
+    color: var(--warn);
+    background: rgba(239, 160, 32, 0.1);
+    animation: pulse 0.8s ease-in-out infinite;
   }
 
-  .tier-badge {
-    font-size: 0.65rem;
-    font-weight: 700;
-    letter-spacing: 1px;
-    padding: 2px 8px;
-    border-radius: 3px;
-    border: 1px solid var(--tier-accent, var(--border-default));
-    color: var(--tier-accent, var(--text-dim));
+  @media (max-width: 900px) {
+    .cell.mission { display: none; }
+    .cell.identity .ship-cls { display: none; }
   }
 
-  @keyframes urgentFlash {
-    0%, 100% { opacity: 1; }
-    50%       { opacity: 0.5; }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .proposal-counts.urgent .count-badge {
-      animation: none;
-    }
-  }
-
-  @media (max-width: 768px) {
-    .status-bar {
-      min-width: 0;
-    }
-
-    .proposal-counts {
-      gap: 4px;
-    }
-
-    .tier-badge,
-    .count-badge,
-    .count-idle {
-      white-space: nowrap;
-    }
+  @media (max-width: 600px) {
+    .cell.vital { min-width: 38px; padding: 0 6px; }
+    .cell.thermal { display: none; }
   }
 </style>

--- a/gui-svelte/src/components/layout/ViewTabs.svelte
+++ b/gui-svelte/src/components/layout/ViewTabs.svelte
@@ -3,7 +3,7 @@
 
   const dispatch = createEventDispatcher<{ "view-change": { view: string } }>();
 
-  export let activeView = "config";
+  export let activeView = "mission";
   export let allowedViews: string[] | null = null; // null = all allowed
 
   const VIEWS: { id: string; label: string; key: string }[] = [
@@ -14,7 +14,7 @@
     { id: "science",     label: "SCIENCE",     key: "5" },
     { id: "comms",       label: "COMMS",       key: "6" },
     { id: "fleet",       label: "FLEET",       key: "7" },
-    { id: "config",      label: "CONFIG",      key: "8" },
+    { id: "mission",     label: "MISSION",     key: "0" },
     { id: "editor",      label: "EDITOR",      key: "9" },
   ];
 
@@ -46,9 +46,15 @@
     }
 
     const idx = parseInt(e.key, 10);
+    if (e.key === "0") {
+      e.preventDefault();
+      selectView("mission");
+      return;
+    }
+
     if (idx >= 1 && idx <= VIEWS.length) {
-      const view = VIEWS[idx - 1];
-      if (isAllowed(view.id)) {
+      const view = VIEWS.find((entry) => entry.key === e.key);
+      if (view && isAllowed(view.id)) {
         e.preventDefault();
         selectView(view.id);
       }

--- a/gui-svelte/src/components/mission/ScenarioLoader.svelte
+++ b/gui-svelte/src/components/mission/ScenarioLoader.svelte
@@ -84,6 +84,17 @@
     tutorial: "TUTORIAL", combat: "COMBAT", stealth: "STEALTH", fleet: "FLEET", campaign: "CAMPAIGN",
   };
   const CATEGORIES = ["all", "tutorial", "combat", "stealth", "fleet", "campaign"];
+  const STATION_THEME: Record<string, { color: string; icon: string; desc: string }> = {
+    captain: { color: "#ffcc00", icon: "✦", desc: "Command authority" },
+    helm: { color: "#00aaff", icon: "⛵", desc: "Flight and navigation" },
+    tactical: { color: "#ff4444", icon: "⊕", desc: "Weapons and targeting" },
+    ops: { color: "#00ff88", icon: "⚙", desc: "Crew and operations" },
+    engineering: { color: "#ff8800", icon: "⚛", desc: "Reactor and thermal" },
+    science: { color: "#44ddff", icon: "◎", desc: "Sensor analysis" },
+    comms: { color: "#aa88ff", icon: "◈", desc: "Traffic and hailing" },
+    fleet: { color: "#ff66cc", icon: "◇", desc: "Fleet coordination" },
+    fleet_commander: { color: "#ff66cc", icon: "◇", desc: "Fleet coordination" },
+  };
 
   function commandSucceeded(resp: CommandEnvelope | null | undefined): boolean {
     if (!resp) return false;
@@ -106,6 +117,14 @@
 
   function commandError(resp: CommandEnvelope | null | undefined, fallback: string): string {
     return String(resp?.message ?? resp?.error ?? resp?.reason ?? fallback);
+  }
+
+  function stationTheme(stationName: string) {
+    return STATION_THEME[stationName.toLowerCase()] ?? { color: "#888899", icon: "•", desc: "Bridge station" };
+  }
+
+  function stationLabel(stationName: string) {
+    return stationName.replaceAll("_", " ").toUpperCase();
   }
 
   // ── Derived ───────────────────────────────────────────────────────
@@ -505,21 +524,35 @@
           {#each ships as ship (ship.id)}
             <div class="ship-card">
               <div class="ship-card-header">
-                <span class="ship-name">{ship.name ?? ship.id}</span>
-                <span class="ship-class-badge">{ship.class ?? "?"}</span>
-                {#if ship.faction}<span class="ship-faction">{ship.faction.toUpperCase()}</span>{/if}
+                <div class="ship-card-id">
+                  <span class="ship-name">{ship.name ?? ship.id}</span>
+                  <span class="ship-id">{ship.id}</span>
+                </div>
+                <div class="ship-card-tags">
+                  <span class="ship-class-badge">{ship.class ?? "?"}</span>
+                  {#if ship.faction}<span class="ship-faction">{ship.faction.toUpperCase()}</span>{/if}
+                </div>
               </div>
               <div class="station-grid">
                 {#each (ship.stations ?? []) as st}
+                  {@const theme = stationTheme(st.station)}
                   {#if st.claimed}
-                    <div class="station-slot occupied" title={st.player ?? "Taken"}>
-                      <span class="st-name">{st.station}</span>
-                      <span class="st-status">{st.player ?? "TAKEN"}</span>
+                    <div class="station-slot occupied" style="--station-color: {theme.color}" title={st.player ?? "Taken"}>
+                      <span class="st-icon" aria-hidden="true">{theme.icon}</span>
+                      <span class="st-copy">
+                        <span class="st-name">{stationLabel(st.station)}</span>
+                        <span class="st-desc">{theme.desc}</span>
+                        <span class="st-status">{st.player ?? "TAKEN"}</span>
+                      </span>
                     </div>
                   {:else}
-                    <button class="station-slot vacant" on:click={() => joinStation(ship.id, st.station)}>
-                      <span class="st-name">{st.station}</span>
-                      <span class="st-status">JOIN</span>
+                    <button class="station-slot vacant" style="--station-color: {theme.color}" on:click={() => joinStation(ship.id, st.station)}>
+                      <span class="st-icon" aria-hidden="true">{theme.icon}</span>
+                      <span class="st-copy">
+                        <span class="st-name">{stationLabel(st.station)}</span>
+                        <span class="st-desc">{theme.desc}</span>
+                        <span class="st-status">JOIN</span>
+                      </span>
                     </button>
                   {/if}
                 {/each}
@@ -616,7 +649,7 @@
 
   /* ── Screen wrapper ── */
   .screen {
-    max-width: 900px;
+    max-width: 1080px;
     margin: 0 auto;
     padding: var(--space-md);
     min-height: 100%;
@@ -850,33 +883,54 @@
 
   .ship-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
     gap: var(--space-sm);
     margin-bottom: var(--space-md);
   }
 
   .ship-card {
-    background: var(--bg-panel);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent 18%),
+      var(--bg-panel);
     border: 1px solid var(--border-default);
-    border-radius: var(--radius-md);
-    padding: var(--space-sm);
+    border-top: 3px solid rgba(var(--tier-accent-rgb, 68, 136, 255), 0.32);
+    border-radius: var(--radius-sm);
+    padding: 10px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
   }
 
   .ship-card-header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
+    justify-content: space-between;
     gap: var(--space-xs);
-    margin-bottom: var(--space-xs);
+    margin-bottom: 10px;
     padding-bottom: var(--space-xs);
     border-bottom: 1px solid var(--border-subtle);
   }
 
+  .ship-card-id,
+  .ship-card-tags {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+  }
+
   .ship-name {
     font-family: var(--font-mono);
-    font-size: var(--font-size-sm);
-    font-weight: 600;
+    font-size: 0.75rem;
+    font-weight: 700;
     color: var(--text-primary);
-    flex: 1;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .ship-id {
+    font-family: var(--font-mono);
+    font-size: 0.56rem;
+    color: var(--text-dim);
+    letter-spacing: 0.08em;
   }
 
   .ship-class-badge, .ship-faction {
@@ -890,30 +944,35 @@
   }
 
   .station-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
   }
 
   .station-slot {
     display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 6px 4px;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 9px 10px;
     border-radius: var(--radius-sm);
     border: 1px solid var(--border-subtle);
     font-family: var(--font-mono);
     transition: all var(--transition-fast);
+    text-align: left;
   }
 
   .station-slot.vacant {
     cursor: pointer;
-    background: rgba(var(--tier-accent-rgb, 68, 136, 255), 0.08);
-    border-color: var(--tier-accent, var(--hud-primary));
+    background: rgba(255, 255, 255, 0.02);
+    border-color: color-mix(in srgb, var(--station-color) 35%, var(--border-subtle));
   }
 
   .station-slot.vacant:hover {
-    background: rgba(var(--tier-accent-rgb, 68, 136, 255), 0.2);
+    background:
+      linear-gradient(90deg, color-mix(in srgb, var(--station-color) 12%, transparent), transparent 80%),
+      rgba(255, 255, 255, 0.02);
+    border-color: color-mix(in srgb, var(--station-color) 70%, var(--border-default));
+    transform: translateY(-1px);
   }
 
   .station-slot.occupied {
@@ -921,21 +980,49 @@
     opacity: 0.7;
   }
 
+  .st-icon {
+    width: 22px;
+    display: grid;
+    place-items: center;
+    color: var(--station-color, var(--tier-accent));
+    font-size: 0.95rem;
+    line-height: 1;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  .st-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
   .st-name {
-    font-size: 0.55rem;
-    color: var(--text-secondary);
+    font-size: 0.6rem;
+    color: var(--text-primary);
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+  }
+
+  .st-desc {
+    font-size: 0.53rem;
+    color: var(--text-dim);
+    line-height: 1.35;
   }
 
   .st-status {
-    font-size: 0.6rem;
+    font-size: 0.56rem;
     font-weight: 600;
-    color: var(--text-primary);
-    margin-top: 2px;
+    color: var(--station-color, var(--tier-accent));
+    margin-top: 3px;
+    letter-spacing: 0.06em;
   }
 
-  .station-slot.vacant .st-status { color: var(--tier-accent, var(--hud-primary)); }
+  .station-slot.occupied .st-status {
+    color: var(--text-secondary);
+  }
 
   .start-btn { width: 100%; margin-top: var(--space-md); }
 

--- a/gui-svelte/src/components/tactical/ArcadeTacticalPanel.svelte
+++ b/gui-svelte/src/components/tactical/ArcadeTacticalPanel.svelte
@@ -1,0 +1,238 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import TargetingLockGame from "../games/TargetingLockGame.svelte";
+  import WeaponsChargeGame from "../games/WeaponsChargeGame.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
+  import {
+    extractShipState,
+    getBestWeaponSolution,
+    getLockedTargetId,
+    getTargetingSummary,
+    getWeaponMounts,
+    toNumber,
+    type WeaponMountState,
+  } from "./tacticalData.js";
+  import { fireRailgun, launchDirectMunition } from "./tacticalActions.js";
+
+  // Arcade tactical station:
+  //   - No target locked  → TargetingLockGame (reticle mini-game)
+  //   - Target locked     → WeaponsChargeGame (timing mini-game)
+  //
+  // The games themselves are passive skill visuals. The FIRE button below each
+  // is the actual fire trigger. It is armed only when the preconditions for a
+  // real shot are met (locked, ammo, solution confidence >= 0.38 for railguns).
+  // The player's interaction with the game does not gate firing — it just makes
+  // the arcade tier feel tactile. Scoring and gating stay server-authoritative.
+
+  $: ship = extractShipState($gameState);
+  $: targeting = getTargetingSummary(ship);
+  $: lockedTargetId = getLockedTargetId(ship);
+  $: effectiveTarget = $selectedTacticalTargetId || lockedTargetId;
+  $: hasLock = targeting.lockState === "locked" && Boolean(lockedTargetId);
+  $: mounts = getWeaponMounts(ship);
+  $: solution = getBestWeaponSolution(ship);
+  $: solutionConfidence = clamp01(toNumber(solution.confidence, targeting.lockQuality));
+  $: bestWeapon = pickBestWeapon(mounts, solutionConfidence);
+  $: firing = false;
+  $: fireHint = buildFireHint(hasLock, bestWeapon, solutionConfidence);
+
+  function clamp01(n: number): number {
+    if (!Number.isFinite(n)) return 0;
+    return Math.max(0, Math.min(1, n));
+  }
+
+  /**
+   * Pick the best weapon available to fire right now.
+   *   Priority: ready railgun w/ strong solution → missile → torpedo.
+   * Returns null if nothing is fireable.
+   */
+  function pickBestWeapon(
+    all: WeaponMountState[],
+    confidence: number,
+  ): WeaponMountState | null {
+    const railgun = all.find(
+      (m) => m.weaponType === "railgun" && m.enabled && m.ammo > 0 && m.ready && confidence >= 0.38,
+    );
+    if (railgun) return railgun;
+
+    const missile = all.find(
+      (m) => m.weaponType === "missile" && m.enabled && m.ammo > 0,
+    );
+    if (missile) return missile;
+
+    const torpedo = all.find(
+      (m) => m.weaponType === "torpedo" && m.enabled && m.ammo > 0,
+    );
+    if (torpedo) return torpedo;
+
+    return null;
+  }
+
+  function buildFireHint(
+    locked: boolean,
+    weapon: WeaponMountState | null,
+    confidence: number,
+  ): string {
+    if (!locked) return "Lock a target first";
+    if (!weapon) return "No weapons available";
+    if (weapon.weaponType === "railgun") {
+      if (!weapon.ready) return `Railgun charging (${Math.round(weapon.charge * 100)}%)`;
+      if (confidence < 0.38) return `Solution too weak (${Math.round(confidence * 100)}%)`;
+      return `Fire railgun — ${Math.round(confidence * 100)}% solution`;
+    }
+    if (weapon.weaponType === "missile") return "Launch missile";
+    if (weapon.weaponType === "torpedo") return "Launch torpedo";
+    return "Weapon ready";
+  }
+
+  async function doFire() {
+    if (firing) return;
+    if (!hasLock || !bestWeapon) return;
+    firing = true;
+    try {
+      if (bestWeapon.weaponType === "railgun") {
+        await fireRailgun({ mountId: bestWeapon.id, targetId: effectiveTarget || undefined });
+      } else if (bestWeapon.weaponType === "torpedo" || bestWeapon.weaponType === "missile") {
+        await launchDirectMunition(bestWeapon.weaponType, {
+          targetId: effectiveTarget || undefined,
+          profile: "direct",
+        });
+      }
+    } finally {
+      firing = false;
+    }
+  }
+
+  $: fireArmed = hasLock && bestWeapon !== null && !firing;
+</script>
+
+<Panel title="Combat Station" domain="weapons" priority="primary">
+  <div class="arcade-body">
+    {#if !hasLock}
+      <div class="stage-label">Acquire target lock</div>
+      <TargetingLockGame />
+      <div class="status-row">
+        <span class="status-label">Lock state</span>
+        <span class="status-value" class:warn={!hasLock}>{targeting.lockState.toUpperCase()}</span>
+      </div>
+    {:else}
+      <div class="stage-label">Charge and fire</div>
+      <WeaponsChargeGame />
+      <div class="status-row">
+        <span class="status-label">Weapon</span>
+        <span class="status-value">{bestWeapon ? bestWeapon.label : "NONE"}</span>
+      </div>
+      <div class="status-row">
+        <span class="status-label">Solution</span>
+        <span class="status-value" class:warn={solutionConfidence < 0.38}>
+          {Math.round(solutionConfidence * 100)}%
+        </span>
+      </div>
+    {/if}
+
+    <button
+      class="fire-btn"
+      class:armed={fireArmed}
+      disabled={!fireArmed}
+      title={fireHint}
+      on:click={() => void doFire()}
+    >
+      {#if firing}
+        FIRING…
+      {:else if fireArmed}
+        <span class="bullet">●</span> FIRE
+        {#if bestWeapon}
+          <span class="weapon-chip">{bestWeapon.weaponType.toUpperCase()}</span>
+        {/if}
+      {:else}
+        {fireHint}
+      {/if}
+    </button>
+  </div>
+</Panel>
+
+<style>
+  .arcade-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    padding: var(--space-xs);
+  }
+
+  .stage-label {
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--tx-dim);
+  }
+
+  .status-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+  }
+
+  .status-label {
+    color: var(--tx-dim);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .status-value {
+    color: var(--tx-primary);
+    font-weight: 600;
+  }
+
+  .status-value.warn {
+    color: var(--warn);
+  }
+
+  .fire-btn {
+    margin-top: 4px;
+    padding: 10px;
+    background: rgba(30, 30, 48, 0.4);
+    border: 1px solid var(--bd-subtle);
+    border-radius: 2px;
+    color: var(--tx-dim);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    cursor: not-allowed;
+    transition: all 0.15s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+
+  .fire-btn.armed {
+    background: rgba(192, 48, 48, 0.2);
+    border-color: rgba(232, 48, 48, 0.5);
+    color: var(--crit);
+    box-shadow: 0 0 18px rgba(232, 48, 48, 0.24);
+    cursor: pointer;
+  }
+
+  .fire-btn.armed:hover {
+    background: rgba(232, 48, 48, 0.3);
+    box-shadow: 0 0 24px rgba(232, 48, 48, 0.36);
+  }
+
+  .weapon-chip {
+    font-size: 0.58rem;
+    padding: 1px 6px;
+    border: 1px solid currentColor;
+    border-radius: 2px;
+    letter-spacing: 0.1em;
+  }
+
+  .bullet {
+    font-size: 0.7em;
+  }
+</style>

--- a/gui-svelte/src/components/tactical/CombatLog.svelte
+++ b/gui-svelte/src/components/tactical/CombatLog.svelte
@@ -1,12 +1,31 @@
 <script lang="ts">
+  /**
+   * CombatLog — prototype-aligned event log.
+   *
+   * Each entry is a single row with:
+   *   - timestamp (mono, dim)
+   *   - color-coded type badge (HIT/MISS/FIRE/LOCK/ALRT/DET/SYS)
+   *   - message text
+   *   - left border tinted to match type
+   * Newest at top; latest row plays a slideUp animation on arrival.
+   * Server-side: polls `get_combat_log` every 900ms using `since_id` + optional `weapon` filter.
+   */
   import { onMount } from "svelte";
   import Panel from "../layout/Panel.svelte";
   import { wsClient } from "../../lib/ws/wsClient.js";
 
   type Filter = "all" | "railgun" | "torpedo" | "missile" | "pdc";
 
+  type LogType = "hit" | "miss" | "fire" | "lock" | "alert" | "detect" | "system";
+  interface DisplayEntry {
+    key: string;
+    type: LogType;
+    timestamp: string;
+    message: string;
+  }
+
   let filter: Filter = "all";
-  let entries: Array<Record<string, unknown>> = [];
+  let entries: DisplayEntry[] = [];
   let latestId = 0;
   let pollHandle: number | null = null;
 
@@ -22,9 +41,13 @@
     try {
       const params: Record<string, unknown> = { since_id: latestId, limit: 50 };
       if (filter !== "all") params.weapon = filter;
-      const response = await wsClient.send("get_combat_log", params) as { entries?: Array<Record<string, unknown>>; latest_id?: number };
+      const response = await wsClient.send("get_combat_log", params) as {
+        entries?: Array<Record<string, unknown>>;
+        latest_id?: number;
+      };
       if (Array.isArray(response.entries) && response.entries.length > 0) {
-        entries = [...entries, ...response.entries].slice(-200);
+        const mapped = response.entries.map(normalize);
+        entries = [...entries, ...mapped].slice(-200);
       }
       latestId = response.latest_id ?? latestId;
     } catch {
@@ -32,33 +55,132 @@
     }
   }
 
-  function headline(entry: Record<string, unknown>): string {
-    return String(entry.summary ?? entry.outcome ?? entry.event_type ?? entry.weapon ?? "event");
+  function setFilter(next: Filter) {
+    filter = next;
+    entries = [];
+    latestId = 0;
+    void poll();
   }
 
-  function detail(entry: Record<string, unknown>): string {
-    return [entry.cause, entry.effect, entry.outcome].filter(Boolean).join(" -> ") || String(entry.description ?? "");
+  function normalize(entry: Record<string, unknown>): DisplayEntry {
+    const id = String(entry.id ?? entry.event_id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    return {
+      key: id,
+      type: classifyType(entry),
+      timestamp: extractTimestamp(entry),
+      message: buildMessage(entry),
+    };
   }
+
+  function classifyType(entry: Record<string, unknown>): LogType {
+    const explicit = String(entry.type ?? entry.event_type ?? "").toLowerCase();
+    if (explicit.includes("hit") || explicit === "impact") return "hit";
+    if (explicit.includes("miss")) return "miss";
+    if (explicit.includes("fire") || explicit.includes("launch") || explicit.includes("shot")) return "fire";
+    if (explicit.includes("lock") || explicit.includes("acquire")) return "lock";
+    if (explicit.includes("alert") || explicit.includes("warn")) return "alert";
+    if (explicit.includes("detect") || explicit.includes("scan") || explicit.includes("ping")) return "detect";
+    if (explicit.includes("system") || explicit.includes("damage") || explicit.includes("subsys")) return "system";
+
+    const outcome = String(entry.outcome ?? "").toLowerCase();
+    if (outcome.includes("hit")) return "hit";
+    if (outcome.includes("miss")) return "miss";
+
+    return "system";
+  }
+
+  function extractTimestamp(entry: Record<string, unknown>): string {
+    const raw = entry.timestamp ?? entry.time ?? entry.t ?? entry.mission_time;
+    if (typeof raw === "string" && raw.length > 0) return raw.slice(-8);
+    if (typeof raw === "number" && Number.isFinite(raw)) {
+      const total = Math.floor(raw);
+      const h = String(Math.floor(total / 3600)).padStart(2, "0");
+      const m = String(Math.floor((total / 60) % 60)).padStart(2, "0");
+      const s = String(total % 60).padStart(2, "0");
+      return `${h}:${m}:${s}`;
+    }
+    const now = new Date();
+    return `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}:${String(now.getSeconds()).padStart(2, "0")}`;
+  }
+
+  function buildMessage(entry: Record<string, unknown>): string {
+    const primary = entry.summary ?? entry.message ?? entry.description;
+    if (typeof primary === "string" && primary.length > 0) return primary;
+    const parts = [entry.weapon, entry.cause, entry.effect, entry.outcome]
+      .filter((v) => typeof v === "string" && v)
+      .map((v) => String(v));
+    return parts.length > 0 ? parts.join(" · ") : String(entry.event_type ?? "event");
+  }
+
+  function typeColor(t: LogType): string {
+    switch (t) {
+      case "hit":    return "var(--nom)";
+      case "miss":   return "var(--warn)";
+      case "fire":   return "#ff8080";
+      case "lock":   return "var(--info)";
+      case "alert":  return "var(--warn)";
+      case "detect": return "var(--info)";
+      case "system": return "var(--crit)";
+    }
+  }
+
+  function typeBg(t: LogType): string {
+    const col = typeColor(t);
+    // 0x18 alpha ≈ 9.4% opacity badge background
+    if (col === "var(--nom)")  return "rgba(0, 221, 106, 0.09)";
+    if (col === "var(--warn)") return "rgba(239, 160, 32, 0.09)";
+    if (col === "var(--info)") return "rgba(30, 140, 255, 0.09)";
+    if (col === "var(--crit)") return "rgba(232, 48, 48, 0.09)";
+    return "rgba(255, 128, 128, 0.09)";
+  }
+
+  function typeTag(t: LogType): string {
+    return ({
+      hit: "HIT",
+      miss: "MISS",
+      fire: "FIRE",
+      lock: "LOCK",
+      alert: "ALRT",
+      detect: "DET",
+      system: "SYS",
+    } as const)[t];
+  }
+
+  $: reversed = [...entries].reverse();
 </script>
 
 <Panel title="Combat Log" domain="weapons" priority="secondary" className="combat-log-panel">
   <div class="shell">
+    <!-- Filter chips -->
     <div class="filters">
       {#each ["all", "railgun", "torpedo", "missile", "pdc"] as item}
-        <button class:selected={filter === item} type="button" on:click={() => { filter = item as Filter; entries = []; latestId = 0; void poll(); }}>
-          {item.toUpperCase()}
-        </button>
+        <button
+          type="button"
+          class="chip"
+          class:selected={filter === item}
+          on:click={() => setFilter(item as Filter)}
+        >{item.toUpperCase()}</button>
       {/each}
     </div>
 
-    <div class="entry-list">
-      {#if entries.length === 0}
+    <!-- Entry list -->
+    <div class="list">
+      {#if reversed.length === 0}
         <div class="empty">No combat events yet.</div>
       {:else}
-        {#each [...entries].reverse() as entry}
-          <div class="entry">
-            <strong>{headline(entry)}</strong>
-            <span>{detail(entry)}</span>
+        {#each reversed as entry, i (entry.key)}
+          {@const col = typeColor(entry.type)}
+          {@const bg = typeBg(entry.type)}
+          <div
+            class="entry"
+            class:newest={i === 0}
+            style="border-left-color: {col};"
+          >
+            <span class="ts">{entry.timestamp}</span>
+            <span class="type-badge" style="color: {col}; background: {bg};">
+              {typeTag(entry.type)}
+            </span>
+            <span class="msg">{entry.message}</span>
           </div>
         {/each}
       {/if}
@@ -67,40 +189,98 @@
 </Panel>
 
 <style>
-  .shell,
-  .entry-list {
-    display: grid;
-    gap: var(--space-sm);
-    padding: var(--space-sm);
+  .shell {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
   }
 
   .filters {
-    display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-    gap: 6px;
+    display: flex;
+    gap: 4px;
+    padding: 5px 8px;
+    border-bottom: 1px solid var(--bd-subtle);
+    flex-shrink: 0;
   }
 
-  .filters button.selected {
+  .chip {
+    flex: 1;
+    background: transparent;
+    border: 1px solid var(--bd-subtle);
+    color: var(--tx-dim);
+    padding: 3px 6px;
+    border-radius: 2px;
+    font-family: var(--font-mono);
+    font-size: 0.52rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: border-color 0.12s, color 0.12s, background 0.12s;
+  }
+
+  .chip:hover {
+    color: var(--tx-sec);
+    border-color: var(--bd-default);
+  }
+
+  .chip.selected {
     border-color: rgba(var(--tier-accent-rgb), 0.5);
-    background: rgba(var(--tier-accent-rgb), 0.12);
+    background: rgba(var(--tier-accent-rgb), 0.1);
+    color: var(--tx-bright);
+  }
+
+  .list {
+    flex: 1;
+    overflow-y: auto;
+    font-family: var(--font-mono);
   }
 
   .entry {
-    display: grid;
-    gap: 4px;
-    padding: 8px;
-    border-radius: var(--radius-sm);
-    border-left: 3px solid rgba(var(--tier-accent-rgb), 0.6);
-    background: rgba(255, 255, 255, 0.02);
+    display: flex;
+    align-items: flex-start;
+    gap: 7px;
+    padding: 5px 10px;
+    border-bottom: 1px solid var(--bd-subtle);
+    border-left: 3px solid;
   }
 
-  .entry span,
+  .entry.newest {
+    animation: slideUp 0.18s ease-out;
+  }
+
+  .ts {
+    font-size: 0.56rem;
+    color: var(--tx-dim);
+    white-space: nowrap;
+    flex-shrink: 0;
+    margin-top: 1px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .type-badge {
+    font-size: 0.56rem;
+    font-weight: 700;
+    white-space: nowrap;
+    flex-shrink: 0;
+    padding: 1px 4px;
+    border-radius: 1px;
+    letter-spacing: 0.04em;
+    align-self: flex-start;
+  }
+
+  .msg {
+    font-size: 0.63rem;
+    color: var(--tx-primary);
+    line-height: 1.35;
+    word-break: break-word;
+  }
+
   .empty {
+    padding: 16px 10px;
+    text-align: center;
     font-size: var(--font-size-xs);
-    color: var(--text-secondary);
-  }
-
-  strong {
-    font-family: var(--font-mono);
+    color: var(--tx-dim);
   }
 </style>

--- a/gui-svelte/src/components/tactical/FireAuthorization.svelte
+++ b/gui-svelte/src/components/tactical/FireAuthorization.svelte
@@ -114,6 +114,14 @@
           <span>MISSILE</span>
           <strong>{ammoPercent(inventory.missiles.loaded, inventory.missiles.capacity)}</strong>
         </button>
+        <button
+          class="arcade-btn pdc"
+          disabled={firingNow === "pdc"}
+          title={!activeTargetId ? "Select a target first" : "Fire PDC at locked target"}
+          on:click={() => fireNow("pdc")}
+        >
+          <span>PDC</span>
+        </button>
       </div>
     {:else if cpuAssistTier}
       <!-- Auto-tactical enable/disable -->
@@ -145,11 +153,11 @@
 
       <!-- Weapon auth toggles -->
       <div class="auth-grid">
-        {#each ["railgun", "torpedo", "missile"] as weapon}
+        {#each ["railgun", "torpedo", "missile", "pdc"] as weapon}
           <button
             class:selected={authorized[weapon]}
             type="button"
-            on:click={() => toggleAuthorization(weapon as "railgun" | "torpedo" | "missile")}
+            on:click={() => toggleAuthorization(weapon as "railgun" | "torpedo" | "missile" | "pdc")}
           >
             <span>{weapon.toUpperCase()}</span>
             <strong>{authorized[weapon] ? "AUTHORIZED" : "HOLD"}</strong>
@@ -174,7 +182,7 @@
 
   .arcade-grid {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: var(--space-sm);
   }
 
@@ -249,7 +257,7 @@
   /* Weapon authorization grid */
   .auth-grid {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: var(--space-sm);
   }
 

--- a/gui-svelte/src/components/tactical/LauncherControl.svelte
+++ b/gui-svelte/src/components/tactical/LauncherControl.svelte
@@ -2,7 +2,14 @@
   import Panel from "../layout/Panel.svelte";
   import { gameState } from "../../lib/stores/gameState.js";
   import { selectedLauncherType, selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
-  import { extractShipState, getLockedTargetId, getTacticalContacts } from "./tacticalData.js";
+  import {
+    asRecord,
+    extractShipState,
+    getCombatState,
+    getLockedTargetId,
+    getTacticalContacts,
+    toStringValue,
+  } from "./tacticalData.js";
   import {
     getMunitionProfileOptions,
     GUIDANCE_OPTIONS,
@@ -10,6 +17,8 @@
     programMunition,
     WARHEAD_OPTIONS,
   } from "./tacticalActions.js";
+
+  export let embedded = false;
 
   const salvoOptions = [1, 2, 4];
 
@@ -20,6 +29,7 @@
   let selectedTarget = "";
 
   $: ship = extractShipState($gameState);
+  $: combat = getCombatState(ship);
   $: contacts = getTacticalContacts(ship);
   $: lockedTargetId = getLockedTargetId(ship);
   $: selectedTarget = $selectedTacticalTargetId || lockedTargetId;
@@ -27,6 +37,10 @@
   $: if (!profileOptions.includes(profile)) {
     profile = profileOptions[0] ?? "direct";
   }
+  $: armedProgram = asRecord(combat.munition_program) ?? {};
+  $: armedProgramType = toStringValue(armedProgram.munition_type);
+  $: hasProgram = Object.keys(armedProgram).length > 0;
+  $: programMatchesSelection = !armedProgramType || armedProgramType === $selectedLauncherType;
 
   async function fire() {
     await launchSalvo({
@@ -53,10 +67,34 @@
     selectedTarget = value;
     selectedTacticalTargetId.set(value);
   }
+
+  function summaryValue(key: string, fallback = "DEFAULT") {
+    return toStringValue(armedProgram[key], fallback).replaceAll("_", " ").toUpperCase();
+  }
 </script>
 
-<Panel title="Launcher Control" domain="weapons" priority="secondary" className="launcher-control-panel">
-  <div class="shell">
+{#if embedded}
+  <div class="shell embedded-shell">
+    {#if hasProgram}
+      <div class="armed-program" class:mismatch={!programMatchesSelection}>
+        <div class="armed-header">
+          <span class="eyebrow">Armed Program</span>
+          <strong>{armedProgramType.toUpperCase()}</strong>
+        </div>
+        <div class="armed-grid">
+          <div><span>Profile</span><strong>{summaryValue("flight_profile")}</strong></div>
+          <div><span>Guidance</span><strong>{summaryValue("guidance_mode")}</strong></div>
+          <div><span>Warhead</span><strong>{summaryValue("warhead_type")}</strong></div>
+          <div><span>Datalink</span><strong>{armedProgram.datalink === false ? "OFF" : "ON"}</strong></div>
+        </div>
+        {#if !programMatchesSelection}
+          <p class="mismatch-note">
+            Next {$selectedLauncherType.toUpperCase()} launch will ignore the armed {armedProgramType.toUpperCase()} program.
+          </p>
+        {/if}
+      </div>
+    {/if}
+
     <div class="toggle-row">
       <button class:selected={$selectedLauncherType === "torpedo"} type="button" on:click={() => selectedLauncherType.set("torpedo")}>TORPEDO</button>
       <button class:selected={$selectedLauncherType === "missile"} type="button" on:click={() => selectedLauncherType.set("missile")}>MISSILE</button>
@@ -110,17 +148,156 @@
     </div>
 
     <div class="actions">
-      <button on:click={program}>PROGRAM</button>
-      <button on:click={fire}>FIRE</button>
+      <button on:click={program}>ARM PROGRAM</button>
+      <button class="fire-action" on:click={fire}>QUEUE SALVO</button>
     </div>
   </div>
-</Panel>
+{:else}
+  <Panel title="Launcher Control" domain="weapons" priority="secondary" className="launcher-control-panel">
+    <div class="shell">
+      {#if hasProgram}
+        <div class="armed-program" class:mismatch={!programMatchesSelection}>
+          <div class="armed-header">
+            <span class="eyebrow">Armed Program</span>
+            <strong>{armedProgramType.toUpperCase()}</strong>
+          </div>
+          <div class="armed-grid">
+            <div><span>Profile</span><strong>{summaryValue("flight_profile")}</strong></div>
+            <div><span>Guidance</span><strong>{summaryValue("guidance_mode")}</strong></div>
+            <div><span>Warhead</span><strong>{summaryValue("warhead_type")}</strong></div>
+            <div><span>Datalink</span><strong>{armedProgram.datalink === false ? "OFF" : "ON"}</strong></div>
+          </div>
+          {#if !programMatchesSelection}
+            <p class="mismatch-note">
+              Next {$selectedLauncherType.toUpperCase()} launch will ignore the armed {armedProgramType.toUpperCase()} program.
+            </p>
+          {/if}
+        </div>
+      {/if}
+
+      <div class="toggle-row">
+        <button class:selected={$selectedLauncherType === "torpedo"} type="button" on:click={() => selectedLauncherType.set("torpedo")}>TORPEDO</button>
+        <button class:selected={$selectedLauncherType === "missile"} type="button" on:click={() => selectedLauncherType.set("missile")}>MISSILE</button>
+      </div>
+
+      <div class="option-grid">
+        <label>
+          <span>Target</span>
+          <select value={selectedTarget} on:change={onTargetChange}>
+            <option value="">Locked target</option>
+            {#each contacts as contact}
+              <option value={contact.id}>{contact.id} · {contact.classification}</option>
+            {/each}
+          </select>
+        </label>
+        <label>
+          <span>Salvo</span>
+          <select bind:value={salvoSize}>
+            {#each salvoOptions as option}
+              <option value={option}>{option}</option>
+            {/each}
+          </select>
+        </label>
+        <label>
+          <span>Profile</span>
+          <select bind:value={profile}>
+            {#each profileOptions as option}
+              <option value={option}>{option}</option>
+            {/each}
+          </select>
+        </label>
+      </div>
+
+      <div class="option-grid">
+        <label>
+          <span>Guidance</span>
+          <select bind:value={guidanceMode}>
+            {#each GUIDANCE_OPTIONS as option}
+              <option value={option}>{option}</option>
+            {/each}
+          </select>
+        </label>
+        <label>
+          <span>Warhead</span>
+          <select bind:value={warheadType}>
+            {#each WARHEAD_OPTIONS as option}
+              <option value={option}>{option}</option>
+            {/each}
+          </select>
+        </label>
+      </div>
+
+      <div class="actions">
+        <button on:click={program}>ARM PROGRAM</button>
+        <button class="fire-action" on:click={fire}>QUEUE SALVO</button>
+      </div>
+    </div>
+  </Panel>
+{/if}
 
 <style>
   .shell {
     display: grid;
     gap: var(--space-sm);
     padding: var(--space-sm);
+  }
+
+  .embedded-shell {
+    padding: 0;
+  }
+
+  .armed-program {
+    display: grid;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(var(--tier-accent-rgb), 0.3);
+    background: rgba(var(--tier-accent-rgb), 0.08);
+  }
+
+  .armed-program.mismatch {
+    border-color: rgba(239, 160, 32, 0.35);
+    background: rgba(239, 160, 32, 0.08);
+  }
+
+  .armed-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  .armed-header strong,
+  .armed-grid strong {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    letter-spacing: 0.06em;
+  }
+
+  .armed-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px 12px;
+  }
+
+  .armed-grid div {
+    display: grid;
+    gap: 4px;
+  }
+
+  .eyebrow,
+  .armed-grid span,
+  .mismatch-note,
+  span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .mismatch-note {
+    margin: 0;
+    line-height: 1.4;
   }
 
   .toggle-row,
@@ -150,10 +327,19 @@
     gap: 6px;
   }
 
-  span {
-    font-size: var(--font-size-xs);
-    color: var(--text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+  .fire-action {
+    border-color: rgba(232, 48, 48, 0.4);
+    background: rgba(192, 48, 48, 0.18);
+    color: var(--crit);
+  }
+
+  @media (max-width: 720px) {
+    .option-grid,
+    .option-grid:last-of-type,
+    .toggle-row,
+    .actions,
+    .armed-grid {
+      grid-template-columns: 1fr;
+    }
   }
 </style>

--- a/gui-svelte/src/components/tactical/PdcControl.svelte
+++ b/gui-svelte/src/components/tactical/PdcControl.svelte
@@ -1,14 +1,23 @@
 <script lang="ts">
   import Panel from "../layout/Panel.svelte";
   import { gameState } from "../../lib/stores/gameState.js";
+  import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
   import {
+    asRecord,
     extractShipState,
     formatDistance,
     getCombatState,
     getIncomingMunitions,
+    getLockedTargetId,
+    getMultiTrackState,
+    getPdcMounts,
+    getTacticalContacts,
+    toNumber,
     toStringValue,
   } from "./tacticalData.js";
-  import { setPdcMode, setPdcPriority } from "./tacticalActions.js";
+  import { addTrack, assignPdcTarget, firePdc, setPdcMode, setPdcPriority } from "./tacticalActions.js";
+
+  export let embedded = false;
 
   const modes = [
     { label: "AUTO", value: "auto" },
@@ -19,14 +28,29 @@
   ];
 
   let modePending = false;
+  let firingMounts = new Set<string>();
+  let mountSelections: Record<string, string> = {};
 
   $: ship = extractShipState($gameState);
   $: combat = getCombatState(ship);
+  $: multiTrack = getMultiTrackState(ship);
+  $: contacts = getTacticalContacts(ship);
+  $: lockedTargetId = getLockedTargetId(ship);
   $: incomingMunitions = getIncomingMunitions($gameState, ship);
+  $: pdcMounts = getPdcMounts(ship);
+  $: pdcAssignments = asRecord(multiTrack.pdcAssignments) ?? {};
+  $: pdcEngagements = asRecord(combat.pdc_engagements) ?? {};
+  $: pdcStats = asRecord(combat.pdc_stats) ?? {};
+  $: trackedIds = new Set(
+    (Array.isArray(multiTrack.tracks) ? multiTrack.tracks : [])
+      .map((track) => toStringValue(asRecord(track)?.contact_id))
+      .filter(Boolean),
+  );
   $: mode = toStringValue(combat.pdc_mode, "auto");
   $: priorityTarget = Array.isArray(combat.pdc_priority_targets)
     ? toStringValue(combat.pdc_priority_targets[0])
     : "";
+  $: mountSelections = syncSelections(mountSelections, pdcMounts.map((mount) => mount.id));
 
   const modeDescriptions: Record<string, string> = {
     auto: "Automatically engage incoming threats",
@@ -35,6 +59,46 @@
     priority: "Engage threat-board priority targets first",
     hold_fire: "PDC will not fire — all mounts safed",
   };
+
+  function syncSelections(current: Record<string, string>, mountIds: string[]) {
+    let changed = false;
+    const next: Record<string, string> = {};
+    for (const mountId of mountIds) {
+      if (current[mountId] !== undefined) next[mountId] = current[mountId];
+      if (!(mountId in current)) changed = true;
+    }
+    for (const mountId of Object.keys(current)) {
+      if (!mountIds.includes(mountId)) changed = true;
+    }
+    return changed ? next : current;
+  }
+
+  function getAssignedTarget(mountId: string) {
+    return toStringValue(
+      mountSelections[mountId],
+      toStringValue(
+        pdcAssignments[mountId],
+        toStringValue(
+          pdcEngagements[mountId],
+          toStringValue($selectedTacticalTargetId, lockedTargetId),
+        ),
+      ),
+    );
+  }
+
+  function assignmentLabel(targetId: string) {
+    if (!targetId) return "NO TRACK ASSIGNED";
+    return trackedIds.has(targetId) ? `TRACK ${targetId}` : `LOCK ${targetId}`;
+  }
+
+  async function ensureTracked(contactId: string) {
+    if (!contactId || trackedIds.has(contactId)) return;
+    try {
+      await addTrack(contactId);
+    } catch {
+      // Best effort; fire path can still fall back to the primary lock.
+    }
+  }
 
   async function setMode(next: string) {
     if (modePending || mode === next) return;
@@ -51,10 +115,65 @@
     if (!targetId) return;
     await setPdcPriority([targetId]);
   }
+
+  async function assignMount(mountId: string, targetId: string) {
+    mountSelections = {
+      ...mountSelections,
+      [mountId]: targetId,
+    };
+    if (!targetId) return;
+    selectedTacticalTargetId.set(targetId);
+    await ensureTracked(targetId);
+    await assignPdcTarget(mountId, targetId);
+  }
+
+  async function fireMount(mountId: string) {
+    if (firingMounts.has(mountId) || mode !== "manual") return;
+    const targetId = getAssignedTarget(mountId);
+    const next = new Set(firingMounts);
+    next.add(mountId);
+    firingMounts = next;
+    try {
+      if (targetId) {
+        await ensureTracked(targetId);
+        await assignPdcTarget(mountId, targetId);
+      }
+      await firePdc({ mountId, targetId: targetId || undefined });
+    } finally {
+      const pending = new Set(firingMounts);
+      pending.delete(mountId);
+      firingMounts = pending;
+    }
+  }
+
+  function mountReady(mountId: string) {
+    const mount = pdcMounts.find((item) => item.id === mountId);
+    return Boolean(mount && mount.enabled && mount.ammo > 0 && !mount.reloading);
+  }
+
+  function statValue(mountId: string, key: string) {
+    const stats = asRecord(pdcStats[mountId]);
+    return Math.round(toNumber(stats?.[key], 0));
+  }
 </script>
 
-<Panel title="PDC Control" domain="weapons" priority="secondary" className="pdc-control-panel">
-  <div class="shell">
+{#if embedded}
+  <div class="shell embedded-shell">
+    <div class="status-strip">
+      <div>
+        <span>Mode</span>
+        <strong>{mode.replaceAll("_", " ").toUpperCase()}</strong>
+      </div>
+      <div>
+        <span>Threats</span>
+        <strong>{incomingMunitions.length}</strong>
+      </div>
+      <div>
+        <span>Tracked</span>
+        <strong>{multiTrack.trackCount}</strong>
+      </div>
+    </div>
+
     <div class="mode-grid">
       {#each modes as item}
         <button
@@ -68,7 +187,7 @@
     </div>
 
     <label>
-      <span>Priority munition</span>
+      <span>Priority Threat</span>
       <select value={priorityTarget} on:change={applyPriority}>
         <option value="">Select incoming threat</option>
         {#each incomingMunitions as munition}
@@ -78,14 +197,198 @@
         {/each}
       </select>
     </label>
+
+    <div class="mount-list">
+      {#each pdcMounts as mount}
+        {@const assignedTarget = getAssignedTarget(mount.id)}
+        <div class="mount-card">
+          <div class="mount-head">
+            <div>
+              <strong>{mount.label}</strong>
+              <p>{mount.status.toUpperCase()} · {mount.ammo}/{mount.ammoCapacity || mount.ammo} RDS</p>
+            </div>
+            <div class="stat-pair">
+              <span>{statValue(mount.id, "shots_fired")} SH</span>
+              <span>{statValue(mount.id, "hits")} HIT</span>
+            </div>
+          </div>
+
+          <label>
+            <span>Assigned Track</span>
+            <select value={assignedTarget} on:change={(event) => assignMount(mount.id, (event.currentTarget as HTMLSelectElement).value)}>
+              <option value="">Locked / selected target</option>
+              {#if incomingMunitions.length > 0}
+                <optgroup label="Incoming Threats">
+                  {#each incomingMunitions as munition}
+                    <option value={munition.id}>
+                      {munition.id} · {munition.munitionType.toUpperCase()}
+                    </option>
+                  {/each}
+                </optgroup>
+              {/if}
+              <optgroup label="Sensor Contacts">
+                {#each contacts as contact}
+                  <option value={contact.id}>
+                    {contact.id} · {contact.classification} {trackedIds.has(contact.id) ? "· TRACKED" : ""}
+                  </option>
+                {/each}
+              </optgroup>
+            </select>
+          </label>
+
+          <div class="mount-actions">
+            <span class="assignment">{assignmentLabel(assignedTarget)}</span>
+            <button
+              class="fire-btn"
+              disabled={mode !== "manual" || !mountReady(mount.id) || firingMounts.has(mount.id)}
+              on:click={() => fireMount(mount.id)}
+            >
+              {firingMounts.has(mount.id) ? "FIRING…" : "FIRE"}
+            </button>
+          </div>
+        </div>
+      {/each}
+    </div>
   </div>
-</Panel>
+{:else}
+  <Panel title="PDC Control" domain="weapons" priority="secondary" className="pdc-control-panel">
+    <div class="shell">
+      <div class="status-strip">
+        <div>
+          <span>Mode</span>
+          <strong>{mode.replaceAll("_", " ").toUpperCase()}</strong>
+        </div>
+        <div>
+          <span>Threats</span>
+          <strong>{incomingMunitions.length}</strong>
+        </div>
+        <div>
+          <span>Tracked</span>
+          <strong>{multiTrack.trackCount}</strong>
+        </div>
+      </div>
+
+      <div class="mode-grid">
+        {#each modes as item}
+          <button
+            class:selected={mode === item.value}
+            disabled={modePending}
+            title={modeDescriptions[item.value] ?? item.label}
+            type="button"
+            on:click={() => setMode(item.value)}
+          >{item.label}</button>
+        {/each}
+      </div>
+
+      <label>
+        <span>Priority Threat</span>
+        <select value={priorityTarget} on:change={applyPriority}>
+          <option value="">Select incoming threat</option>
+          {#each incomingMunitions as munition}
+            <option value={munition.id}>
+              {munition.id} · {munition.munitionType.toUpperCase()} · {formatDistance(munition.distance)}
+            </option>
+          {/each}
+        </select>
+      </label>
+
+      <div class="mount-list">
+        {#each pdcMounts as mount}
+          {@const assignedTarget = getAssignedTarget(mount.id)}
+          <div class="mount-card">
+            <div class="mount-head">
+              <div>
+                <strong>{mount.label}</strong>
+                <p>{mount.status.toUpperCase()} · {mount.ammo}/{mount.ammoCapacity || mount.ammo} RDS</p>
+              </div>
+              <div class="stat-pair">
+                <span>{statValue(mount.id, "shots_fired")} SH</span>
+                <span>{statValue(mount.id, "hits")} HIT</span>
+              </div>
+            </div>
+
+            <label>
+              <span>Assigned Track</span>
+              <select value={assignedTarget} on:change={(event) => assignMount(mount.id, (event.currentTarget as HTMLSelectElement).value)}>
+                <option value="">Locked / selected target</option>
+                {#if incomingMunitions.length > 0}
+                  <optgroup label="Incoming Threats">
+                    {#each incomingMunitions as munition}
+                      <option value={munition.id}>
+                        {munition.id} · {munition.munitionType.toUpperCase()}
+                      </option>
+                    {/each}
+                  </optgroup>
+                {/if}
+                <optgroup label="Sensor Contacts">
+                  {#each contacts as contact}
+                    <option value={contact.id}>
+                      {contact.id} · {contact.classification} {trackedIds.has(contact.id) ? "· TRACKED" : ""}
+                    </option>
+                  {/each}
+                </optgroup>
+              </select>
+            </label>
+
+            <div class="mount-actions">
+              <span class="assignment">{assignmentLabel(assignedTarget)}</span>
+              <button
+                class="fire-btn"
+                disabled={mode !== "manual" || !mountReady(mount.id) || firingMounts.has(mount.id)}
+                on:click={() => fireMount(mount.id)}
+              >
+                {firingMounts.has(mount.id) ? "FIRING…" : "FIRE"}
+              </button>
+            </div>
+          </div>
+        {/each}
+      </div>
+    </div>
+  </Panel>
+{/if}
 
 <style>
   .shell {
     display: grid;
     gap: var(--space-sm);
     padding: var(--space-sm);
+  }
+
+  .embedded-shell {
+    padding: 0;
+  }
+
+  .status-strip {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-sm);
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .status-strip div,
+  .mount-card,
+  label {
+    display: grid;
+    gap: 6px;
+  }
+
+  .status-strip span,
+  span,
+  .mount-head p,
+  .assignment {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .status-strip strong,
+  .mount-head strong,
+  .stat-pair span {
+    font-family: var(--font-mono);
   }
 
   .mode-grid {
@@ -99,15 +402,62 @@
     background: rgba(var(--tier-accent-rgb), 0.12);
   }
 
-  label {
+  .mount-list {
     display: grid;
-    gap: 6px;
+    gap: var(--space-sm);
   }
 
-  span {
-    font-size: var(--font-size-xs);
-    color: var(--text-secondary);
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
+  .mount-card {
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .mount-head {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    align-items: start;
+  }
+
+  .mount-head p {
+    margin: 0;
+  }
+
+  .stat-pair {
+    display: flex;
+    gap: 8px;
+  }
+
+  .mount-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-sm);
+  }
+
+  .assignment {
+    flex: 1;
+  }
+
+  .fire-btn {
+    min-width: 88px;
+    border-color: rgba(232, 48, 48, 0.4);
+    background: rgba(192, 48, 48, 0.18);
+    color: var(--crit);
+  }
+
+  @media (max-width: 720px) {
+    .status-strip,
+    .mode-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .mount-actions,
+    .mount-head {
+      flex-direction: column;
+      align-items: stretch;
+    }
   }
 </style>

--- a/gui-svelte/src/components/tactical/SensorContacts.svelte
+++ b/gui-svelte/src/components/tactical/SensorContacts.svelte
@@ -1,4 +1,12 @@
 <script lang="ts">
+  /**
+   * SensorContacts — prototype-aligned contact list.
+   *
+   * Layout columns: IFF tag | contact ID+name | distance | bearing.
+   * Color-coded by IFF (hostile red, friendly green, unknown orange).
+   * Threat badge on high-threat contacts. Pulsing animation for ordnance.
+   * Clicking a contact selects it as the tactical target.
+   */
   import Panel from "../layout/Panel.svelte";
   import { gameState } from "../../lib/stores/gameState.js";
   import { tier } from "../../lib/stores/tier.js";
@@ -6,13 +14,11 @@
   import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
   import {
     extractShipState,
-    formatBearing,
-    formatContactSummary,
-    formatContactVector,
     getLockedTargetId,
     getSensorState,
     getTacticalContacts,
     toNumber,
+    type TacticalContact,
   } from "./tacticalData.js";
   import { lockTarget } from "./tacticalActions.js";
 
@@ -24,11 +30,64 @@
   $: contacts = getTacticalContacts(ship);
   $: sensors = getSensorState(ship);
   $: lockedTargetId = getLockedTargetId(ship);
-  $: arcadeTier = $tier === "arcade";
-  $: cpuAssistTier = $tier === "cpu-assist";
-  $: manualTier = $tier === "manual";
   $: cooldown = toNumber(sensors.ping_cooldown_remaining);
   $: canPing = !passive && Boolean(sensors.can_ping ?? true) && cooldown <= 0;
+
+  // Sort: ordnance first (threats!), then by distance
+  $: sortedContacts = [...contacts].sort((a, b) => {
+    const aOrd = isOrdnance(a) ? 0 : 1;
+    const bOrd = isOrdnance(b) ? 0 : 1;
+    if (aOrd !== bOrd) return aOrd - bOrd;
+    return a.distance - b.distance;
+  });
+
+  $: hostileCount = contacts.filter((c) => iffKind(c) === "hostile").length;
+
+  function iffKind(c: TacticalContact): "hostile" | "friendly" | "unknown" | "neutral" {
+    const dip = c.diplomaticState.toLowerCase();
+    if (dip.includes("hostile") || c.threatLevel === "red" || c.threatLevel === "orange") return "hostile";
+    if (dip.includes("friend") || dip.includes("allied")) return "friendly";
+    if (dip.includes("unknown") || dip === "") return "unknown";
+    return "neutral";
+  }
+
+  function iffTag(c: TacticalContact): string {
+    const k = iffKind(c);
+    if (k === "hostile") return "HOT";
+    if (k === "friendly") return "FRD";
+    if (k === "unknown") return "UNK";
+    return "NEU";
+  }
+
+  function iffColor(c: TacticalContact): string {
+    const k = iffKind(c);
+    if (k === "hostile") return "#e83030";
+    if (k === "friendly") return "#00dd6a";
+    if (k === "unknown") return "#efa020";
+    return "#6888aa";
+  }
+
+  function isOrdnance(c: TacticalContact): boolean {
+    return /torpedo|missile|ordnance/i.test(c.classification);
+  }
+
+  function threatBadge(c: TacticalContact): string | null {
+    if (isOrdnance(c)) return "CRIT";
+    if (c.threatLevel === "red") return "HIGH";
+    if (c.threatLevel === "orange") return "MED";
+    return null;
+  }
+
+  function threatColor(label: string): string {
+    if (label === "CRIT" || label === "HIGH") return "#e83030";
+    if (label === "MED") return "#efa020";
+    return "#3a3a52";
+  }
+
+  function distStr(m: number): string {
+    if (m >= 1000) return `${(m / 1000).toFixed(0)}k`;
+    return `${Math.round(m)}m`;
+  }
 
   async function pingSensors() {
     if (!canPing) return;
@@ -40,75 +99,89 @@
     }
   }
 
-  async function lockContact(contactId: string) {
+  async function selectContact(contactId: string) {
     selectedTacticalTargetId.set(contactId);
     if (passive) return;
     await lockTarget(contactId);
   }
 </script>
 
-<Panel title={passive ? "Passive Contacts" : "Sensor Contacts"} domain="sensor" priority={$tier === "manual" ? "primary" : "secondary"} className="sensor-contacts-panel">
+<Panel
+  title={passive ? "Passive Contacts" : "Sensor Contacts"}
+  domain="sensor"
+  priority="primary"
+  className="sensor-contacts-panel"
+>
   <div class="shell">
+    <!-- Toolbar -->
     {#if !passive}
       <div class="toolbar">
         <button
+          class="ping-btn"
           disabled={!canPing || busy}
-          title={cooldown > 0 ? `Active ping cooling down — ready in ${cooldown.toFixed(1)}s` : busy ? "Pinging…" : "Send active sonar ping to resolve contacts"}
+          title={cooldown > 0
+            ? `Active ping cooling down — ready in ${cooldown.toFixed(1)}s`
+            : busy ? "Pinging…" : "Send active sensor ping to resolve contacts"}
           on:click={pingSensors}
         >
-          {cooldown > 0 ? `PING ${cooldown.toFixed(1)}s` : busy ? "PINGING…" : "PING SENSORS"}
+          {cooldown > 0 ? `PING ${cooldown.toFixed(1)}s` : busy ? "PINGING…" : "PING"}
         </button>
-        <div class="summary">{contacts.length} contacts</div>
+        <span class="status-badge" class:hot={hostileCount > 0}>
+          {hostileCount > 0 ? `${hostileCount} HOT` : `${contacts.length} LIVE`}
+        </span>
       </div>
     {:else}
       <div class="toolbar passive-bar">
         <span class="passive-badge">PASSIVE</span>
-        <div class="summary">{contacts.length} contacts · read-only</div>
+        <span class="status-badge">{contacts.length} RO</span>
       </div>
     {/if}
 
+    <!-- Column headers -->
+    <div class="header">
+      <span>IFF</span>
+      <span>Contact</span>
+      <span class="right">Dist</span>
+      <span class="right">Brg</span>
+    </div>
+
+    <!-- List -->
     <div class="list">
-      {#if contacts.length === 0}
+      {#if sortedContacts.length === 0}
         <div class="empty">No contacts resolved.</div>
       {:else}
-        {#each contacts as contact}
+        {#each sortedContacts as c (c.id)}
+          {@const kind = iffKind(c)}
+          {@const col = iffColor(c)}
+          {@const tag = iffTag(c)}
+          {@const badge = threatBadge(c)}
+          {@const ord = isOrdnance(c)}
+          {@const selected = c.id === $selectedTacticalTargetId || c.id === lockedTargetId}
           <button
-            class="contact-row"
-            class:selected={contact.id === $selectedTacticalTargetId || contact.id === lockedTargetId}
-            class:passive={passive}
+            class="row"
+            class:selected
+            class:torpedo={ord}
+            class:passive
             type="button"
             disabled={passive}
-            title={passive ? "Passive mode — active lock unavailable" : `Lock ${contact.id} as tactical target`}
-            on:click={() => lockContact(contact.id)}
+            title={passive ? "Passive — cannot designate" : `Designate ${c.id}`}
+            style="--iff: {col}; --iff-border: {col}50;"
+            on:click={() => selectContact(c.id)}
           >
-            <div class="topline">
-              <strong>{contact.id}</strong>
-              <span class="threat {contact.threatLevel}">{contact.threatLevel.toUpperCase()}</span>
-            </div>
-
-            {#if cpuAssistTier}
-              <div class="primary-line">{contact.classification || "Unknown"} · {Math.round(contact.threatScore * 100)} threat</div>
-            {:else}
-              <div class="primary-line">{contact.classification || "Unknown"} · {formatContactSummary(contact)}</div>
-            {/if}
-
-            {#if !arcadeTier && !cpuAssistTier}
-              <div class="detail-line">
-                <span>Bearing {formatBearing(contact.bearing)}</span>
-                <span>Closure {contact.closureRate >= 0 ? "+" : ""}{contact.closureRate.toFixed(0)} m/s</span>
+            <span class="iff" style="color: {col};">{tag}</span>
+            <div class="ident">
+              <div class="ident-top">
+                <strong class="cid">{c.id}</strong>
+                {#if badge}
+                  <span class="threat" style="color: {threatColor(badge)}; border-color: {threatColor(badge)}44;">{badge}</span>
+                {/if}
               </div>
-            {/if}
-
-            {#if manualTier}
-              <div class="detail-line">
-                <span>Signal {contact.signalStrength.toFixed(2)}</span>
-                <span>V {formatContactVector(contact)}</span>
+              <div class="cname">
+                {(c.name.length > 16 ? c.name.slice(0, 15) + "…" : c.name).toUpperCase()}
               </div>
-            {/if}
-
-            <div class="confidence-track" aria-label="Contact confidence">
-              <div class="confidence-fill {contact.threatLevel}" style={`width: ${(contact.confidence * 100).toFixed(0)}%;`}></div>
             </div>
+            <span class="num">{distStr(c.distance)}</span>
+            <span class="num">{String(Math.round(c.bearing < 0 ? c.bearing + 360 : c.bearing)).padStart(3, "0")}°</span>
           </button>
         {/each}
       {/if}
@@ -117,110 +190,194 @@
 </Panel>
 
 <style>
-  .shell,
-  .list {
-    display: grid;
-    gap: var(--space-sm);
-    padding: var(--space-sm);
-  }
-
-  .toolbar,
-  .topline,
-  .detail-line {
+  .shell {
     display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .toolbar {
+    display: flex;
+    align-items: center;
     justify-content: space-between;
-    gap: var(--space-sm);
-    align-items: center;
-  }
-
-  .summary,
-  .primary-line,
-  .detail-line,
-  .empty {
-    font-size: var(--font-size-xs);
-    color: var(--text-secondary);
-  }
-
-  .contact-row {
-    display: grid;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--bd-subtle);
+    background: rgba(0, 0, 0, 0.18);
     gap: 6px;
-    width: 100%;
-    text-align: left;
-    padding: 10px;
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--border-default);
-    background: rgba(255, 255, 255, 0.02);
+    flex-shrink: 0;
   }
 
-  .contact-row.selected {
-    border-color: rgba(var(--tier-accent-rgb), 0.5);
-    background: rgba(var(--tier-accent-rgb), 0.12);
+  .ping-btn {
+    background: transparent;
+    border: 1px solid var(--bd-default);
+    color: var(--tx-sec);
+    padding: 3px 8px;
+    border-radius: 2px;
+    font-family: var(--font-mono);
+    font-size: 0.59rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    cursor: pointer;
   }
 
-  .contact-row.passive {
-    cursor: not-allowed;
-    opacity: 0.55;
+  .ping-btn:hover:not(:disabled) {
+    color: var(--tx-bright);
+    border-color: var(--bd-focus);
   }
 
-  .passive-bar {
-    align-items: center;
+  .status-badge {
+    font-size: 0.51rem;
+    font-weight: 700;
+    font-family: var(--font-mono);
+    padding: 1px 5px;
+    border-radius: 2px;
+    color: var(--nom);
+    background: rgba(0, 221, 106, 0.1);
+    border: 1px solid rgba(0, 221, 106, 0.28);
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+  }
+
+  .status-badge.hot {
+    color: var(--crit);
+    background: rgba(232, 48, 48, 0.1);
+    border-color: rgba(232, 48, 48, 0.4);
   }
 
   .passive-badge {
     font-family: var(--font-mono);
     font-size: 0.6rem;
     letter-spacing: 0.1em;
-    padding: 3px 7px;
-    border-radius: 3px;
+    padding: 2px 6px;
+    border-radius: 2px;
     background: rgba(255, 216, 77, 0.18);
     color: #ffd84d;
     border: 1px solid rgba(255, 216, 77, 0.35);
   }
 
-  .contact-row strong {
+  .header {
+    display: grid;
+    grid-template-columns: 34px 1fr 48px 52px;
+    padding: 3px 8px;
+    border-bottom: 1px solid var(--bd-subtle);
+    font-size: 0.52rem;
+    color: var(--tx-dim);
     font-family: var(--font-mono);
-    color: var(--text-primary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    flex-shrink: 0;
+  }
+
+  .header .right {
+    text-align: right;
+  }
+
+  .list {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 34px 1fr 48px 52px;
+    padding: 5px 8px;
+    border: none;
+    border-bottom: 1px solid var(--bd-subtle);
+    border-left: 3px solid var(--iff-border, var(--bd-default));
+    border-radius: 0;
+    background: transparent;
+    text-align: left;
+    cursor: pointer;
+    font-family: inherit;
+    width: 100%;
+    transition: background 0.1s ease;
+  }
+
+  .row:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .row.selected {
+    background: rgba(255, 255, 255, 0.04);
+    border-left-color: #fff;
+  }
+
+  .row.torpedo {
+    background: rgba(232, 48, 48, 0.06);
+    animation: pulse 1s ease-in-out infinite;
+  }
+
+  .row.passive {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  .iff {
+    font-size: 0.57rem;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    align-self: center;
+  }
+
+  .ident {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    overflow: hidden;
+    min-width: 0;
+  }
+
+  .ident-top {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .cid {
+    font-size: 0.68rem;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    color: var(--tx-primary);
+  }
+
+  .row.selected .cid {
+    color: var(--tx-bright);
   }
 
   .threat {
+    font-size: 0.48rem;
     font-family: var(--font-mono);
-    font-size: 0.65rem;
-    letter-spacing: 0.08em;
+    padding: 0 3px;
+    border-radius: 1px;
+    border: 1px solid;
+    letter-spacing: 0.04em;
   }
 
-  .threat.green,
-  .confidence-fill.green {
-    color: var(--status-nominal);
-    background: rgba(0, 255, 136, 0.85);
-  }
-
-  .threat.yellow,
-  .confidence-fill.yellow {
-    color: #ffd84d;
-    background: rgba(255, 216, 77, 0.85);
-  }
-
-  .threat.orange,
-  .confidence-fill.orange {
-    color: #ff9d47;
-    background: rgba(255, 157, 71, 0.9);
-  }
-
-  .threat.red,
-  .confidence-fill.red {
-    color: var(--status-critical);
-    background: rgba(255, 68, 68, 0.9);
-  }
-
-  .confidence-track {
-    height: 8px;
+  .cname {
+    font-size: 0.58rem;
+    color: var(--tx-dim);
+    font-family: var(--font-mono);
+    text-overflow: ellipsis;
     overflow: hidden;
-    border-radius: 999px;
-    background: var(--bg-input);
-    border: 1px solid var(--border-subtle);
+    white-space: nowrap;
   }
 
-  .confidence-fill {
-    height: 100%;
+  .num {
+    font-size: 0.63rem;
+    font-family: var(--font-mono);
+    text-align: right;
+    color: var(--tx-primary);
+    font-variant-numeric: tabular-nums;
+    align-self: center;
+  }
+
+  .empty {
+    padding: 14px;
+    text-align: center;
+    font-size: var(--font-size-xs);
+    color: var(--tx-dim);
   }
 </style>

--- a/gui-svelte/src/components/tactical/TacticalMap.svelte
+++ b/gui-svelte/src/components/tactical/TacticalMap.svelte
@@ -1,223 +1,873 @@
 <script lang="ts">
+  /**
+   * TacticalMap — canvas-based tactical display.
+   *
+   * Rewritten to match the prototype in tools/design_reference_v2.html:
+   *   • Dark vignette + starfield
+   *   • Range rings & grid
+   *   • IFF-coded contact shapes (square / diamond / dashed circle)
+   *   • Velocity vectors, targeting brackets, firing solution cone
+   *   • Trajectory projection along own-ship velocity
+   *   • Compass rose and scale label
+   *   • Toolbar with scale zoom and flag toggles (V/G/S/T/A)
+   *
+   * Data wiring is preserved from the previous implementation — we still read
+   * from gameState + selectedTacticalTargetId and use tacticalData.ts helpers.
+   */
+  import { onDestroy, onMount, tick } from "svelte";
   import Panel from "../layout/Panel.svelte";
-  import SpatialMapCanvas from "../spatial/SpatialMapCanvas.svelte";
-  import type { SpatialLegendItem, SpatialLink, SpatialRing, SpatialTrack } from "../spatial/spatialMapTypes.js";
   import { gameState } from "../../lib/stores/gameState.js";
   import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
-  import { extractShipState, getTacticalContacts, getWeaponMounts } from "./tacticalData.js";
+  import {
+    extractShipState,
+    getTacticalContacts,
+    getBestWeaponSolution,
+    getLockedTargetId,
+    getTargetingSummary,
+    type TacticalContact,
+  } from "./tacticalData.js";
   import { lockTarget } from "./tacticalActions.js";
-  import { getOrientation, getPosition, getVelocity, toStringValue, toVec3 } from "../helm/helmData.js";
+  import { getOrientation, getPosition, getVelocity, toNumber } from "../helm/helmData.js";
 
-  type CombatEntity = Record<string, unknown>;
-
-  const LEGEND: SpatialLegendItem[] = [
-    { label: "Own ship", color: "#8ef7ff", symbol: "▲" },
-    { label: "Threat", color: "#ff5a5a", symbol: "◆" },
-    { label: "Neutral", color: "#82b8ff", symbol: "●" },
-    { label: "Rail slug", color: "#f9f871", symbol: "•" },
-    { label: "Munition", color: "#ff9966", symbol: "◇" },
-  ];
-  const legendItems = LEGEND;
-
+  // ── State ──────────────────────────────────────────────────────────────
+  let canvas: HTMLCanvasElement;
+  let container: HTMLDivElement;
+  let dims = { w: 400, h: 400 };
+  let scale = 90000; // meters radius
+  const scaleSteps = [5000, 10000, 25000, 50000, 100000, 200000, 400000, 800000];
+  let flags = {
+    vectors: true,
+    grid: true,
+    solutions: true,
+    traj: true,
+    arcs: false,
+    auto: true,
+  };
+  let stars: Array<{ x: number; y: number; r: number; a: number }> = [];
+  let pinging = false;
+  let rafId: number | null = null;
   let lockBusy = false;
+  let viewCenter = { x: 0, y: 0 };
+  let pointerId: number | null = null;
+  let pointerDown = false;
+  let dragMoved = false;
+  let suppressClick = false;
+  let dragStart = { x: 0, y: 0 };
+  let dragOrigin = { x: 0, y: 0 };
 
+  // ── Reactive data from gameState ──────────────────────────────────────
   $: ship = extractShipState($gameState);
   $: contacts = getTacticalContacts(ship);
-  $: mounts = getWeaponMounts(ship);
-  $: shipPosition = getPosition(ship);
-  $: shipVelocity = getVelocity(ship);
-  $: shipHeading = getOrientation(ship).yaw;
-  $: projectiles = Array.isArray(($gameState as Record<string, unknown>).projectiles) ? (($gameState as Record<string, unknown>).projectiles as CombatEntity[]) : [];
-  $: torpedoes = Array.isArray(($gameState as Record<string, unknown>).torpedoes) ? (($gameState as Record<string, unknown>).torpedoes as CombatEntity[]) : [];
-
-  $: contactTracks = contacts.map((contact) => ({
-    id: contact.id,
-    label: contact.id,
-    position: contact.position,
-    velocity: contact.velocity,
-    kind: contact.diplomaticState.toLowerCase().includes("hostile") || contact.threatLevel === "red" || contact.threatLevel === "orange"
-      ? "hostile"
-      : "neutral",
-    confidence: contact.confidence,
-    annotation: `${contact.classification} · ${Math.round(contact.distance / 1000)} km`,
-    selectable: true,
-    elevationConnector: contact.id === $selectedTacticalTargetId ? "selected" : "none",
-  } satisfies SpatialTrack));
-
-  $: projectileTracks = projectiles
-    .map((entity) => {
-      const position = toVec3(entity.position);
-      const velocity = toVec3(entity.velocity);
-      return {
-        id: `proj:${toStringValue(entity.id, Math.random().toString(36).slice(2))}`,
-        label: toStringValue(entity.mount, toStringValue(entity.weapon, "slug")).toUpperCase(),
-        position,
-        velocity,
-        kind: "projectile",
-        annotation: toStringValue(entity.target),
-        selectable: false,
-        elevationConnector: "none",
-      } satisfies SpatialTrack;
-    });
-
-  $: munitionTracks = torpedoes
-    .map((entity) => {
-      const kind = toStringValue(entity.munition_type, "torpedo");
-      const target = toStringValue(entity.target);
-      return {
-        id: `mun:${toStringValue(entity.id, Math.random().toString(36).slice(2))}`,
-        label: toStringValue(entity.id, kind.toUpperCase()),
-        position: toVec3(entity.position),
-        velocity: toVec3(entity.velocity),
-        kind: "munition",
-        annotation: `${kind.toUpperCase()}${target ? ` → ${target}` : ""}`,
-        selectable: false,
-        elevationConnector: "none",
-      } satisfies SpatialTrack;
-    });
-
-  $: tracks = [
-    {
-      id: "ownship",
-      label: toStringValue(ship.name, toStringValue(ship.id, "OWN SHIP")),
-      position: shipPosition,
-      velocity: shipVelocity,
-      headingDeg: shipHeading,
-      kind: "ownship",
-      selectable: false,
-      emphasis: true,
-      annotation: "Combat platform",
-      elevationConnector: "always",
-      elevationLabel: "OWN SHIP",
-    } satisfies SpatialTrack,
-    ...contactTracks,
-    ...munitionTracks,
-    ...projectileTracks,
-  ];
-
-  $: selectedContact = contacts.find((contact) => contact.id === $selectedTacticalTargetId) ?? null;
-
-  $: rings = buildRings(shipPosition, mounts);
-  $: links = buildLinks(shipPosition, selectedContact, torpedoes, contacts);
-  $: initialRadius = deriveInitialRadius(contacts, mounts);
-
-  function buildRings(position: typeof shipPosition, weaponMounts: typeof mounts): SpatialRing[] {
-    const grouped = new Map<string, number>();
-    for (const mount of weaponMounts) {
-      if (!mount.range || mount.range <= 0) continue;
-      const key = mount.weaponType;
-      grouped.set(key, Math.max(grouped.get(key) ?? 0, mount.range));
+  $: shipPos = getPosition(ship);
+  $: shipVel = getVelocity(ship);
+  $: shipHeading = getOrientation(ship).yaw; // degrees
+  $: targeting = getTargetingSummary(ship);
+  $: lockedTargetId = getLockedTargetId(ship);
+  $: bestSolution = getBestWeaponSolution(ship);
+  $: selectedId = $selectedTacticalTargetId;
+  $: if (flags.auto || (!pointerDown && viewCenter.x === 0 && viewCenter.y === 0)) {
+    if (Math.abs(viewCenter.x - shipPos.x) > 0.01 || Math.abs(viewCenter.y - shipPos.y) > 0.01) {
+      viewCenter = { x: shipPos.x, y: shipPos.y };
     }
+  }
 
-    const palette: Record<string, { color: string; label: string }> = {
-      railgun: { color: "rgba(135, 196, 255, 0.34)", label: "Rail" },
-      pdc: { color: "rgba(98, 255, 201, 0.28)", label: "PDC" },
-      torpedo: { color: "rgba(255, 173, 91, 0.28)", label: "Torp" },
-      missile: { color: "rgba(255, 123, 123, 0.26)", label: "Missile" },
-      other: { color: "rgba(220, 220, 220, 0.2)", label: "Envelope" },
-    };
-
-    return Array.from(grouped.entries()).map(([weaponType, radius]) => ({
-      id: `ring:${weaponType}`,
-      center: position,
-      radius,
-      color: palette[weaponType]?.color ?? palette.other.color,
-      label: palette[weaponType]?.label ?? palette.other.label,
-      dashed: weaponType !== "railgun",
+  // Generate stars once
+  onMount(() => {
+    stars = Array.from({ length: 120 }, () => ({
+      x: Math.random(),
+      y: Math.random(),
+      r: Math.random() * 0.9 + 0.2,
+      a: Math.random() * 0.5 + 0.1,
     }));
+
+    const obs = new ResizeObserver((entries) => {
+      const rect = entries[0].contentRect;
+      dims = { w: Math.max(100, rect.width), h: Math.max(100, rect.height) };
+    });
+    if (container) obs.observe(container);
+
+    // Animation loop (drives starfield-twinkle, pulses, radar sweep)
+    const loop = () => {
+      draw();
+      rafId = requestAnimationFrame(loop);
+    };
+    rafId = requestAnimationFrame(loop);
+
+    return () => {
+      obs.disconnect();
+      if (rafId != null) cancelAnimationFrame(rafId);
+    };
+  });
+
+  onDestroy(() => {
+    if (rafId != null) cancelAnimationFrame(rafId);
+  });
+
+  // Trigger redraw when reactive data changes
+  $: if (canvas && dims.w) {
+    void dims;
+    void contacts;
+    void shipPos;
+    void shipVel;
+    void shipHeading;
+    void targeting;
+    void selectedId;
+    void scale;
+    void flags;
+    // draw is called each RAF — nothing to do here; this block just keeps
+    // reactivity alive so Svelte re-evaluates when props change.
   }
 
-  function buildLinks(
-    position: typeof shipPosition,
-    selected: typeof selectedContact,
-    munitions: CombatEntity[],
-    tacticalContacts: typeof contacts,
-  ): SpatialLink[] {
-    const result: SpatialLink[] = [];
-    if (selected) {
-      result.push({
-        id: "selected-track",
-        from: position,
-        to: selected.position,
-        color: "rgba(255, 90, 90, 0.6)",
-        label: "Current target",
-        arrow: true,
-      });
+  // ── Helpers ────────────────────────────────────────────────────────────
+  function iffColor(contact: TacticalContact): string {
+    const dip = contact.diplomaticState.toLowerCase();
+    if (dip.includes("hostile") || contact.threatLevel === "red") return "#e83030";
+    if (dip.includes("friend") || dip.includes("allied")) return "#00dd6a";
+    if (dip.includes("unknown") || !dip) return "#efa020";
+    return "#6888aa";
+  }
+
+  function iffKind(contact: TacticalContact): "hostile" | "friendly" | "unknown" | "neutral" {
+    const dip = contact.diplomaticState.toLowerCase();
+    if (dip.includes("hostile") || contact.threatLevel === "red" || contact.threatLevel === "orange") return "hostile";
+    if (dip.includes("friend") || dip.includes("allied")) return "friendly";
+    if (dip.includes("unknown") || dip === "") return "unknown";
+    return "neutral";
+  }
+
+  function isOrdnance(contact: TacticalContact): boolean {
+    return /torpedo|missile|ordnance/i.test(contact.classification);
+  }
+
+  function autoScaleFit(): number {
+    if (!flags.auto || !contacts.length) return scale;
+    let mx = 0;
+    for (const c of contacts) if (c.distance > mx) mx = c.distance;
+    const fit = scaleSteps.find((o) => o >= mx * 1.3);
+    return fit ?? scaleSteps[scaleSteps.length - 1];
+  }
+
+  function mod(value: number, divisor: number): number {
+    return ((value % divisor) + divisor) % divisor;
+  }
+
+  function pixelsPerMeter(activeScale: number): number {
+    return Math.min(dims.w, dims.h) / 2 / activeScale;
+  }
+
+  function worldToScreen(worldX: number, worldY: number, ppm: number, cx: number, cy: number) {
+    return {
+      x: cx + (worldX - viewCenter.x) * ppm,
+      y: cy - (worldY - viewCenter.y) * ppm,
+    };
+  }
+
+  function screenToWorld(screenX: number, screenY: number, ppm: number, cx: number, cy: number) {
+    return {
+      x: viewCenter.x + (screenX - cx) / ppm,
+      y: viewCenter.y - (screenY - cy) / ppm,
+    };
+  }
+
+  // ── Drawing ────────────────────────────────────────────────────────────
+  function draw() {
+    if (!canvas || !dims.w) return;
+    const dpr = window.devicePixelRatio || 1;
+    if (canvas.width !== dims.w * dpr || canvas.height !== dims.h * dpr) {
+      canvas.width = dims.w * dpr;
+      canvas.height = dims.h * dpr;
+    }
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.scale(dpr, dpr);
+    const w = dims.w;
+    const h = dims.h;
+    const cx = w / 2;
+    const cy = h / 2;
+    const t = Date.now();
+
+    const sc = autoScaleFit();
+    const ppm = pixelsPerMeter(sc);
+    const shipScreen = worldToScreen(shipPos.x, shipPos.y, ppm, cx, cy);
+
+    // Background
+    ctx.fillStyle = "#020207";
+    ctx.fillRect(0, 0, w, h);
+    const vig = ctx.createRadialGradient(cx, cy, 0, cx, cy, Math.max(w, h) * 0.8);
+    vig.addColorStop(0, "rgba(14,14,30,.05)");
+    vig.addColorStop(1, "rgba(0,0,4,.72)");
+    ctx.fillStyle = vig;
+    ctx.fillRect(0, 0, w, h);
+
+    // Starfield
+    for (const s of stars) {
+      ctx.beginPath();
+      ctx.arc(s.x * w, s.y * h, s.r, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(180,190,220,${s.a})`;
+      ctx.fill();
     }
 
-    for (const munition of munitions) {
-      const targetId = toStringValue(munition.target);
-      const target = tacticalContacts.find((contact) => contact.id === targetId);
-      if (!target) continue;
-      result.push({
-        id: `munition:${toStringValue(munition.id, targetId)}`,
-        from: toVec3(munition.position),
-        to: target.position,
-        color: "rgba(255, 166, 102, 0.34)",
-        dashed: true,
-        faint: true,
-        arrow: true,
-      });
+    // Grid
+    if (flags.grid) {
+      const gPx = (sc / 4) * ppm;
+      ctx.strokeStyle = "rgba(24,24,52,.55)";
+      ctx.lineWidth = 1;
+      if (gPx > 6) {
+        for (let x = mod(cx - viewCenter.x * ppm, gPx); x < w; x += gPx) {
+          ctx.beginPath();
+          ctx.moveTo(x, 0);
+          ctx.lineTo(x, h);
+          ctx.stroke();
+        }
+        for (let y = mod(cy + viewCenter.y * ppm, gPx); y < h; y += gPx) {
+          ctx.beginPath();
+          ctx.moveTo(0, y);
+          ctx.lineTo(w, y);
+          ctx.stroke();
+        }
+      }
+      ctx.strokeStyle = "rgba(40,40,80,.4)";
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(cx - 8, cy);
+      ctx.lineTo(cx + 8, cy);
+      ctx.moveTo(cx, cy - 8);
+      ctx.lineTo(cx, cy + 8);
+      ctx.stroke();
     }
-    return result;
+
+    // Range rings (50% & 100% of scale)
+    for (const [frac, col] of [
+      [0.5, "rgba(28,110,200,.14)"] as const,
+      [1.0, "rgba(28,110,200,.2)"] as const,
+    ]) {
+      const r = sc * frac * ppm;
+      ctx.beginPath();
+      ctx.arc(shipScreen.x, shipScreen.y, r, 0, Math.PI * 2);
+      ctx.strokeStyle = col;
+      ctx.lineWidth = frac === 1 ? 1.5 : 1;
+      ctx.stroke();
+      const labelM = sc * frac;
+      const lbl = labelM >= 1000 ? `${(labelM / 1000).toFixed(0)}km` : `${labelM.toFixed(0)}m`;
+      ctx.fillStyle = "rgba(40,100,200,.4)";
+      ctx.font = "9px 'JetBrains Mono', monospace";
+      ctx.textAlign = "left";
+      ctx.fillText(lbl, shipScreen.x + r * Math.cos(-Math.PI * 0.45) + 3, shipScreen.y + r * Math.sin(-Math.PI * 0.45));
+    }
+
+    // Radar sweep when pinging
+    if (pinging) {
+      const sa = (t / 420) % (Math.PI * 2);
+      ctx.save();
+      ctx.translate(shipScreen.x, shipScreen.y);
+      ctx.rotate(sa);
+      ctx.beginPath();
+      ctx.moveTo(0, 0);
+      ctx.arc(0, 0, sc * ppm, -0.4, 0);
+      ctx.closePath();
+      ctx.fillStyle = "rgba(0,190,130,.07)";
+      ctx.fill();
+      ctx.beginPath();
+      ctx.moveTo(0, 0);
+      ctx.lineTo(0, -Math.min(w, h) * 0.5);
+      ctx.strokeStyle = "rgba(0,200,140,.5)";
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    // Trajectory projection (dashed line along own-ship velocity)
+    if (flags.traj) {
+      const vx = shipVel.x;
+      const vy = shipVel.y;
+      const vmag = Math.sqrt(vx * vx + vy * vy);
+      if (vmag > 0.1) {
+        ctx.save();
+        ctx.setLineDash([3, 5]);
+        ctx.strokeStyle = "rgba(30,120,220,.35)";
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(shipScreen.x, shipScreen.y);
+        for (let i = 1; i <= 20; i++) {
+          const ft = (60 / 20) * i; // 60s projection in 20 steps
+          const sx = shipScreen.x + vx * ft * ppm;
+          const sy = shipScreen.y - vy * ft * ppm;
+          if (sx < -30 || sx > w + 30 || sy < -30 || sy > h + 30) break;
+          ctx.lineTo(sx, sy);
+        }
+        ctx.stroke();
+        ctx.setLineDash([]);
+        ctx.restore();
+      }
+    }
+
+    // Firing solution cone
+    if (flags.solutions && targeting.lockState === "locked" && lockedTargetId) {
+      const tgt = contacts.find((c) => c.id === lockedTargetId);
+      if (tgt) {
+        // In game coords, contact.position is relative to ship? Or absolute?
+        // tacticalData normalizes via contact.position from item.position.
+        // We draw relative to own ship, so use (tgt.position - shipPos).
+        const dx = tgt.position.x - shipPos.x;
+        const dy = tgt.position.y - shipPos.y;
+        const ang = Math.atan2(dx, -dy);
+        const conf = toNumber(bestSolution.confidence, targeting.lockQuality);
+        const ha = ((1 - conf) * 18 + 2) * Math.PI / 180;
+        const clen = Math.sqrt(dx * dx + dy * dy) * ppm;
+        ctx.save();
+        ctx.translate(shipScreen.x, shipScreen.y);
+        ctx.rotate(ang);
+        const cg = ctx.createLinearGradient(0, 0, 0, -clen);
+        cg.addColorStop(0, `rgba(240,150,0,${0.06 + conf * 0.09})`);
+        cg.addColorStop(1, "rgba(240,150,0,0)");
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.lineTo(Math.sin(ha) * clen, -clen);
+        ctx.lineTo(-Math.sin(ha) * clen, -clen);
+        ctx.closePath();
+        ctx.fillStyle = cg;
+        ctx.fill();
+        ctx.strokeStyle = "rgba(240,150,0,.28)";
+        ctx.lineWidth = 1;
+        ctx.setLineDash([3, 4]);
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.lineTo(Math.sin(ha) * clen, -clen);
+        ctx.moveTo(0, 0);
+        ctx.lineTo(-Math.sin(ha) * clen, -clen);
+        ctx.stroke();
+        ctx.setLineDash([]);
+        ctx.restore();
+      }
+    }
+
+    // Contacts
+    for (const c of contacts) {
+      const { x: sx, y: sy } = worldToScreen(c.position.x, c.position.y, ppm, cx, cy);
+      if (sx < -30 || sx > w + 30 || sy < -30 || sy > h + 30) continue;
+
+      const kind = iffKind(c);
+      const col = iffColor(c);
+      const al = 0.38 + c.confidence * 0.62;
+      const ordnance = isOrdnance(c);
+
+      // Velocity vector
+      if (flags.vectors && (c.velocity.x || c.velocity.y)) {
+        const vx = c.velocity.x * ppm * 14;
+        const vy = -c.velocity.y * ppm * 14;
+        if (Math.sqrt(vx * vx + vy * vy) > 2) {
+          ctx.strokeStyle = col;
+          ctx.lineWidth = 1;
+          ctx.globalAlpha = al * 0.5;
+          ctx.beginPath();
+          ctx.moveTo(sx, sy);
+          ctx.lineTo(sx + vx, sy + vy);
+          ctx.stroke();
+        }
+      }
+
+      ctx.globalAlpha = al;
+      ctx.strokeStyle = col;
+      ctx.fillStyle = col;
+
+      // IFF shape
+      if (kind === "hostile") {
+        if (ordnance) {
+          const ps = 5 + Math.sin(t / 200) * 0.5;
+          ctx.lineWidth = 1.5;
+          ctx.beginPath();
+          ctx.moveTo(sx, sy - ps);
+          ctx.lineTo(sx + ps, sy);
+          ctx.lineTo(sx, sy + ps);
+          ctx.lineTo(sx - ps, sy);
+          ctx.closePath();
+          ctx.stroke();
+          ctx.globalAlpha = al * 0.4;
+          ctx.fill();
+        } else {
+          ctx.lineWidth = 1.5;
+          ctx.beginPath();
+          ctx.rect(sx - 8, sy - 8, 16, 16);
+          ctx.stroke();
+          ctx.globalAlpha = al * 0.15;
+          ctx.fill();
+        }
+      } else if (kind === "friendly") {
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(sx, sy - 9);
+        ctx.lineTo(sx + 9, sy);
+        ctx.lineTo(sx, sy + 9);
+        ctx.lineTo(sx - 9, sy);
+        ctx.closePath();
+        ctx.stroke();
+        ctx.globalAlpha = al * 0.2;
+        ctx.fill();
+      } else if (kind === "unknown") {
+        ctx.lineWidth = 1;
+        ctx.setLineDash([2, 2]);
+        ctx.beginPath();
+        ctx.arc(sx, sy, 8, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.setLineDash([]);
+        ctx.globalAlpha = al;
+        ctx.font = "bold 8px 'JetBrains Mono', monospace";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText("?", sx, sy + 1);
+      } else {
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.arc(sx, sy, 6, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+      ctx.globalAlpha = 1;
+
+      // Targeting brackets
+      const isLocked = targeting.lockState === "locked" && c.id === lockedTargetId;
+      const isAcquiring = (targeting.lockState === "acquiring" || targeting.lockState === "tracking" || targeting.lockState === "designated") && c.id === (lockedTargetId || selectedId);
+      if (isLocked || isAcquiring) {
+        const pulse = isLocked ? 1 + Math.sin(t / 700) * 0.04 : 1;
+        const bs = (isLocked ? 14 : 18) * pulse;
+        const bc = isLocked ? "rgba(255,255,255,.88)" : "rgba(240,160,0,.7)";
+        ctx.strokeStyle = bc;
+        ctx.lineWidth = isLocked ? 1.5 : 1;
+        if (isAcquiring) ctx.setLineDash([3, 2]);
+        ctx.beginPath();
+        // Four corner brackets
+        ctx.moveTo(sx - bs, sy - bs + 5);
+        ctx.lineTo(sx - bs, sy - bs);
+        ctx.lineTo(sx - bs + 5, sy - bs);
+        ctx.moveTo(sx + bs - 5, sy - bs);
+        ctx.lineTo(sx + bs, sy - bs);
+        ctx.lineTo(sx + bs, sy - bs + 5);
+        ctx.moveTo(sx + bs, sy + bs - 5);
+        ctx.lineTo(sx + bs, sy + bs);
+        ctx.lineTo(sx + bs - 5, sy + bs);
+        ctx.moveTo(sx - bs + 5, sy + bs);
+        ctx.lineTo(sx - bs, sy + bs);
+        ctx.lineTo(sx - bs, sy + bs - 5);
+        ctx.stroke();
+        ctx.setLineDash([]);
+      }
+
+      // Labels
+      ctx.globalAlpha = al * 0.9;
+      const labelCol: Record<string, string> = {
+        hostile: "#ff7070",
+        friendly: "#44ff99",
+        unknown: "#ffcc66",
+        neutral: "#aabbc8",
+      };
+      ctx.fillStyle = labelCol[kind] || "#aaa";
+      ctx.font = "600 9px 'JetBrains Mono', monospace";
+      ctx.textAlign = "left";
+      ctx.textBaseline = "top";
+      ctx.fillText(c.id, sx + 14, sy - 4);
+      ctx.font = "9px 'JetBrains Mono', monospace";
+      ctx.globalAlpha = al * 0.55;
+      const dStr = c.distance >= 1000 ? `${(c.distance / 1000).toFixed(0)}km` : `${Math.round(c.distance)}m`;
+      ctx.fillText(`${String(Math.round(c.bearing)).padStart(3, "0")}° ${dStr}`, sx + 14, sy + 6);
+      ctx.globalAlpha = 1;
+    }
+
+    // Player ship
+    ctx.save();
+    ctx.translate(shipScreen.x, shipScreen.y);
+    const hdgRad = (shipHeading - 90) * Math.PI / 180;
+
+    // Velocity vector
+    if (flags.vectors) {
+      const vx = shipVel.x * ppm * 13;
+      const vy = -shipVel.y * ppm * 13;
+      if (Math.sqrt(vx * vx + vy * vy) > 2) {
+        ctx.strokeStyle = "#00dd6a";
+        ctx.lineWidth = 2;
+        ctx.globalAlpha = 0.75;
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.lineTo(vx, vy);
+        ctx.stroke();
+        ctx.globalAlpha = 1;
+      }
+    }
+
+    // Heading line
+    ctx.strokeStyle = "rgba(30,140,255,.65)";
+    ctx.lineWidth = 1.5;
+    ctx.globalAlpha = 0.7;
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.lineTo(Math.cos(hdgRad) * 38, Math.sin(hdgRad) * 38);
+    ctx.stroke();
+    ctx.globalAlpha = 1;
+
+    // Ship triangle
+    ctx.rotate(hdgRad + Math.PI / 2);
+    ctx.fillStyle = "#1e8cff";
+    ctx.beginPath();
+    ctx.moveTo(0, -10);
+    ctx.lineTo(-6, 8);
+    ctx.lineTo(6, 8);
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle = "rgba(120,180,255,.8)";
+    ctx.lineWidth = 1;
+    ctx.stroke();
+    ctx.restore();
+
+    // Compass rose
+    const cr = 22;
+    const cxR = w - 34;
+    const cyR = 34;
+    ctx.save();
+    ctx.translate(cxR, cyR);
+    ctx.strokeStyle = "#2e2e50";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(0, 0, cr, 0, Math.PI * 2);
+    ctx.stroke();
+    const dirs = ["N", "E", "S", "W"];
+    dirs.forEach((d, i) => {
+      const a = i * Math.PI / 2;
+      const r = cr - 7;
+      ctx.fillStyle = d === "N" ? "#4499ff" : "#3a3a52";
+      ctx.font = "bold 7px 'JetBrains Mono', monospace";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(d, Math.cos(a) * r, Math.sin(a) * r);
+    });
+    const hr = (shipHeading - 90) * Math.PI / 180;
+    ctx.strokeStyle = "#4499ff";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.lineTo(Math.cos(hr) * cr * 0.72, Math.sin(hr) * cr * 0.72);
+    ctx.stroke();
+    ctx.fillStyle = "#4499ff";
+    ctx.font = "600 7px 'JetBrains Mono', monospace";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(`${String(Math.round(shipHeading < 0 ? shipHeading + 360 : shipHeading)).padStart(3, "0")}°`, 0, 0);
+    ctx.restore();
+
+    // Scale label
+    const sl = sc >= 1000 ? `${(sc / 1000).toFixed(0)} km radius` : `${sc} m radius`;
+    ctx.fillStyle = "#3a3a52";
+    ctx.font = "9px 'JetBrains Mono', monospace";
+    ctx.textAlign = "left";
+    ctx.fillText(sl, 8, h - 8);
   }
 
-  function deriveInitialRadius(tacticalContacts: typeof contacts, weaponMounts: typeof mounts) {
-    const farthestContact = tacticalContacts.reduce((max, contact) => Math.max(max, contact.distance), 0);
-    const farthestRange = weaponMounts.reduce((max, mount) => Math.max(max, mount.range || 0), 0);
-    return Math.max(15_000, Math.min(500_000, Math.max(farthestContact, farthestRange) * 1.1 || 40_000));
+  // ── Toolbar actions ────────────────────────────────────────────────────
+  function zoom(dir: 1 | -1) {
+    const i = scaleSteps.findIndex((v) => v === scale);
+    const pi = i === -1 ? scaleSteps.findIndex((v) => v >= scale) : i;
+    // "+" = zoom in = smaller scale. "−" = zoom out = larger scale.
+    const next = dir > 0 ? pi - 1 : pi + 1;
+    if (next >= 0 && next < scaleSteps.length) {
+      scale = scaleSteps[next];
+      flags = { ...flags, auto: false };
+    }
   }
 
-  async function lockSelected(id = $selectedTacticalTargetId) {
-    if (!id) return;
+  function zoomAt(dir: 1 | -1, screenX = dims.w / 2, screenY = dims.h / 2) {
+    const i = scaleSteps.findIndex((v) => v === scale);
+    const pi = i === -1 ? scaleSteps.findIndex((v) => v >= scale) : i;
+    const next = dir > 0 ? pi - 1 : pi + 1;
+    if (next < 0 || next >= scaleSteps.length) return;
+
+    const currentPpm = pixelsPerMeter(scale);
+    const anchor = screenToWorld(screenX, screenY, currentPpm, dims.w / 2, dims.h / 2);
+    const nextScale = scaleSteps[next];
+    const nextPpm = pixelsPerMeter(nextScale);
+
+    scale = nextScale;
+    flags = { ...flags, auto: false };
+    viewCenter = {
+      x: anchor.x - (screenX - dims.w / 2) / nextPpm,
+      y: anchor.y + (screenY - dims.h / 2) / nextPpm,
+    };
+  }
+
+  function toggleFlag(k: keyof typeof flags) {
+    const next = !flags[k];
+    flags = { ...flags, [k]: next };
+    if (k === "auto" && next) {
+      viewCenter = { x: shipPos.x, y: shipPos.y };
+    }
+  }
+
+  function recenterOnShip() {
+    viewCenter = { x: shipPos.x, y: shipPos.y };
+  }
+
+  async function onLockSelected() {
+    if (!selectedId || lockBusy) return;
     lockBusy = true;
     try {
-      selectedTacticalTargetId.set(id);
-      await lockTarget(id);
+      await lockTarget(selectedId);
     } finally {
       lockBusy = false;
     }
   }
+
+  // Canvas click → select nearest contact
+  function onCanvasClick(e: MouseEvent) {
+    if (suppressClick) {
+      suppressClick = false;
+      return;
+    }
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+    const cx = dims.w / 2;
+    const cy = dims.h / 2;
+    const sc = autoScaleFit();
+    const ppm = pixelsPerMeter(sc);
+
+    let closest: { id: string; d: number } | null = null;
+    for (const c of contacts) {
+      const { x: sx, y: sy } = worldToScreen(c.position.x, c.position.y, ppm, cx, cy);
+      const dx = sx - mx;
+      const dy = sy - my;
+      const d = Math.sqrt(dx * dx + dy * dy);
+      if (d < 18 && (!closest || d < closest.d)) {
+        closest = { id: c.id, d };
+      }
+    }
+    if (closest) {
+      selectedTacticalTargetId.set(closest.id);
+    }
+  }
+
+  function pointerToLocal(event: MouseEvent | PointerEvent | WheelEvent) {
+    if (!canvas) return { x: 0, y: 0 };
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
+  }
+
+  function onPointerDown(event: PointerEvent) {
+    if (!canvas) return;
+    pointerId = event.pointerId;
+    pointerDown = true;
+    dragMoved = false;
+    const point = pointerToLocal(event);
+    dragStart = point;
+    dragOrigin = { ...viewCenter };
+    canvas.setPointerCapture(event.pointerId);
+  }
+
+  function onPointerMove(event: PointerEvent) {
+    if (!pointerDown || pointerId !== event.pointerId) return;
+    const point = pointerToLocal(event);
+    const dx = point.x - dragStart.x;
+    const dy = point.y - dragStart.y;
+    if (!dragMoved && Math.hypot(dx, dy) > 4) {
+      dragMoved = true;
+    }
+    if (!dragMoved) return;
+
+    const ppm = pixelsPerMeter(scale);
+    viewCenter = {
+      x: dragOrigin.x - dx / ppm,
+      y: dragOrigin.y + dy / ppm,
+    };
+    if (flags.auto) {
+      flags = { ...flags, auto: false };
+    }
+  }
+
+  function releasePointer(event: PointerEvent) {
+    if (!pointerDown || pointerId !== event.pointerId) return;
+    if (canvas?.hasPointerCapture(event.pointerId)) {
+      canvas.releasePointerCapture(event.pointerId);
+    }
+    pointerDown = false;
+    pointerId = null;
+    suppressClick = dragMoved;
+  }
+
+  function onWheel(event: WheelEvent) {
+    event.preventDefault();
+    const point = pointerToLocal(event);
+    zoomAt(event.deltaY < 0 ? 1 : -1, point.x, point.y);
+  }
 </script>
 
-<Panel title="Tactical Map" domain="sensor" priority="primary" className="tactical-map-panel">
-  <div class="map-wrapper" class:lock-busy={lockBusy}>
-    <SpatialMapCanvas
-      mode="tactical"
-      {tracks}
-      {rings}
-      {links}
-      {legendItems}
-      ownshipId="ownship"
-      selectedId={$selectedTacticalTargetId}
-      {initialRadius}
-      caption="Scroll to zoom · drag to pan · click contact to select · Lock to acquire targeting"
-      selectionActionLabel={lockBusy ? "Locking…" : "Lock"}
-      selectionActionDisabled={!$selectedTacticalTargetId || lockBusy}
-      on:select={(event) => selectedTacticalTargetId.set(event.detail.id)}
-      on:activate={(event) => lockSelected(event.detail.id)}
-    />
+<Panel title="Tactical Display" domain="sensor" priority="primary" className="tactical-map-panel">
+  <div class="map-root">
+    <!-- Toolbar -->
+    <div class="toolbar">
+      <span class="tb-lbl">SCALE</span>
+      <button class="tb-btn small" on:click={() => zoom(-1)} title="Zoom out">−</button>
+      <button class="tb-btn small" on:click={() => zoom(1)} title="Zoom in">+</button>
+      <div class="tb-sep"></div>
+      <button class="tb-btn small" class:on={flags.vectors} on:click={() => toggleFlag("vectors")} title="Toggle velocity vectors">V</button>
+      <button class="tb-btn small" class:on={flags.grid} on:click={() => toggleFlag("grid")} title="Toggle grid">G</button>
+      <button class="tb-btn small" class:on={flags.solutions} on:click={() => toggleFlag("solutions")} title="Toggle firing solution cone">S</button>
+      <button class="tb-btn small" class:on={flags.traj} on:click={() => toggleFlag("traj")} title="Toggle trajectory projection">T</button>
+      <button class="tb-btn small" class:on={flags.auto} on:click={() => toggleFlag("auto")} title="Auto-scale to contacts">A</button>
+      <button class="tb-btn small" on:click={recenterOnShip} title="Recenter camera on own ship">Ship</button>
+
+      <div class="tb-spacer"></div>
+
+      <button
+        class="tb-btn"
+        disabled={!selectedId || lockBusy}
+        title={!selectedId ? "Select a contact to lock" : lockBusy ? "Locking…" : "Lock selected as target"}
+        on:click={onLockSelected}
+      >
+        {lockBusy ? "LOCKING…" : "LOCK"}
+      </button>
+    </div>
+
+    <div bind:this={container} class="canvas-wrap" class:lock-busy={lockBusy} class:dragging={pointerDown && dragMoved}>
+      <canvas
+        bind:this={canvas}
+        on:click={onCanvasClick}
+        on:pointerdown={onPointerDown}
+        on:pointermove={onPointerMove}
+        on:pointerup={releasePointer}
+        on:pointercancel={releasePointer}
+        on:wheel={onWheel}
+      ></canvas>
+      {#if pinging}
+        <div class="ping-ring"></div>
+      {/if}
+    </div>
   </div>
 </Panel>
 
 <style>
-  .map-wrapper {
-    position: relative;
-    display: contents;
+  :global(.tactical-map-panel .panel-body) {
+    display: flex;
+    min-height: 0;
+    overflow: hidden;
+    padding: 0;
   }
 
-  .map-wrapper.lock-busy::after {
+  .map-root {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--bd-subtle);
+    background: rgba(0, 0, 0, 0.2);
+    flex-shrink: 0;
+    flex-wrap: wrap;
+  }
+
+  .tb-lbl {
+    font-size: 0.55rem;
+    color: var(--tx-dim);
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .tb-btn {
+    background: transparent;
+    border: 1px solid var(--bd-default);
+    color: var(--tx-sec);
+    padding: 3px 8px;
+    border-radius: 2px;
+    font-family: var(--font-mono);
+    font-size: 0.63rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: all 0.1s ease;
+  }
+
+  .tb-btn.small {
+    padding: 2px 7px;
+    font-size: 0.59rem;
+  }
+
+  .tb-btn:hover:not(:disabled) {
+    color: var(--tx-bright);
+    border-color: var(--bd-focus);
+  }
+
+  .tb-btn.on {
+    color: var(--tx-bright);
+    background: rgba(255, 255, 255, 0.07);
+    border-color: var(--bd-active);
+  }
+
+  .tb-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .tb-sep {
+    width: 1px;
+    height: 12px;
+    background: var(--bd-default);
+    margin: 0 2px;
+  }
+
+  .tb-spacer { flex: 1; }
+
+  .canvas-wrap {
+    flex: 1;
+    min-height: 320px;
+    position: relative;
+    background: #020207;
+    cursor: grab;
+    overflow: hidden;
+    touch-action: none;
+  }
+
+  .canvas-wrap.dragging {
+    cursor: grabbing;
+  }
+
+  .canvas-wrap canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+
+  .ping-ring {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    border: 2px solid var(--info);
+    border-radius: 2px;
+    animation: pingRing 0.85s ease-out forwards;
+  }
+
+  .canvas-wrap.lock-busy::after {
     content: "";
     position: absolute;
     inset: 0;
     border: 2px solid rgba(var(--tier-accent-rgb), 0.5);
-    border-radius: var(--radius-sm);
+    border-radius: 2px;
     pointer-events: none;
-    animation: lock-pulse 0.7s ease-in-out infinite;
+    animation: pulse 0.7s ease-in-out infinite;
   }
 
-  @keyframes lock-pulse {
-    0%, 100% { opacity: 0.3; }
-    50% { opacity: 0.9; }
+  @media (max-width: 720px) {
+    .canvas-wrap {
+      min-height: 260px;
+    }
   }
 </style>

--- a/gui-svelte/src/components/tactical/TacticalSupportDrawer.svelte
+++ b/gui-svelte/src/components/tactical/TacticalSupportDrawer.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import { tier } from "../../lib/stores/tier.js";
+
+  import FiringSolutionDisplay from "./FiringSolutionDisplay.svelte";
+  import SubsystemSelector from "./SubsystemSelector.svelte";
+  import ThreatBoard from "./ThreatBoard.svelte";
+  import FireAuthorization from "./FireAuthorization.svelte";
+  import EcmControlPanel from "./EcmControlPanel.svelte";
+  import EccmControlPanel from "./EccmControlPanel.svelte";
+  import MultiTrackPanel from "./MultiTrackPanel.svelte";
+  import TargetAssessment from "./TargetAssessment.svelte";
+
+  import SensorSweepGame from "../games/SensorSweepGame.svelte";
+  import TargetingLockGame from "../games/TargetingLockGame.svelte";
+  import WeaponsChargeGame from "../games/WeaponsChargeGame.svelte";
+  import PdcThreatGame from "../games/PdcThreatGame.svelte";
+  import EcmFrequencyGame from "../games/EcmFrequencyGame.svelte";
+  import MunitionConfigGame from "../games/MunitionConfigGame.svelte";
+
+  type DrawerTab = "analysis" | "control" | "ew" | "arcade" | null;
+
+  let activeTab: DrawerTab = null;
+  let openedArcadeTools = false;
+
+  $: arcadeTier = $tier === "arcade";
+  $: if (arcadeTier && !openedArcadeTools) {
+    activeTab = "arcade";
+    openedArcadeTools = true;
+  }
+
+  function toggle(tab: Exclude<DrawerTab, null>) {
+    activeTab = activeTab === tab ? null : tab;
+  }
+</script>
+
+<div class="support-drawer" class:open={activeTab !== null}>
+  <div class="toolbar">
+    <button class:active={activeTab === "analysis"} type="button" on:click={() => toggle("analysis")}>Analysis</button>
+    <button class:active={activeTab === "control"} type="button" on:click={() => toggle("control")}>Control</button>
+    <button class:active={activeTab === "ew"} type="button" on:click={() => toggle("ew")}>EW</button>
+    {#if arcadeTier}
+      <button class:active={activeTab === "arcade"} type="button" on:click={() => toggle("arcade")}>Arcade</button>
+    {/if}
+  </div>
+
+  {#if activeTab !== null}
+    <div class="drawer-body">
+      {#if activeTab === "analysis"}
+        <ThreatBoard />
+        <TargetAssessment />
+        <FiringSolutionDisplay />
+        <SubsystemSelector />
+      {:else if activeTab === "control"}
+        <FireAuthorization />
+        <MultiTrackPanel />
+      {:else if activeTab === "ew"}
+        <EcmControlPanel />
+        <EccmControlPanel />
+      {:else if activeTab === "arcade"}
+        <SensorSweepGame />
+        <TargetingLockGame />
+        <WeaponsChargeGame />
+        <PdcThreatGame />
+        <EcmFrequencyGame />
+        <MunitionConfigGame />
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .support-drawer {
+    display: grid;
+    gap: var(--space-xs);
+    min-height: 34px;
+  }
+
+  .toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding-top: var(--space-xs);
+    border-top: 1px solid var(--bd-subtle);
+  }
+
+  .toolbar button.active {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+    color: var(--text-primary);
+  }
+
+  .drawer-body {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: var(--space-xs);
+    overflow: auto;
+    max-height: 360px;
+    padding-bottom: var(--space-xs);
+  }
+</style>

--- a/gui-svelte/src/components/tactical/TargetingDisplay.svelte
+++ b/gui-svelte/src/components/tactical/TargetingDisplay.svelte
@@ -1,4 +1,14 @@
 <script lang="ts">
+  /**
+   * TargetingDisplay — prototype-aligned lock/solution card.
+   *
+   * Sections (top → bottom):
+   *   1. Lock state card: pulsing status dot + LOCKED/ACQUIRING/UNLOCKED text, track-quality %.
+   *   2. Locked target block: target id/name + 6-cell k/v grid (Class, IFF, Distance, Bearing, Closure, Conf).
+   *   3. Firing solution block: SVG circular arc gauge (stroke-dasharray = conf%) paired with TOF/TTI readouts.
+   * Data wiring preserved: getTargetingSummary, getBestWeaponSolution, selectedTacticalTargetId,
+   * lockTarget / unlockTarget actions. Solution polled every 2.5s via get_target_solution.
+   */
   import { onMount } from "svelte";
   import Panel from "../layout/Panel.svelte";
   import { gameState } from "../../lib/stores/gameState.js";
@@ -7,27 +17,34 @@
   import {
     asRecord,
     extractShipState,
-    formatDistance,
-    formatDuration,
+    findTacticalContact,
+    getBestWeaponSolution,
     getLockedTargetId,
     getTargetingSummary,
     toNumber,
     toStringValue,
+    type TacticalContact,
   } from "./tacticalData.js";
   import { lockTarget, unlockTarget } from "./tacticalActions.js";
 
-  const stages = ["Acquisition", "Weapons Lock", "Solution", "Ready to Fire"];
-
-  let solution: Record<string, unknown> = {};
   let pollHandle: number | null = null;
+  let solution: Record<string, unknown> = {};
   let locking = false;
 
   $: ship = extractShipState($gameState);
   $: targeting = getTargetingSummary(ship);
   $: lockedTargetId = getLockedTargetId(ship);
   $: targetId = $selectedTacticalTargetId || lockedTargetId;
-  $: solutionQuality = Math.max(targeting.lockQuality, toNumber(solution.lock_quality, 0));
-  $: progressWidth = `${Math.round(solutionQuality * 100)}%`;
+  $: contact = targetId ? findTacticalContact(ship, targetId) : null;
+  $: bestSolution = getBestWeaponSolution(ship);
+
+  // Prefer polled solution (freshest), fall back to tick-embedded solution.
+  $: activeSolution = Object.keys(solution).length > 0 ? solution : bestSolution;
+  $: confidence = clamp01(toNumber(activeSolution.confidence, targeting.lockQuality));
+  $: confPct = Math.round(confidence * 100);
+  $: trackQ = Math.round(targeting.trackQuality * 100);
+  $: tof = toNumber(activeSolution.time_of_flight, NaN);
+  $: tti = toNumber(activeSolution.time_to_cpa, toNumber(activeSolution.time_to_impact, NaN));
 
   onMount(() => {
     void refreshSolution();
@@ -42,7 +59,6 @@
       solution = {};
       return;
     }
-
     try {
       const response = await wsClient.sendShipCommand("get_target_solution", {});
       solution = asRecord(response) ?? {};
@@ -66,44 +82,184 @@
     await unlockTarget();
     solution = {};
   }
+
+  function clamp01(n: number): number {
+    if (!Number.isFinite(n)) return 0;
+    return Math.max(0, Math.min(1, n));
+  }
+
+  function lockColor(state: string): string {
+    switch (state) {
+      case "locked":    return "var(--nom)";
+      case "tracking":  return "var(--info)";
+      case "acquiring": return "var(--warn)";
+      case "designated": return "var(--warn)";
+      default:          return "var(--tx-dim)";
+    }
+  }
+
+  function lockBg(state: string): string {
+    return state === "locked" ? "rgba(0, 221, 106, 0.05)" : "rgba(0, 0, 0, 0.18)";
+  }
+
+  function lockBorder(state: string): string {
+    const col = lockColor(state);
+    // Semi-transparent variant of state color
+    if (col === "var(--nom)") return "rgba(0, 221, 106, 0.35)";
+    if (col === "var(--info)") return "rgba(30, 140, 255, 0.35)";
+    if (col === "var(--warn)") return "rgba(239, 160, 32, 0.35)";
+    return "var(--bd-subtle)";
+  }
+
+  function confColor(pct: number): string {
+    if (pct > 70) return "var(--nom)";
+    if (pct > 45) return "var(--warn)";
+    return "var(--crit)";
+  }
+
+  function iffTagFor(c: TacticalContact): string {
+    const d = c.diplomaticState.toLowerCase();
+    if (d.includes("hostile") || c.threatLevel === "red" || c.threatLevel === "orange") return "HOT";
+    if (d.includes("friend") || d.includes("allied")) return "FRD";
+    if (d.includes("unknown") || d === "") return "UNK";
+    return "NEU";
+  }
+
+  function distStr(m: number): string {
+    if (!Number.isFinite(m)) return "--";
+    if (m >= 1000) return `${(m / 1000).toFixed(1)} km`;
+    return `${Math.round(m)} m`;
+  }
+
+  // Arc gauge geometry — matches prototype: r=28, stroke=7, circumference≈175.9
+  const ARC_R = 28;
+  const ARC_CIRC = 2 * Math.PI * ARC_R; // ≈ 175.929
+  $: arcDash = `${confidence * ARC_CIRC} ${ARC_CIRC}`;
 </script>
 
-<Panel title="Targeting Display" domain="weapons" priority={targeting.lockState === "locked" ? "primary" : "secondary"} className="targeting-display-panel">
+<Panel
+  title="Targeting Display"
+  domain="weapons"
+  priority={targeting.lockState === "locked" ? "primary" : "secondary"}
+  className="targeting-display-panel"
+>
   <div class="shell">
-    <div class="header">
-      <div>
-        <div class="label">Target</div>
-        <strong>{targetId || "NO TARGET"}</strong>
-      </div>
-      <div class="badge">{Math.round(solutionQuality * 100)}%</div>
-    </div>
-
-    <div class="pipeline">
-      {#each stages as stage, index}
-        <div class="stage" class:active={index < targeting.stage} class:current={index === Math.max(0, targeting.stage - 1)}>
-          <span>{stage}</span>
+    <!-- Lock state header -->
+    <div
+      class="lock-card"
+      style="background: {lockBg(targeting.lockState)}; border-color: {lockBorder(targeting.lockState)};"
+    >
+      <span
+        class="lock-dot"
+        class:pulsing={targeting.lockState === "acquiring" || targeting.lockState === "tracking"}
+        class:locked={targeting.lockState === "locked"}
+        style="background: {lockColor(targeting.lockState)};"
+        aria-hidden="true"
+      ></span>
+      <div class="lock-main">
+        <div class="field-label">Lock State</div>
+        <div class="lock-state-txt" style="color: {lockColor(targeting.lockState)};">
+          {targeting.lockState.toUpperCase()}
         </div>
-      {/each}
+      </div>
+      <div class="lock-track">
+        <div class="field-label">Track Q</div>
+        <div class="lock-track-val" style="color: {trackQ > 75 ? 'var(--nom)' : 'var(--warn)'};">
+          {trackQ}%
+        </div>
+      </div>
     </div>
 
-    <div class="confidence-track">
-      <div class="confidence-fill" style={`width: ${progressWidth};`}></div>
-    </div>
+    <!-- Locked target block -->
+    {#if contact}
+      <div class="block">
+        <div class="divider">
+          <span>Locked Target</span>
+          <span class="divider-line"></span>
+        </div>
+        <div class="target-id">{contact.id} — {contact.name.toUpperCase()}</div>
+        <div class="kv-grid">
+          <div class="kv"><span>Class</span><strong>{contact.classification.toUpperCase()}</strong></div>
+          <div class="kv"><span>IFF</span><strong>{iffTagFor(contact)}</strong></div>
+          <div class="kv">
+            <span>Distance</span>
+            <strong>{distStr(contact.distance)}</strong>
+          </div>
+          <div class="kv">
+            <span>Bearing</span>
+            <strong>{String(Math.round(contact.bearing < 0 ? contact.bearing + 360 : contact.bearing)).padStart(3, "0")}°</strong>
+          </div>
+          <div class="kv">
+            <span>Closure</span>
+            <strong class:crit={Math.abs(contact.closureRate) > 150}>
+              {(contact.closureRate > 0 ? "+" : "") + contact.closureRate.toFixed(1)} m/s
+            </strong>
+          </div>
+          <div class="kv"><span>Conf.</span><strong>{Math.round(contact.confidence * 100)}%</strong></div>
+        </div>
+      </div>
+    {:else}
+      <div class="empty">No target designated.</div>
+    {/if}
 
-    <div class="metrics">
-      <div class="metric"><span>Lock state</span><strong>{targeting.lockState.toUpperCase()}</strong></div>
-      <div class="metric"><span>Range</span><strong>{formatDistance(toNumber(solution.range, NaN))}</strong></div>
-      <div class="metric"><span>ETA</span><strong>{formatDuration(toNumber(solution.time_to_cpa, toNumber(solution.time_of_flight, NaN)))}</strong></div>
-      <div class="metric"><span>Subsystem</span><strong>{toStringValue(solution.target_subsystem, targeting.subsystem).toUpperCase()}</strong></div>
-    </div>
+    <!-- Firing solution block -->
+    {#if contact && (Object.keys(activeSolution).length > 0 || confidence > 0)}
+      <div class="block">
+        <div class="divider">
+          <span>Firing Solution</span>
+          <span class="divider-line"></span>
+        </div>
+        <div class="solution-row">
+          <svg class="arc-gauge" width="68" height="68" viewBox="0 0 68 68">
+            <circle cx="34" cy="34" r={ARC_R} fill="none" stroke="var(--bd-active)" stroke-width="7" />
+            <circle
+              cx="34"
+              cy="34"
+              r={ARC_R}
+              fill="none"
+              stroke={confColor(confPct)}
+              stroke-width="7"
+              stroke-linecap="round"
+              stroke-dasharray={arcDash}
+              transform="rotate(-90 34 34)"
+              style="transition: stroke-dasharray 0.45s ease, stroke 0.4s ease;"
+            />
+            <text
+              x="34"
+              y="38"
+              text-anchor="middle"
+              font-size="13"
+              font-weight="700"
+              font-family="var(--font-mono)"
+              fill={confColor(confPct)}
+            >{confPct}%</text>
+          </svg>
+          <div class="sol-kvs">
+            <div class="kv-lg">
+              <span>Time of Flight</span>
+              <strong>{Number.isFinite(tof) ? `${tof.toFixed(2)} s` : "—"}</strong>
+            </div>
+            <div class="kv-lg">
+              <span>Time to Impact</span>
+              <strong class:crit={Number.isFinite(tti) && tti < 10}>
+                {Number.isFinite(tti) ? `${tti.toFixed(1)} s` : "—"}
+              </strong>
+            </div>
+          </div>
+        </div>
+      </div>
+    {/if}
 
+    <!-- Actions -->
     <div class="actions">
       <button
+        class="btn"
         disabled={!targetId || locking}
         title={!targetId ? "Select a contact first" : locking ? "Acquiring lock…" : "Acquire targeting lock"}
         on:click={lockSelectedTarget}
       >{locking ? "LOCKING…" : "LOCK TARGET"}</button>
       <button
+        class="btn"
         disabled={!lockedTargetId}
         title={!lockedTargetId ? "No active lock" : "Release targeting lock"}
         on:click={clearTargetLock}
@@ -114,87 +270,221 @@
 
 <style>
   .shell {
-    display: grid;
-    gap: var(--space-sm);
-    padding: var(--space-sm);
-  }
-
-  .header,
-  .actions {
     display: flex;
-    justify-content: space-between;
-    gap: var(--space-sm);
+    flex-direction: column;
+    gap: 9px;
+    padding: 10px;
+    height: 100%;
+    overflow-y: auto;
+  }
+
+  /* ── Lock state header ── */
+  .lock-card {
+    display: flex;
     align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    border-radius: 2px;
+    border: 1px solid;
   }
 
-  .label,
-  .metric span {
-    font-size: var(--font-size-xs);
-    color: var(--text-secondary);
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
+  .lock-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
   }
 
-  strong,
-  .badge {
+  .lock-dot.locked {
+    box-shadow: 0 0 9px rgba(0, 221, 106, 0.7);
+  }
+
+  .lock-dot.pulsing {
+    animation: pulse 1.2s ease-in-out infinite;
+  }
+
+  .lock-main {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .lock-track {
+    text-align: right;
+  }
+
+  .field-label {
+    font-size: 0.52rem;
+    color: var(--tx-dim);
     font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
   }
 
-  .badge {
-    padding: 6px 10px;
-    border-radius: 999px;
-    border: 1px solid rgba(var(--tier-accent-rgb), 0.4);
+  .lock-state-txt {
+    font-size: 0.82rem;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
   }
 
-  .pipeline {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+  .lock-track-val {
+    font-size: 0.82rem;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* ── Target/solution block shell ── */
+  .block {
+    display: flex;
+    flex-direction: column;
     gap: 6px;
   }
 
-  .stage {
-    padding: 8px;
-    border-radius: var(--radius-sm);
-    background: rgba(255, 255, 255, 0.025);
-    border: 1px solid var(--border-subtle);
+  .divider {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.52rem;
+    font-family: var(--font-mono);
+    color: var(--tx-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
   }
 
-  .stage.active {
-    border-color: rgba(var(--tier-accent-rgb), 0.35);
-    background: rgba(var(--tier-accent-rgb), 0.1);
+  .divider-line {
+    flex: 1;
+    height: 1px;
+    background: var(--bd-subtle);
   }
 
-  .stage.current {
-    box-shadow: inset 0 0 0 1px rgba(var(--tier-accent-rgb), 0.35);
+  .target-id {
+    font-size: 0.78rem;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    color: #ff8080;
+    letter-spacing: 0.03em;
   }
 
-  .stage span {
-    font-size: 0.72rem;
+  /* ── K/V grid (2 cols) ── */
+  .kv-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 5px 10px;
   }
 
-  .confidence-track {
-    height: 10px;
-    border-radius: 999px;
-    background: var(--bg-input);
+  .kv {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+  }
+
+  .kv span {
+    font-size: 0.5rem;
+    color: var(--tx-dim);
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .kv strong {
+    font-size: 0.66rem;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    color: var(--tx-primary);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
     overflow: hidden;
+    text-overflow: ellipsis;
   }
 
-  .confidence-fill {
-    height: 100%;
-    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.3), var(--tier-accent));
+  .kv strong.crit,
+  .kv-lg strong.crit {
+    color: var(--crit);
   }
 
-  .metrics {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: var(--space-sm);
+  /* ── Firing solution row ── */
+  .solution-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
   }
 
-  .metric {
-    display: grid;
-    gap: 4px;
-    padding: 8px;
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--border-subtle);
+  .arc-gauge {
+    flex-shrink: 0;
+  }
+
+  .sol-kvs {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+  }
+
+  .kv-lg {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .kv-lg span {
+    font-size: 0.52rem;
+    color: var(--tx-dim);
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .kv-lg strong {
+    font-size: 0.78rem;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    color: var(--tx-primary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* ── Empty ── */
+  .empty {
+    padding: 18px 10px;
+    text-align: center;
+    font-size: var(--font-size-xs);
+    color: var(--tx-dim);
+    font-family: var(--font-mono);
+    border: 1px dashed var(--bd-subtle);
+    border-radius: 2px;
+  }
+
+  /* ── Actions ── */
+  .actions {
+    display: flex;
+    gap: 6px;
+    margin-top: auto;
+  }
+
+  .btn {
+    flex: 1;
+    padding: 6px 10px;
+    background: transparent;
+    border: 1px solid var(--bd-default);
+    border-radius: 2px;
+    color: var(--tx-sec);
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s;
+  }
+
+  .btn:hover:not(:disabled) {
+    color: var(--tx-bright);
+    border-color: var(--bd-focus);
+  }
+
+  .btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
   }
 </style>

--- a/gui-svelte/src/components/tactical/WeaponMountList.svelte
+++ b/gui-svelte/src/components/tactical/WeaponMountList.svelte
@@ -1,0 +1,411 @@
+<script lang="ts">
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { selectedTacticalTargetId } from "../../lib/stores/tacticalUi.js";
+  import {
+    extractShipState,
+    getBestWeaponSolution,
+    getLauncherInventory,
+    getLockedTargetId,
+    getTargetingSummary,
+    getWeaponMounts,
+    toNumber,
+    type WeaponMountState,
+  } from "./tacticalData.js";
+  import { fireRailgun, launchDirectMunition } from "./tacticalActions.js";
+
+  let firingIds = new Set<string>();
+
+  $: ship = extractShipState($gameState);
+  $: mounts = getWeaponMounts(ship);
+  $: targeting = getTargetingSummary(ship);
+  $: lockedTargetId = getLockedTargetId(ship);
+  $: effectiveTarget = $selectedTacticalTargetId || lockedTargetId;
+  $: solution = getBestWeaponSolution(ship);
+  $: solutionConfidence = clamp01(toNumber(solution.confidence, targeting.lockQuality));
+  $: launchers = getLauncherInventory(ship);
+
+  $: displayMounts = buildDisplayMounts(mounts, launchers);
+
+  function clamp01(n: number): number {
+    if (!Number.isFinite(n)) return 0;
+    return Math.max(0, Math.min(1, n));
+  }
+
+  function buildDisplayMounts(
+    existing: WeaponMountState[],
+    inv: ReturnType<typeof getLauncherInventory>,
+  ): WeaponMountState[] {
+    const list = [...existing];
+    const hasType = (t: WeaponMountState["weaponType"]) => list.some((mount) => mount.weaponType === t);
+
+    const torpLoaded = toNumber(inv.torpedoes.loaded, Number.NaN);
+    const torpCap = toNumber(inv.torpedoes.capacity, toNumber(inv.torpedoes.max, Number.NaN));
+    if (!hasType("torpedo") && Number.isFinite(torpLoaded) && torpLoaded > 0) {
+      list.push(syntheticLauncher("torpedo", "TORPEDO BAY", torpLoaded, torpCap));
+    }
+
+    const missileLoaded = toNumber(inv.missiles.loaded, Number.NaN);
+    const missileCap = toNumber(inv.missiles.capacity, toNumber(inv.missiles.max, Number.NaN));
+    if (!hasType("missile") && Number.isFinite(missileLoaded) && missileLoaded > 0) {
+      list.push(syntheticLauncher("missile", "MISSILE BAY", missileLoaded, missileCap));
+    }
+
+    return list;
+  }
+
+  function syntheticLauncher(
+    type: "torpedo" | "missile",
+    label: string,
+    loaded: number,
+    cap: number,
+  ): WeaponMountState {
+    return {
+      id: type === "torpedo" ? "torpedo_bay" : "missile_bay",
+      label,
+      type,
+      weaponType: type,
+      ammo: loaded,
+      ammoCapacity: Number.isFinite(cap) ? cap : loaded,
+      ready: loaded > 0,
+      enabled: true,
+      charge: 1,
+      cooldown: 0,
+      reloading: false,
+      reloadProgress: 0,
+      reloadTime: 0,
+      chargeState: "idle",
+      status: loaded > 0 ? "loaded" : "empty",
+      range: 0,
+    };
+  }
+
+  function ammoPct(mount: WeaponMountState): number {
+    if (mount.ammoCapacity <= 0) return 100;
+    return Math.max(0, Math.min(100, (mount.ammo / mount.ammoCapacity) * 100));
+  }
+
+  function statusDotColor(mount: WeaponMountState): string {
+    const status = mount.status.toLowerCase();
+    if (mount.ready || status === "loaded" || status === "ready") return "var(--nom)";
+    if (mount.reloading || status === "reloading") return "var(--warn)";
+    if (status === "empty" || mount.ammo <= 0) return "var(--crit)";
+    return "var(--tx-dim)";
+  }
+
+  function statusTextColor(mount: WeaponMountState): string {
+    const status = mount.status.toLowerCase();
+    if (status === "ready" || status === "loaded") return "var(--nom)";
+    if (status === "reloading") return "var(--warn)";
+    if (status === "empty") return "var(--crit)";
+    return "var(--tx-dim)";
+  }
+
+  function ammoColor(pct: number): string {
+    if (pct > 60) return "var(--nom)";
+    if (pct > 30) return "var(--warn)";
+    return "var(--crit)";
+  }
+
+  function rowBgTint(mount: WeaponMountState): string {
+    if (mount.weaponType === "railgun") return "rgba(192, 48, 48, 0.04)";
+    if (mount.weaponType === "torpedo") return "rgba(240, 152, 32, 0.03)";
+    if (mount.weaponType === "missile") return "rgba(239, 160, 32, 0.025)";
+    return "transparent";
+  }
+
+  function canFire(mount: WeaponMountState): boolean {
+    if (!mount.enabled || mount.ammo <= 0) return false;
+    if (mount.weaponType === "railgun") {
+      return mount.ready && targeting.lockState === "locked" && solutionConfidence >= 0.38 && !firingIds.has(mount.id);
+    }
+    if (mount.weaponType === "torpedo" || mount.weaponType === "missile") {
+      return targeting.lockState === "locked" && !firingIds.has(mount.id);
+    }
+    return false;
+  }
+
+  function fireTitle(mount: WeaponMountState): string {
+    if (mount.ammo <= 0) return "No ammunition";
+    if (!mount.enabled) return "Weapon disabled";
+    if (targeting.lockState !== "locked") return "Target not locked";
+    if (mount.weaponType === "railgun") {
+      if (!mount.ready) {
+        const chargePct = Math.round(mount.charge * 100);
+        return chargePct < 100 ? `Charging (${chargePct}%)` : "Not ready";
+      }
+      if (solutionConfidence < 0.38) {
+        return `Solution too weak (${Math.round(solutionConfidence * 100)}%)`;
+      }
+      return "Fire railgun";
+    }
+    if (mount.weaponType === "torpedo") return "Launch torpedo";
+    if (mount.weaponType === "missile") return "Launch missile";
+    return "PDC auto-engages";
+  }
+
+  async function fire(mount: WeaponMountState) {
+    if (!canFire(mount)) return;
+    firingIds = new Set(firingIds).add(mount.id);
+    try {
+      if (mount.weaponType === "railgun") {
+        await fireRailgun({ mountId: mount.id, targetId: effectiveTarget || undefined });
+      } else if (mount.weaponType === "torpedo") {
+        await launchDirectMunition("torpedo", { targetId: effectiveTarget || undefined });
+      } else if (mount.weaponType === "missile") {
+        await launchDirectMunition("missile", { targetId: effectiveTarget || undefined });
+      }
+    } finally {
+      const next = new Set(firingIds);
+      next.delete(mount.id);
+      firingIds = next;
+    }
+  }
+</script>
+
+<div class="shell">
+  {#if displayMounts.length === 0}
+    <div class="empty">No weapons available.</div>
+  {:else}
+    {#each displayMounts as mount (mount.id)}
+      {@const ammoPercentage = ammoPct(mount)}
+      {@const status = mount.status.toLowerCase()}
+      {@const isRailgun = mount.weaponType === "railgun"}
+      {@const isPdc = mount.weaponType === "pdc"}
+      {@const isLauncher = mount.weaponType === "torpedo" || mount.weaponType === "missile"}
+      {@const showFire = isRailgun || isLauncher}
+      {@const allowed = canFire(mount)}
+      <div class="row" style="background: {rowBgTint(mount)};">
+        <div class="head">
+          <div class="name">
+            <span class="dot" style="background: {statusDotColor(mount)};" aria-hidden="true"></span>
+            <span class="lbl">{mount.label}</span>
+          </div>
+          <div class="status">
+            {#if isPdc}
+              <span class="auto-badge">AUTO</span>
+            {/if}
+            <span
+              class="status-txt"
+              class:pulse={mount.reloading || status === "reloading"}
+              style="color: {statusTextColor(mount)};"
+            >{mount.status.toUpperCase()}</span>
+          </div>
+        </div>
+
+        <div class="ammo-row">
+          <div class="bar-track" class:thick={isRailgun}>
+            <div
+              class="bar-fill"
+              style="width: {ammoPercentage}%; background: {ammoColor(ammoPercentage)}; box-shadow: {ammoPercentage > 60 ? `0 0 6px ${ammoColor(ammoPercentage)}55` : 'none'};"
+            ></div>
+          </div>
+          <span class="ammo-count">{mount.ammo}/{mount.ammoCapacity || mount.ammo}</span>
+        </div>
+
+        {#if mount.reloading || status === "reloading"}
+          <div class="reload-track">
+            <div class="reload-fill" style="width: {Math.round(mount.reloadProgress * 100)}%;"></div>
+          </div>
+        {/if}
+
+        {#if showFire}
+          <button
+            class="fire-btn"
+            class:armed={allowed}
+            disabled={!allowed}
+            title={fireTitle(mount)}
+            on:click={() => void fire(mount)}
+          >
+            {#if firingIds.has(mount.id)}
+              <span class="bullet">●</span> FIRING…
+            {:else if allowed}
+              <span class="bullet">●</span>
+              {isRailgun
+                ? `FIRE — ${Math.round(solutionConfidence * 100)}% SOL`
+                : isLauncher && mount.weaponType === "torpedo"
+                  ? "LAUNCH TORPEDO"
+                  : "LAUNCH MISSILE"}
+            {:else}
+              <span class="bullet">●</span>
+              {targeting.lockState !== "locked"
+                ? "LOCK REQUIRED"
+                : isRailgun
+                  ? "SOLUTION REQUIRED"
+                  : "NOT READY"}
+            {/if}
+          </button>
+        {/if}
+      </div>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .shell {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow-y: auto;
+  }
+
+  .empty {
+    padding: 18px;
+    text-align: center;
+    font-size: var(--font-size-xs);
+    color: var(--tx-dim);
+    font-family: var(--font-mono);
+  }
+
+  .row {
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--bd-subtle);
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .row:last-child {
+    border-bottom: none;
+  }
+
+  .head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+  }
+
+  .name {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .lbl {
+    font-size: 0.67rem;
+    font-family: var(--font-mono);
+    font-weight: 600;
+    color: var(--tx-primary);
+    letter-spacing: 0.02em;
+  }
+
+  .status {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .auto-badge {
+    font-size: 0.53rem;
+    font-family: var(--font-mono);
+    color: var(--tx-dim);
+    padding: 1px 5px;
+    border: 1px solid var(--bd-default);
+    border-radius: 2px;
+    letter-spacing: 0.08em;
+  }
+
+  .status-txt {
+    font-size: 0.58rem;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .status-txt.pulse {
+    animation: pulse 1s ease-in-out infinite;
+  }
+
+  .ammo-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .bar-track {
+    flex: 1;
+    height: 3px;
+    background: var(--bg-input);
+    border-radius: 1px;
+    overflow: hidden;
+  }
+
+  .bar-track.thick {
+    height: 4px;
+  }
+
+  .bar-fill {
+    height: 100%;
+    transition: width 0.4s ease, background 0.4s ease;
+  }
+
+  .ammo-count {
+    font-size: 0.6rem;
+    font-family: var(--font-mono);
+    color: var(--tx-sec);
+    min-width: 44px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .reload-track {
+    height: 2px;
+    background: var(--bg-input);
+    border-radius: 1px;
+    overflow: hidden;
+  }
+
+  .reload-fill {
+    height: 100%;
+    background: var(--warn);
+    transition: width 0.25s linear;
+  }
+
+  .fire-btn {
+    margin-top: 2px;
+    width: 100%;
+    padding: 7px 10px;
+    background: rgba(30, 30, 48, 0.4);
+    border: 1px solid var(--bd-subtle);
+    border-radius: 2px;
+    color: var(--tx-dim);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    cursor: not-allowed;
+    transition: all 0.15s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+  }
+
+  .fire-btn.armed {
+    background: rgba(192, 48, 48, 0.18);
+    border-color: rgba(232, 48, 48, 0.4);
+    color: var(--crit);
+    box-shadow: 0 0 16px rgba(232, 48, 48, 0.22);
+    cursor: pointer;
+  }
+
+  .fire-btn.armed:hover {
+    background: rgba(232, 48, 48, 0.28);
+    box-shadow: 0 0 22px rgba(232, 48, 48, 0.32);
+  }
+
+  .bullet {
+    font-size: 0.7em;
+    line-height: 1;
+  }
+</style>

--- a/gui-svelte/src/components/tactical/WeaponsHardpointsDisplay.svelte
+++ b/gui-svelte/src/components/tactical/WeaponsHardpointsDisplay.svelte
@@ -1,0 +1,334 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { extractShipState, getLauncherInventory, getWeaponMounts, type WeaponMountState } from "./tacticalData.js";
+
+  export let title = "Hardpoints";
+
+  type VisualState = "ready" | "charging" | "reloading" | "destroyed" | "exhausted";
+
+  const HP_LAYOUT: Record<string, { x: number; y: number; r: number }> = {
+    railgun_1: { x: 262, y: 80, r: 13 },
+    railgun_2: { x: 250, y: 67, r: 12 },
+    pdc_1: { x: 230, y: 57, r: 10 },
+    pdc_2: { x: 230, y: 103, r: 10 },
+    pdc_3: { x: 175, y: 50, r: 10 },
+    pdc_4: { x: 175, y: 110, r: 10 },
+  };
+
+  const AUTO_FALLBACK = [
+    { x: 130, y: 58, r: 10 },
+    { x: 130, y: 102, r: 10 },
+    { x: 105, y: 62, r: 10 },
+    { x: 105, y: 98, r: 10 },
+  ];
+
+  const COLORS: Record<VisualState | "firing", string> = {
+    ready: "#00cc66",
+    charging: "#ff9900",
+    reloading: "#4488ff",
+    exhausted: "#4a4d5c",
+    destroyed: "#cc2244",
+    firing: "#ffffff",
+  };
+
+  const TORP_ANCHOR = { x: 86, y: 68 };
+  const MSL_ANCHOR = { x: 86, y: 96 };
+  const previousAmmo = new Map<string, number>();
+  const flashTimers = new Map<string, number>();
+
+  let flashingIds = new Set<string>();
+
+  function svgArcPath(cx: number, cy: number, r: number, startDeg: number, endDeg: number) {
+    const rad = (deg: number) => (deg - 90) * Math.PI / 180;
+    const x1 = cx + r * Math.cos(rad(startDeg));
+    const y1 = cy + r * Math.sin(rad(startDeg));
+    const x2 = cx + r * Math.cos(rad(endDeg));
+    const y2 = cy + r * Math.sin(rad(endDeg));
+    const large = endDeg - startDeg > 180 ? 1 : 0;
+    return `M ${x1} ${y1} A ${r} ${r} 0 ${large} 1 ${x2} ${y2}`;
+  }
+
+  function compactMountLabel(mount: WeaponMountState) {
+    if (mount.weaponType === "railgun") return mount.id.endsWith("_2") ? "RG2" : "RG";
+    if (mount.weaponType === "pdc") return "PDC";
+    if (mount.weaponType === "torpedo") return "TORP";
+    if (mount.weaponType === "missile") return "MSL";
+    return mount.label.slice(0, 4);
+  }
+
+  function visualState(mount: WeaponMountState): VisualState {
+    const status = mount.status.toLowerCase();
+    if (!mount.enabled || status.includes("destroyed") || status.includes("offline") || status.includes("failed")) {
+      return "destroyed";
+    }
+    if (mount.reloading) return "reloading";
+    if (mount.chargeState === "charging") return "charging";
+    if (mount.ammoCapacity > 0 && mount.ammo <= 0) return "exhausted";
+    return "ready";
+  }
+
+  function progressFor(mount: WeaponMountState) {
+    if (mount.reloading) return mount.reloadProgress;
+    if (mount.chargeState === "charging") return mount.charge;
+    return 0;
+  }
+
+  function progressText(mount: WeaponMountState) {
+    if (mount.chargeState === "charging") return `${Math.round(mount.charge * 100)}%`;
+    if (mount.reloading) return `${mount.cooldown.toFixed(1)}s`;
+    if (mount.ammoCapacity > 0) return `×${mount.ammo}`;
+    return mount.status.toUpperCase();
+  }
+
+  function ammoDots(ammo: number, capacity: number) {
+    const visible = 8;
+    const maxDots = Math.max(1, Math.min(visible, capacity || visible));
+    const filled = capacity > visible
+      ? Math.round((Math.max(0, ammo) / Math.max(1, capacity)) * maxDots)
+      : Math.min(maxDots, Math.max(0, ammo));
+    return Array.from({ length: maxDots }, (_, index) => index < filled);
+  }
+
+  function bankDots(loaded: unknown, capacity: unknown) {
+    return ammoDots(Number(loaded ?? 0), Number(capacity ?? 0));
+  }
+
+  function markFlash(id: string) {
+    flashingIds = new Set([...flashingIds, id]);
+    const current = flashTimers.get(id);
+    if (current != null) window.clearTimeout(current);
+    const handle = window.setTimeout(() => {
+      const next = new Set(flashingIds);
+      next.delete(id);
+      flashingIds = next;
+      flashTimers.delete(id);
+    }, 150);
+    flashTimers.set(id, handle);
+  }
+
+  function syncAmmoFlashes(mounts: WeaponMountState[]) {
+    const activeIds = new Set(mounts.map((mount) => mount.id));
+    for (const mount of mounts) {
+      const previous = previousAmmo.get(mount.id);
+      if (previous != null && mount.ammo < previous) {
+        markFlash(mount.id);
+      }
+      previousAmmo.set(mount.id, mount.ammo);
+    }
+    for (const id of Array.from(previousAmmo.keys())) {
+      if (!activeIds.has(id)) previousAmmo.delete(id);
+    }
+  }
+
+  onDestroy(() => {
+    for (const handle of flashTimers.values()) window.clearTimeout(handle);
+    flashTimers.clear();
+  });
+
+  $: ship = extractShipState($gameState);
+  $: hardpoints = getWeaponMounts(ship);
+  $: inventory = getLauncherInventory(ship);
+  $: syncAmmoFlashes(hardpoints);
+</script>
+
+<Panel title={title} domain="weapons" priority="primary" className="weapons-hardpoints-panel">
+  <div class="shell">
+    <svg viewBox="0 0 320 174" aria-label="Weapons hardpoints schematic">
+      <polygon class="hull" points="55,80 80,50 230,52 282,80 230,108 80,110" />
+      <line class="centerline" x1="55" y1="80" x2="282" y2="80" />
+      <ellipse cx="62" cy="68" rx="6" ry="4" class="engine-ring" />
+      <ellipse cx="62" cy="92" rx="6" ry="4" class="engine-ring" />
+
+      {#each hardpoints as mount, index}
+        {@const position = HP_LAYOUT[mount.id] ?? AUTO_FALLBACK[index % AUTO_FALLBACK.length]}
+        {@const state = visualState(mount)}
+        {@const fillColor = flashingIds.has(mount.id) ? COLORS.firing : COLORS[state]}
+        {@const progress = progressFor(mount)}
+        {@const label = compactMountLabel(mount)}
+        <g class="hardpoint" class:charging={state === "charging"} transform={`translate(${position.x} ${position.y})`}>
+          <circle class="hp-bg" r={position.r} />
+          <circle class="hp-fill" r={position.r - 3} fill={fillColor} />
+          {#if progress > 0}
+            <path
+              class="hp-ring"
+              class:pulse-ring={state === "charging"}
+              d={svgArcPath(0, 0, position.r - 1, 0, progress * 360)}
+              stroke={fillColor}
+            />
+          {/if}
+          {#if state === "destroyed"}
+            <line class="hp-disabled" x1={-(position.r - 3)} y1={-(position.r - 3)} x2={position.r - 3} y2={position.r - 3} />
+            <line class="hp-disabled" x1={position.r - 3} y1={-(position.r - 3)} x2={-(position.r - 3)} y2={position.r - 3} />
+          {/if}
+          <text class="hp-label" y="2">{label}</text>
+          <text class="hp-meta" y={position.r + 9}>{progressText(mount)}</text>
+          <g transform={`translate(${-((ammoDots(mount.ammo, mount.ammoCapacity).length - 1) * 4)} ${position.r + 16})`}>
+            {#each ammoDots(mount.ammo, mount.ammoCapacity) as filled, dotIndex}
+              <circle
+                class="ammo-dot"
+                cx={dotIndex * 8}
+                cy="0"
+                r="2.1"
+                fill={filled ? fillColor : "rgba(255,255,255,0.14)"}
+              />
+            {/each}
+          </g>
+        </g>
+      {/each}
+
+      <g transform={`translate(${TORP_ANCHOR.x} ${TORP_ANCHOR.y})`}>
+        <text class="bank-label" x="-2" y="-10">TORP</text>
+        {#each bankDots(inventory.torpedoes.loaded, inventory.torpedoes.capacity) as filled, index}
+          <circle
+            class="bank-dot"
+            cx={index * 9}
+            cy="0"
+            r="3.4"
+            fill={filled ? (Number(inventory.torpedoes.cooldown ?? 0) > 0 ? COLORS.reloading : COLORS.ready) : COLORS.exhausted}
+          />
+        {/each}
+        <text class="bank-meta" x="38" y="3">
+          {inventory.torpedoes.loaded ?? 0}/{inventory.torpedoes.capacity ?? 0}
+        </text>
+      </g>
+
+      <g transform={`translate(${MSL_ANCHOR.x} ${MSL_ANCHOR.y})`}>
+        <text class="bank-label" x="-2" y="-10">MSL</text>
+        {#each bankDots(inventory.missiles.loaded, inventory.missiles.capacity) as filled, index}
+          <circle
+            class="bank-dot"
+            cx={index * 9}
+            cy="0"
+            r="3.4"
+            fill={filled ? (Number(inventory.missiles.cooldown ?? 0) > 0 ? COLORS.reloading : COLORS.ready) : COLORS.exhausted}
+          />
+        {/each}
+        <text class="bank-meta" x="38" y="3">
+          {inventory.missiles.loaded ?? 0}/{inventory.missiles.capacity ?? 0}
+        </text>
+      </g>
+
+      <g transform="translate(10 154)">
+        <circle cx="4" cy="3" r="3" fill={COLORS.ready} />
+        <text class="legend" x="10" y="5">Ready</text>
+        <circle cx="48" cy="3" r="3" fill={COLORS.charging} />
+        <text class="legend" x="54" y="5">Charging</text>
+        <circle cx="108" cy="3" r="3" fill={COLORS.reloading} />
+        <text class="legend" x="114" y="5">Reloading</text>
+        <circle cx="170" cy="3" r="3" fill={COLORS.destroyed} />
+        <text class="legend" x="176" y="5">Offline</text>
+      </g>
+    </svg>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    padding: var(--space-sm);
+  }
+
+  svg {
+    width: 100%;
+    height: auto;
+    display: block;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background:
+      radial-gradient(circle at 76% 50%, rgba(255, 102, 102, 0.08), transparent 32%),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0)),
+      #090f17;
+  }
+
+  .hull {
+    fill: #1a1a2e;
+    stroke: #3a3a5a;
+    stroke-width: 1.5;
+  }
+
+  .centerline {
+    stroke: #2a2a4a;
+    stroke-width: 0.5;
+    stroke-dasharray: 4 3;
+  }
+
+  .engine-ring {
+    fill: none;
+    stroke: #2a3a5a;
+    stroke-width: 1;
+  }
+
+  .hp-bg {
+    fill: #10151e;
+    stroke: rgba(255, 255, 255, 0.15);
+    stroke-width: 1;
+  }
+
+  .hp-fill {
+    transition: fill var(--transition-fast);
+  }
+
+  .hp-ring {
+    fill: none;
+    stroke-width: 2.5;
+    stroke-linecap: round;
+  }
+
+  .pulse-ring {
+    animation: pulse-ring 0.85s ease-in-out infinite;
+  }
+
+  .hp-disabled {
+    stroke: #cc2244;
+    stroke-width: 1.6;
+    stroke-linecap: round;
+  }
+
+  .hp-label,
+  .hp-meta,
+  .bank-label,
+  .bank-meta,
+  .legend {
+    font-family: var(--font-mono);
+  }
+
+  .hp-label {
+    font-size: 7px;
+    fill: #d8e3f1;
+    text-anchor: middle;
+    dominant-baseline: middle;
+    pointer-events: none;
+  }
+
+  .hp-meta,
+  .bank-meta,
+  .legend {
+    font-size: 6px;
+    fill: #7f8ea5;
+    text-anchor: middle;
+  }
+
+  .bank-label {
+    font-size: 6px;
+    fill: #8a97ab;
+    text-anchor: start;
+    letter-spacing: 0.08em;
+  }
+
+  .bank-dot,
+  .ammo-dot {
+    transition: fill var(--transition-fast);
+  }
+
+  @keyframes pulse-ring {
+    0%,
+    100% {
+      opacity: 0.45;
+    }
+
+    50% {
+      opacity: 1;
+    }
+  }
+</style>

--- a/gui-svelte/src/components/tactical/WeaponsWorkflowPanel.svelte
+++ b/gui-svelte/src/components/tactical/WeaponsWorkflowPanel.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import Panel from "../layout/Panel.svelte";
+  import { gameState } from "../../lib/stores/gameState.js";
+  import { selectedLauncherType } from "../../lib/stores/tacticalUi.js";
+  import {
+    asRecord,
+    extractShipState,
+    getCombatState,
+    getTargetingSummary,
+    toStringValue,
+  } from "./tacticalData.js";
+  import WeaponMountList from "./WeaponMountList.svelte";
+  import LauncherControl from "./LauncherControl.svelte";
+  import PdcControl from "./PdcControl.svelte";
+  import MunitionProgrammingPanel from "../games/MunitionProgrammingPanel.svelte";
+
+  type WorkflowTab = "mounts" | "launch" | "program" | "pdc";
+
+  let activeTab: WorkflowTab = "mounts";
+
+  $: ship = extractShipState($gameState);
+  $: combat = getCombatState(ship);
+  $: targeting = getTargetingSummary(ship);
+  $: munitionProgram = asRecord(combat.munition_program) ?? {};
+  $: hasProgram = Object.keys(munitionProgram).length > 0;
+  $: programType = toStringValue(munitionProgram.munition_type);
+</script>
+
+<Panel title="Weapons" domain="weapons" priority="primary" className="weapons-workflow-panel">
+  <div class="shell">
+    <div class="workflow-header">
+      <div class="status-card">
+        <span>Targeting</span>
+        <strong>{targeting.lockState.toUpperCase()}</strong>
+      </div>
+      <div class="status-card">
+        <span>Launcher</span>
+        <strong>{$selectedLauncherType.toUpperCase()}</strong>
+      </div>
+      <div class="status-card" class:armed={hasProgram}>
+        <span>Program</span>
+        <strong>{hasProgram ? programType.toUpperCase() : "DEFAULT"}</strong>
+      </div>
+    </div>
+
+    <div class="workflow-tabs">
+      <button class:active={activeTab === "mounts"} type="button" on:click={() => (activeTab = "mounts")}>Mounts</button>
+      <button class:active={activeTab === "launch"} type="button" on:click={() => (activeTab = "launch")}>Launch</button>
+      <button class:active={activeTab === "program"} type="button" on:click={() => (activeTab = "program")}>Program</button>
+      <button class:active={activeTab === "pdc"} type="button" on:click={() => (activeTab = "pdc")}>PDC</button>
+    </div>
+
+    <div class="workflow-body">
+      {#if activeTab === "mounts"}
+        <WeaponMountList />
+      {:else if activeTab === "launch"}
+        <LauncherControl embedded />
+      {:else if activeTab === "program"}
+        <MunitionProgrammingPanel embedded />
+      {:else}
+        <PdcControl embedded />
+      {/if}
+    </div>
+  </div>
+</Panel>
+
+<style>
+  .shell {
+    display: grid;
+    grid-template-rows: auto auto minmax(0, 1fr);
+    gap: var(--space-sm);
+    height: 100%;
+    padding: var(--space-sm);
+  }
+
+  .workflow-header {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-sm);
+  }
+
+  .status-card {
+    display: grid;
+    gap: 4px;
+    padding: 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-default);
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .status-card.armed {
+    border-color: rgba(var(--tier-accent-rgb), 0.35);
+    background: rgba(var(--tier-accent-rgb), 0.08);
+  }
+
+  .status-card span {
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .status-card strong {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.05em;
+  }
+
+  .workflow-tabs {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  .workflow-tabs button.active {
+    border-color: rgba(var(--tier-accent-rgb), 0.5);
+    background: rgba(var(--tier-accent-rgb), 0.12);
+    color: var(--text-primary);
+  }
+
+  .workflow-body {
+    min-height: 0;
+    overflow: auto;
+  }
+
+  @media (max-width: 720px) {
+    .workflow-header,
+    .workflow-tabs {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+</style>

--- a/gui-svelte/src/components/tactical/tacticalActions.ts
+++ b/gui-svelte/src/components/tactical/tacticalActions.ts
@@ -1,6 +1,6 @@
 import { wsClient } from "../../lib/ws/wsClient.js";
 
-export type TacticalWeaponType = "railgun" | "torpedo" | "missile";
+export type TacticalWeaponType = "railgun" | "torpedo" | "missile" | "pdc";
 export type MunitionType = "torpedo" | "missile";
 
 export const GUIDANCE_OPTIONS = ["dumb", "guided", "smart"] as const;
@@ -85,7 +85,10 @@ export async function fireArcadeWeapon(
   if (weaponType === "railgun") {
     return fireRailgun({ targetId });
   }
-  return launchDirectMunition(weaponType, { targetId, profile: "direct" });
+  if (weaponType === "pdc") {
+    return firePdc({ targetId });
+  }
+  return launchDirectMunition(weaponType as MunitionType, { targetId, profile: "direct" });
 }
 
 export async function launchSalvo(options: {
@@ -136,4 +139,26 @@ export async function setPdcMode(mode: string) {
 
 export async function setPdcPriority(torpedoIds: string[]) {
   return wsClient.sendShipCommand("set_pdc_priority", { torpedo_ids: torpedoIds });
+}
+
+export async function assignPdcTarget(mountId: string, contactId: string) {
+  return wsClient.sendShipCommand("assign_pdc_target", {
+    mount_id: mountId,
+    contact_id: contactId,
+  });
+}
+
+export async function addTrack(contactId: string) {
+  return wsClient.sendShipCommand("add_track", { contact_id: contactId });
+}
+
+export async function removeTrack(contactId: string) {
+  return wsClient.sendShipCommand("remove_track", { contact_id: contactId });
+}
+
+export async function firePdc(options: { mountId?: string; targetId?: string }) {
+  return wsClient.sendShipCommand("fire_pdc", {
+    weapon_id: options.mountId,
+    ...withOptionalTarget(options.targetId),
+  });
 }

--- a/gui-svelte/src/components/tactical/tacticalData.ts
+++ b/gui-svelte/src/components/tactical/tacticalData.ts
@@ -40,12 +40,19 @@ export interface TacticalContact {
 
 export interface WeaponMountState {
   id: string;
+  label: string;
   type: string;
   weaponType: "railgun" | "pdc" | "torpedo" | "missile" | "other";
   ammo: number;
+  ammoCapacity: number;
   ready: boolean;
+  enabled: boolean;
   charge: number;
   cooldown: number;
+  reloading: boolean;
+  reloadProgress: number;
+  reloadTime: number;
+  chargeState: string;
   status: string;
   range: number;
 }
@@ -224,14 +231,30 @@ export function getWeaponMounts(ship: JsonMap): WeaponMountState[] {
       else if (typeString.includes("torpedo")) weaponType = "torpedo";
       else if (typeString.includes("missile")) weaponType = "missile";
 
+      const ammo = toNumber(item.ammo);
+      const ammoCapacity = toNumber(item.ammo_capacity, ammo);
+      const charge = clamp(toNumber(item.charge_fraction, toNumber(item.charge_progress, toNumber(item.charge, 0))), 0, 1);
+      const reloadProgress = clamp(toNumber(item.reload_progress, 0), 0, 1);
+      const reloadTime = toNumber(item.reload_time, 0);
+      const reloading = Boolean(item.reloading);
+
       return {
         id,
+        label: toStringValue(item.name, toStringValue(item.weapon_type, toStringValue(item.type, id))).toUpperCase(),
         type: toStringValue(item.type, id),
         weaponType,
-        ammo: toNumber(item.ammo),
+        ammo,
+        ammoCapacity,
         ready: Boolean(item.ready),
-        charge: clamp(toNumber(item.charge_fraction, toNumber(item.charge, 0)), 0, 1),
-        cooldown: toNumber(item.cooldown_remaining, toNumber(item.cooldown)),
+        enabled: item.enabled !== false,
+        charge,
+        cooldown: reloading
+          ? Math.max(0, reloadTime * (1 - reloadProgress))
+          : toNumber(item.cooldown_remaining, toNumber(item.cooldown)),
+        reloading,
+        reloadProgress,
+        reloadTime,
+        chargeState: toStringValue(item.charge_state, "idle"),
         status: toStringValue(item.status, item.ready ? "ready" : "standby"),
         range: toNumber(item.range, toNumber(item.max_range)),
       };

--- a/gui-svelte/src/styles/app.css
+++ b/gui-svelte/src/styles/app.css
@@ -1,5 +1,8 @@
-/* Flaxos GUI — App base layout */
+/* Flaxos GUI — App base layout
+ * Mirrors tokens + animations from tools/design_reference_v2.html
+ */
 
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap");
 @import "./tokens.css";
 
 *,
@@ -19,7 +22,7 @@ html {
 body {
   font-family: var(--font-sans);
   font-size: var(--font-size-base);
-  color: var(--text-primary);
+  color: var(--tx-primary);
   background-color: var(--bg-void);
   line-height: 1.5;
   height: 100%;
@@ -29,15 +32,15 @@ body {
   position: relative;
 }
 
-/* Noise overlay */
+/* ── Noise overlay (prototype-matched) ── */
 body::before {
-  content: '';
+  content: "";
   position: fixed;
   inset: 0;
   pointer-events: none;
   z-index: 0;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
-  opacity: var(--noise-opacity, 0.018);
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 300 300' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.72' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  opacity: var(--noise-opacity, 0.016);
 }
 
 #app {
@@ -50,14 +53,14 @@ body::before {
 
 /* ── Bridge chrome regions ── */
 .status-bar {
-  flex: 0 0 32px;
-  min-height: 32px;
+  flex: 0 0 36px;
+  min-height: 36px;
   display: flex;
   align-items: center;
-  background: var(--bg-panel);
-  border-bottom: 2px solid var(--tier-accent, #4488ff);
-  padding: 0 var(--space-sm);
-  gap: var(--space-sm);
+  background: var(--bg-raised);
+  border-bottom: 2px solid var(--tier-accent, #1e8cff);
+  padding: 0 2px;
+  gap: 0;
   font-size: var(--font-size-xs);
   z-index: 100;
 }
@@ -68,7 +71,7 @@ body::before {
   display: flex;
   align-items: center;
   background: var(--bg-panel);
-  border-bottom: 2px solid var(--tier-accent, #4488ff);
+  border-bottom: 2px solid var(--tier-accent, #1e8cff);
   padding: 0 var(--space-sm);
   gap: var(--space-sm);
   z-index: 99;
@@ -79,8 +82,8 @@ body::before {
   min-height: 36px;
   display: flex;
   align-items: stretch;
-  background: var(--bg-panel);
-  border-bottom: 1px solid var(--border-default);
+  background: var(--bg-raised);
+  border-bottom: 1px solid var(--bd-default);
   padding: 0 var(--space-xs);
   gap: 2px;
   z-index: 98;
@@ -108,7 +111,7 @@ body::before {
 h1, h2, h3, h4, h5, h6 {
   font-weight: 600;
   line-height: 1.3;
-  color: var(--text-bright);
+  color: var(--tx-bright);
 }
 
 h1 { font-size: var(--font-size-xl); }
@@ -119,9 +122,9 @@ h3 { font-size: var(--font-size-base); }
 button {
   font-family: inherit;
   cursor: pointer;
-  border: 1px solid var(--border-default);
+  border: 1px solid var(--bd-default);
   background: var(--bg-input);
-  color: var(--text-primary);
+  color: var(--tx-primary);
   border-radius: var(--radius-sm);
   padding: var(--space-xs) var(--space-sm);
   font-size: var(--font-size-xs);
@@ -130,7 +133,7 @@ button {
 
 button:hover:not(:disabled) {
   background: var(--bg-hover);
-  border-color: var(--border-active);
+  border-color: var(--bd-active);
 }
 
 button:disabled {
@@ -143,33 +146,41 @@ input, select, textarea {
   font-family: inherit;
   font-size: var(--font-size-sm);
   background: var(--bg-input);
-  color: var(--text-primary);
-  border: 1px solid var(--border-default);
+  color: var(--tx-primary);
+  border: 1px solid var(--bd-default);
   border-radius: var(--radius-sm);
   padding: var(--space-xs) var(--space-sm);
 }
 
 input:focus, select:focus, textarea:focus {
   outline: none;
-  border-color: var(--border-focus);
+  border-color: var(--bd-focus);
 }
 
-/* ── Scrollbars ── */
+input[type="range"] {
+  accent-color: var(--tier-accent);
+}
+
+/* ── Scrollbars (thinner, prototype-matched) ── */
 ::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: 4px;
+  height: 4px;
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--bg-panel);
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--border-active);
-  border-radius: 3px;
+  background: var(--bd-default);
+  border-radius: 2px;
 }
 
-/* ── 12-column grid base ── */
+::-webkit-scrollbar-thumb:hover {
+  background: var(--bd-active);
+}
+
+/* ── 12-column grid base (legacy) ── */
 .view-grid {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
@@ -177,4 +188,52 @@ input:focus, select:focus, textarea:focus {
   padding: var(--space-xs);
   height: 100%;
   overflow: hidden;
+}
+
+/* ═══════════════════════════════════════════════════════════
+   Global animations (prototype-matched)
+═══════════════════════════════════════════════════════════ */
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.45; }
+}
+
+@keyframes critFlicker {
+  0%, 88%, 92%, 100% { opacity: 1; }
+  90% { opacity: 0.25; }
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes slideRight {
+  from { opacity: 0; transform: translateX(-12px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes toastIn {
+  from { opacity: 0; transform: translateX(20px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes reloadBar {
+  from { width: 0%; }
+  to   { width: 100%; }
+}
+
+@keyframes pingRing {
+  0%   { transform: scale(1);   opacity: 0.6; }
+  100% { transform: scale(3.5); opacity: 0; }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes lockRotate {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
 }

--- a/gui-svelte/src/styles/tiers.css
+++ b/gui-svelte/src/styles/tiers.css
@@ -3,11 +3,13 @@
  * Mirrors gui/styles/tiers.css.
  */
 
-/* ── Tier accent tokens ── */
+/* ── Tier accent tokens (updated to prototype palette) ── */
 body.tier-manual     { --tier-accent: #ff8800; --tier-accent-rgb: 255, 136, 0; }
-body.tier-raw        { --tier-accent: #ff4444; --tier-accent-rgb: 255, 68, 68; }
-body.tier-arcade     { --tier-accent: #4488ff; --tier-accent-rgb: 68, 136, 255; }
-body.tier-cpu-assist { --tier-accent: #c0a0ff; --tier-accent-rgb: 192, 160, 255; }
+body.tier-raw        { --tier-accent: #e83030; --tier-accent-rgb: 232, 48, 48; }
+body.tier-arcade     { --tier-accent: #1e8cff; --tier-accent-rgb: 30, 140, 255; }
+body.tier-cpu-assist { --tier-accent: #aa88ff; --tier-accent-rgb: 170, 136, 255; }
+/* Alias — prototype uses "tier-cpu" shorthand; keep the long name as canonical. */
+body.tier-cpu        { --tier-accent: #aa88ff; --tier-accent-rgb: 170, 136, 255; }
 
 /* ── MANUAL: Amber flight-sim HUD ── */
 body.tier-manual {

--- a/gui-svelte/src/styles/tokens.css
+++ b/gui-svelte/src/styles/tokens.css
@@ -1,43 +1,68 @@
 /* Flaxos Spaceship Sim — Design Tokens
- * Mirrors gui/styles/main.css — keep variable names in sync.
+ * Updated to match design_reference_v2.html palette.
+ * Legacy variable aliases retained so existing components keep working.
  */
 
 :root {
-  /* ── Core backgrounds ── */
-  --bg-primary:       #0a0a0f;
-  --bg-panel:         #12121a;
-  --bg-input:         #1a1a24;
-  --bg-hover:         #22222e;
-  --bg-void:          #050508;
-  --bg-panel-deep:    #0d0d14;
-  --bg-glass:         rgba(22, 22, 34, 0.85);
-  --bg-panel-raised:  #161622;
-  --bg-active:        #2a2a3a;
+  /* ── Core backgrounds (new palette from prototype) ── */
+  --bg-void:         #020205;
+  --bg-app:          #07070d;
+  --bg-panel:        #0c0c14;
+  --bg-raised:       #111119;
+  --bg-input:        #15151e;
+  --bg-hover:        #1b1b26;
 
-  /* ── Borders ── */
-  --border-default:   #2a2a3a;
-  --border-active:    #3a3a4a;
-  --border-focus:     #4a4a5a;
-  --border-subtle:    #1e1e2e;
+  /* Legacy aliases — previous tokens retained for older components */
+  --bg-primary:      #0a0a0f;
+  --bg-panel-deep:   #0d0d14;
+  --bg-glass:        rgba(22, 22, 34, 0.85);
+  --bg-panel-raised: var(--bg-raised);
+  --bg-active:       #2a2a3a;
 
-  /* ── Text ── */
-  --text-primary:     #e0e0e0;
-  --text-secondary:   #888899;
-  --text-dim:         #555566;
-  --text-bright:      #f0f0f4;
+  /* ── Borders (new palette) ── */
+  --bd-subtle:       #16162a;
+  --bd-default:      #20203a;
+  --bd-active:       #2e2e50;
+  --bd-focus:        #3e3e68;
 
-  /* ── Status ── */
-  --status-nominal:   #00ff88;
-  --status-warning:   #ffaa00;
-  --status-critical:  #ff4444;
-  --status-info:      #00aaff;
-  --status-offline:   #555566;
+  /* Legacy aliases */
+  --border-default:  var(--bd-default);
+  --border-active:   var(--bd-active);
+  --border-focus:    var(--bd-focus);
+  --border-subtle:   var(--bd-subtle);
+
+  /* ── Text (new palette) ── */
+  --tx-bright:       #f0f0f6;
+  --tx-primary:      #b8b8cc;
+  --tx-sec:          #68687e;
+  --tx-dim:          #3a3a52;
+  --tx-muted:        #252538;
+
+  /* Legacy aliases */
+  --text-primary:    var(--tx-primary);
+  --text-secondary:  var(--tx-sec);
+  --text-dim:        var(--tx-dim);
+  --text-bright:     var(--tx-bright);
+
+  /* ── Status colors (sharper / prototype) ── */
+  --nom:             #00dd6a;
+  --warn:            #efa020;
+  --crit:            #e83030;
+  --info:            #1e8cff;
+  --offline:         #3a3a52;
+
+  /* Legacy aliases */
+  --status-nominal:  var(--nom);
+  --status-warning:  var(--warn);
+  --status-critical: var(--crit);
+  --status-info:     var(--info);
+  --status-offline:  var(--offline);
 
   /* ── Alert levels ── */
-  --alert-advisory:   #4488ff;
-  --alert-caution:    #ffaa00;
-  --alert-warning:    #ff6600;
-  --alert-critical:   #ff2222;
+  --alert-advisory:  #4488ff;
+  --alert-caution:   var(--warn);
+  --alert-warning:   #ff6600;
+  --alert-critical:  #ff2222;
 
   /* ── Category colors (event log) ── */
   --cat-nav:   #00aaff;
@@ -47,13 +72,25 @@
   --cat-com:   #aa88ff;
   --cat-err:   #ff4444;
 
-  /* ── Domain accent colors ── */
-  --domain-nav:     #3399ff;
-  --domain-sensor:  #00ccaa;
-  --domain-weapons: #cc4444;
-  --domain-power:   #cc8800;
-  --domain-comms:   #9977dd;
-  --domain-helm:    #6699cc;
+  /* ── Domain accent colors (updated to prototype) ── */
+  --d-sensor:        #00a882;
+  --d-weapons:       #c03030;
+  --d-nav:           #1e7ee0;
+  --d-power:         #c07800;
+  --d-helm:          #3878aa;
+  --d-comms:         #8866cc;
+  --d-ops:           #779933;
+  --d-fleet:         #1e99bb;
+
+  /* Legacy aliases */
+  --domain-nav:      var(--d-nav);
+  --domain-sensor:   var(--d-sensor);
+  --domain-weapons:  var(--d-weapons);
+  --domain-power:    var(--d-power);
+  --domain-comms:    var(--d-comms);
+  --domain-helm:     var(--d-helm);
+  --domain-ops:      var(--d-ops);
+  --domain-fleet:    var(--d-fleet);
 
   /* ── HUD ── */
   --hud-primary: #4a9eff;
@@ -61,6 +98,8 @@
   /* ── Typography ── */
   --font-mono:       "JetBrains Mono", "Fira Code", "Consolas", monospace;
   --font-sans:       "Inter", "Segoe UI", system-ui, sans-serif;
+  --fm:              var(--font-mono);
+  --fs:              var(--font-sans);
   --font-size-xs:    0.7rem;
   --font-size-sm:    0.8rem;
   --font-size-base:  0.9rem;
@@ -75,7 +114,7 @@
   --space-xl: 32px;
 
   /* ── Border radius ── */
-  --radius-sm: 4px;
+  --radius-sm: 3px;
   --radius-md: 8px;
   --radius-lg: 12px;
 
@@ -87,17 +126,23 @@
   --transition-base: 0.2s ease;
 
   /* ── Glows ── */
-  --glow-nominal:  0 0 8px rgba(0, 255, 136, 0.35);
-  --glow-warning:  0 0 8px rgba(255, 170, 0, 0.35);
-  --glow-critical: 0 0 12px rgba(255, 68, 68, 0.5);
-  --glow-info:     0 0 8px rgba(0, 170, 255, 0.3);
-  --glow-tier:     0 0 10px rgba(var(--tier-accent-rgb, 68, 136, 255), 0.25);
+  --glow-nominal:  0 0 8px rgba(0, 221, 106, 0.35);
+  --glow-warning:  0 0 8px rgba(239, 160, 32, 0.35);
+  --glow-critical: 0 0 12px rgba(232, 48, 48, 0.5);
+  --glow-info:     0 0 8px rgba(30, 140, 255, 0.3);
+  --glow-tier:     0 0 10px rgba(var(--tier-accent-rgb, 30, 140, 255), 0.25);
 
   /* ── Noise / scanlines ── */
-  --noise-opacity:    0.018;
+  --noise-opacity:    0.016;
   --scanline-opacity: 0.022;
 
   /* ── Tier accent (default: arcade blue) ── */
-  --tier-accent:     #4488ff;
-  --tier-accent-rgb: 68, 136, 255;
+  --tier-accent:     #1e8cff;
+  --tier-accent-rgb: 30, 140, 255;
+
+  /* ── IFF colors (tactical display) ── */
+  --iff-hostile:  #e83030;
+  --iff-friendly: #00dd6a;
+  --iff-unknown:  #efa020;
+  --iff-neutral:  #6888aa;
 }

--- a/gui-svelte/src/views/EngineeringView.svelte
+++ b/gui-svelte/src/views/EngineeringView.svelte
@@ -4,9 +4,11 @@
   import { proposals, autoSystems } from "../lib/stores/proposals.js";
 
   import ThermalDisplay from "../components/engineering/ThermalDisplay.svelte";
+  import EngineeringShipSchematic from "../components/engineering/EngineeringShipSchematic.svelte";
   import EngineeringControlPanel from "../components/engineering/EngineeringControlPanel.svelte";
   import SubsystemStatus from "../components/engineering/SubsystemStatus.svelte";
   import PowerDrawDisplay from "../components/engineering/PowerDrawDisplay.svelte";
+  import PowerFlowDisplay from "../components/engineering/PowerFlowDisplay.svelte";
   import PowerAllocationPanel from "../components/engineering/PowerAllocationPanel.svelte";
   import SystemToggles from "../components/engineering/SystemToggles.svelte";
 
@@ -42,6 +44,11 @@
 </script>
 
 <div class="engineering-root" class:arcade={arcadeTier} class:manual={manualTier} class:cpu={cpuAssistTier}>
+  <section class="column schematic">
+    <div class="column-title">Damage Control</div>
+    <EngineeringShipSchematic />
+  </section>
+
   <section class="column thermal">
     <div class="column-title">Thermal &amp; Drive</div>
     <ThermalDisplay />
@@ -54,7 +61,10 @@
 
   <section class="column power">
     <div class="column-title">Power</div>
-    <PowerDrawDisplay />
+    <PowerFlowDisplay />
+    {#if rawTier}
+      <PowerDrawDisplay />
+    {/if}
     <PowerAllocationPanel />
   </section>
 
@@ -120,8 +130,12 @@
     gap: var(--space-xs);
   }
 
-  .column.thermal {
+  .column.schematic {
     grid-column: span 2;
+  }
+
+  .column.thermal {
+    grid-column: span 1;
   }
 
   .column-title {
@@ -168,6 +182,10 @@
     }
 
     .column.thermal {
+      grid-column: span 1;
+    }
+
+    .column.schematic {
       grid-column: span 1;
     }
   }

--- a/gui-svelte/src/views/HelmView.svelte
+++ b/gui-svelte/src/views/HelmView.svelte
@@ -1,83 +1,48 @@
 <script lang="ts">
   import { tier } from "../lib/stores/tier.js";
-
-  import HelmWorkflowStrip from "../components/helm/HelmWorkflowStrip.svelte";
-  import HelmNavMap from "../components/helm/HelmNavMap.svelte";
   import FlightDataPanel from "../components/helm/FlightDataPanel.svelte";
-  import AutopilotStatus from "../components/helm/AutopilotStatus.svelte";
   import FlightComputerPanel from "../components/helm/FlightComputerPanel.svelte";
   import ManualFlightPanel from "../components/helm/ManualFlightPanel.svelte";
   import RcsControls from "../components/helm/RcsControls.svelte";
-  import RcsThrusterDisplay from "../components/helm/RcsThrusterDisplay.svelte";
-  import HelmQueuePanel from "../components/helm/HelmQueuePanel.svelte";
-  import DockingPanel from "../components/helm/DockingPanel.svelte";
-  import ManeuverPlanner from "../components/helm/ManeuverPlanner.svelte";
-  import HelmBalanceGame from "../components/games/HelmBalanceGame.svelte";
+  import HelmNavMap from "../components/helm/HelmNavMap.svelte";
+  import HelmNavigationPanel from "../components/helm/HelmNavigationPanel.svelte";
+  import HelmSupportDrawer from "../components/helm/HelmSupportDrawer.svelte";
   import SensorContacts from "../components/tactical/SensorContacts.svelte";
+  import SubsystemStatus from "../components/engineering/SubsystemStatus.svelte";
+  import HelmBalanceGame from "../components/games/HelmBalanceGame.svelte";
 
-  $: manualTier = $tier === "manual";
-  $: rawTier = $tier === "raw";
+  // Tier drives which center-cell workflow the pilot uses:
+  //   manual/raw   → direct throttle + RCS controls (stacked)
+  //   arcade       → helm balance mini-game
+  //   cpu-assist   → flight computer program selector
+  // All other cells stay the same — information density doesn't change by tier.
+  $: manualLike = $tier === "manual" || $tier === "raw";
   $: arcadeTier = $tier === "arcade";
-  $: cpuAssistTier = $tier === "cpu-assist";
+  $: cpuAssist = $tier === "cpu-assist";
 </script>
 
-<div class="helm-root" class:manual={manualTier} class:arcade={arcadeTier} class:cpu={cpuAssistTier}>
-  <div class="workflow-slot">
-    <HelmWorkflowStrip />
-  </div>
+<div class="helm-root">
+  <div class="cell left-top"><FlightDataPanel /></div>
+  <div class="cell left-bottom"><SensorContacts /></div>
 
-  <section class="column awareness">
-    <div class="column-title">Awareness</div>
-    <HelmNavMap />
-    <FlightDataPanel />
-    <SensorContacts />
-    {#if arcadeTier}
-      <HelmBalanceGame />
-    {/if}
-    <RcsThrusterDisplay />
-    {#if rawTier}
-      <ManeuverPlanner />
-    {/if}
-  </section>
-
-  <section class="column command">
-    <div class="column-title">Command</div>
-
-    {#if manualTier}
-      <div class="prominent">
+  <div class="cell center">
+    {#if manualLike}
+      <div class="stack">
         <ManualFlightPanel />
+        <RcsControls />
       </div>
-      <ManeuverPlanner />
     {:else if arcadeTier}
-      <div class="prominent">
-        <FlightComputerPanel />
-      </div>
-      <ManualFlightPanel />
-      <RcsControls />
-    {:else if cpuAssistTier}
+      <HelmBalanceGame />
+    {:else if cpuAssist}
       <FlightComputerPanel />
-    {:else}
-      <FlightComputerPanel />
-      <ManualFlightPanel />
-      <RcsControls />
-      <ManeuverPlanner />
     {/if}
-  </section>
+  </div>
+  <div class="cell nav"><HelmNavMap /></div>
 
-  <section class="column status">
-    <div class="column-title">Status</div>
+  <div class="cell right-top"><SubsystemStatus /></div>
+  <div class="cell right-bottom"><HelmNavigationPanel /></div>
 
-    {#if cpuAssistTier}
-      <div class="prominent">
-        <AutopilotStatus />
-      </div>
-    {:else}
-      <AutopilotStatus />
-    {/if}
-
-    <HelmQueuePanel />
-    <DockingPanel />
-  </section>
+  <div class="cell support"><HelmSupportDrawer /></div>
 </div>
 
 <style>
@@ -85,90 +50,66 @@
     width: 100%;
     height: 100%;
     display: grid;
-    grid-template-columns: minmax(270px, 0.9fr) minmax(340px, 1.2fr) minmax(270px, 0.95fr);
-    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-columns: 210px minmax(0, 1fr) 220px;
+    grid-template-rows: minmax(0, 1fr) minmax(220px, 0.78fr) auto;
+    grid-template-areas:
+      "left-top center right-top"
+      "left-bottom nav right-bottom"
+      "support support support";
     gap: var(--space-xs);
     padding: var(--space-xs);
     overflow: hidden;
   }
 
-  .helm-root.manual {
-    grid-template-columns: minmax(250px, 0.8fr) minmax(420px, 1.45fr) minmax(250px, 0.85fr);
-  }
-
-  .helm-root.cpu {
-    grid-template-columns: minmax(260px, 0.9fr) minmax(320px, 1fr) minmax(340px, 1.2fr);
-  }
-
-  .workflow-slot {
-    grid-column: 1 / -1;
-    min-width: 0;
-  }
-
-  .column {
+  .cell {
     min-height: 0;
-    overflow: auto;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .left-top { grid-area: left-top; }
+  .left-bottom { grid-area: left-bottom; }
+  .center { grid-area: center; }
+  .nav { grid-area: nav; }
+  .right-top { grid-area: right-top; }
+  .right-bottom { grid-area: right-bottom; }
+  .support { grid-area: support; overflow: visible; }
+
+  /* manual/raw: stack ManualFlightPanel + RcsControls in the center cell. */
+  .stack {
     display: flex;
     flex-direction: column;
     gap: var(--space-xs);
-    padding-right: 2px;
-  }
-
-  .column-title {
-    position: sticky;
-    top: 0;
-    z-index: 2;
-    padding: 6px 10px;
-    border: 1px solid var(--border-default);
-    border-radius: var(--radius-sm);
-    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.12), transparent 60%), var(--bg-panel);
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--text-secondary);
-  }
-
-  .prominent {
-    flex: 1 0 auto;
-  }
-
-  .prominent :global(.panel) {
-    height: 100%;
+    min-height: 0;
+    overflow: auto;
   }
 
   @media (max-width: 1180px) {
-    .helm-root,
-    .helm-root.manual,
-    .helm-root.cpu {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      grid-template-rows: auto auto minmax(0, 1fr);
-    }
-
-    .awareness {
-      grid-column: 1;
-    }
-
-    .command {
-      grid-column: 2;
-    }
-
-    .status {
-      grid-column: 1 / -1;
+    .helm-root {
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      grid-template-rows: minmax(0, 1fr) minmax(260px, auto) auto auto;
+      grid-template-areas:
+        "left-top right-top"
+        "center center"
+        "nav nav"
+        "left-bottom right-bottom"
+        "support support";
+      overflow: auto;
     }
   }
 
   @media (max-width: 780px) {
-    .helm-root,
-    .helm-root.manual,
-    .helm-root.cpu {
+    .helm-root {
       grid-template-columns: 1fr;
-      grid-template-rows: auto;
-      overflow: auto;
-    }
-
-    .column {
-      overflow: visible;
+      grid-template-areas:
+        "left-top"
+        "center"
+        "nav"
+        "right-top"
+        "left-bottom"
+        "right-bottom"
+        "support";
     }
   }
 </style>

--- a/gui-svelte/src/views/TacticalView.svelte
+++ b/gui-svelte/src/views/TacticalView.svelte
@@ -1,96 +1,58 @@
 <script lang="ts">
   import { tier } from "../lib/stores/tier.js";
-
   import SensorContacts from "../components/tactical/SensorContacts.svelte";
   import TacticalMap from "../components/tactical/TacticalMap.svelte";
   import TargetingDisplay from "../components/tactical/TargetingDisplay.svelte";
-  import FiringSolutionDisplay from "../components/tactical/FiringSolutionDisplay.svelte";
-  import SubsystemSelector from "../components/tactical/SubsystemSelector.svelte";
-  import ThreatBoard from "../components/tactical/ThreatBoard.svelte";
-  import WeaponsStatus from "../components/tactical/WeaponsStatus.svelte";
-  import FireAuthorization from "../components/tactical/FireAuthorization.svelte";
-  import RailgunControl from "../components/tactical/RailgunControl.svelte";
-  import PdcControl from "../components/tactical/PdcControl.svelte";
-  import LauncherControl from "../components/tactical/LauncherControl.svelte";
-  import EcmControlPanel from "../components/tactical/EcmControlPanel.svelte";
-  import EccmControlPanel from "../components/tactical/EccmControlPanel.svelte";
-  import MultiTrackPanel from "../components/tactical/MultiTrackPanel.svelte";
   import CombatLog from "../components/tactical/CombatLog.svelte";
-  import TargetAssessment from "../components/tactical/TargetAssessment.svelte";
+  import WeaponsHardpointsDisplay from "../components/tactical/WeaponsHardpointsDisplay.svelte";
+  import WeaponsWorkflowPanel from "../components/tactical/WeaponsWorkflowPanel.svelte";
+  import TacticalSupportDrawer from "../components/tactical/TacticalSupportDrawer.svelte";
+  import FireAuthorization from "../components/tactical/FireAuthorization.svelte";
+  import FiringSolutionDisplay from "../components/tactical/FiringSolutionDisplay.svelte";
+  import ThreatBoard from "../components/tactical/ThreatBoard.svelte";
+  import ArcadeTacticalPanel from "../components/tactical/ArcadeTacticalPanel.svelte";
 
-  import SensorSweepGame from "../components/games/SensorSweepGame.svelte";
-  import TargetingLockGame from "../components/games/TargetingLockGame.svelte";
-  import WeaponsChargeGame from "../components/games/WeaponsChargeGame.svelte";
-  import PdcThreatGame from "../components/games/PdcThreatGame.svelte";
-  import EcmFrequencyGame from "../components/games/EcmFrequencyGame.svelte";
-  import MunitionConfigGame from "../components/games/MunitionConfigGame.svelte";
-  import MunitionProgrammingPanel from "../components/games/MunitionProgrammingPanel.svelte";
-
-  $: manualTier = $tier === "manual";
-  $: rawTier = $tier === "raw";
+  // Tier drives interaction model, not information density.
+  //   manual/raw   → direct hardpoint controls + full sensor table
+  //   arcade       → mini-game style combat station + threat board
+  //   cpu-assist   → one-click fire authorization + firing solution telemetry
+  $: manualLike = $tier === "manual" || $tier === "raw";
   $: arcadeTier = $tier === "arcade";
-  $: cpuAssistTier = $tier === "cpu-assist";
+  $: cpuAssist = $tier === "cpu-assist";
 </script>
 
-<div class="tactical-root" class:arcade={arcadeTier} class:manual={manualTier} class:cpu={cpuAssistTier}>
-  <section class="group detect">
-    <div class="group-title">Detect</div>
-    <TacticalMap />
-    <SensorContacts />
+<div class="tactical-root">
+  <div class="cell contacts">
     {#if arcadeTier}
-      <SensorSweepGame />
-    {/if}
-  </section>
-
-  <section class="group decide">
-    <div class="group-title">Decide</div>
-    <TargetingDisplay />
-    <FiringSolutionDisplay />
-    <SubsystemSelector />
-    <MultiTrackPanel />
-    {#if arcadeTier}
-      <TargetingLockGame />
-    {/if}
-  </section>
-
-  <section class="group destroy">
-    <div class="group-title">Destroy</div>
-    <FireAuthorization />
-    {#if arcadeTier}
-      <WeaponsChargeGame />
-      <MunitionConfigGame />
-      <PdcThreatGame />
-    {:else if cpuAssistTier}
-      <!-- CPU-ASSIST: proposal-based fire handled by FireAuthorization above -->
+      <ThreatBoard />
     {:else}
-      <RailgunControl />
-      <PdcControl />
-      <LauncherControl />
-      {#if manualTier}
-        <MunitionProgrammingPanel />
-      {/if}
+      <SensorContacts />
     {/if}
-  </section>
+  </div>
+  <div class="cell map"><TacticalMap /></div>
+  <div class="cell targeting"><TargetingDisplay /></div>
 
-  <section class="group awareness">
-    <div class="group-title">Awareness</div>
-    <ThreatBoard />
-    <WeaponsStatus />
-    <TargetAssessment />
-    <EcmControlPanel />
-    <EccmControlPanel />
-    {#if arcadeTier}
-      <EcmFrequencyGame />
+  <div class="cell ship-status">
+    {#if manualLike}
+      <WeaponsHardpointsDisplay title="Ship Status" />
+    {:else if arcadeTier}
+      <FiringSolutionDisplay />
+    {:else if cpuAssist}
+      <FiringSolutionDisplay />
     {/if}
-  </section>
+  </div>
+  <div class="cell combat-log"><CombatLog /></div>
+  <div class="cell weapons">
+    {#if manualLike}
+      <WeaponsWorkflowPanel />
+    {:else if arcadeTier}
+      <ArcadeTacticalPanel />
+    {:else if cpuAssist}
+      <FireAuthorization />
+    {/if}
+  </div>
 
-  <section class="group aftermath">
-    <div class="group-title">After-Action</div>
-    <CombatLog />
-    {#if cpuAssistTier}
-      <SensorContacts passive />
-    {/if}
-  </section>
+  <div class="cell support"><TacticalSupportDrawer /></div>
 </div>
 
 <style>
@@ -98,72 +60,64 @@
     width: 100%;
     height: 100%;
     display: grid;
-    grid-template-columns: minmax(320px, 1.25fr) minmax(260px, 0.95fr) minmax(280px, 1fr) minmax(250px, 0.9fr) minmax(260px, 0.95fr);
+    grid-template-columns: 220px minmax(0, 1fr) 280px;
+    grid-template-rows: minmax(0, 1.65fr) minmax(250px, 0.95fr) auto;
+    grid-template-areas:
+      "contacts map targeting"
+      "ship-status combat-log weapons"
+      "support support support";
     gap: var(--space-xs);
     padding: var(--space-xs);
     overflow: hidden;
   }
 
-  .tactical-root.arcade {
-    grid-template-columns: minmax(300px, 1.15fr) minmax(250px, 0.9fr) minmax(300px, 1.05fr) minmax(240px, 0.85fr) minmax(240px, 0.85fr);
-  }
-
-  .tactical-root.cpu {
-    grid-template-columns: minmax(300px, 1.1fr) minmax(280px, 0.95fr) minmax(320px, 1.1fr) minmax(260px, 0.9fr) minmax(260px, 0.9fr);
-  }
-
-  .group {
+  .cell {
     min-height: 0;
-    overflow: auto;
+    overflow: hidden;
     display: flex;
     flex-direction: column;
-    gap: var(--space-xs);
-    padding-right: 2px;
   }
 
-  .group-title {
-    position: sticky;
-    top: 0;
-    z-index: 2;
-    padding: 6px 10px;
-    border: 1px solid var(--border-default);
-    border-radius: var(--radius-sm);
-    background: linear-gradient(90deg, rgba(var(--tier-accent-rgb), 0.12), transparent 60%), var(--bg-panel);
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--text-secondary);
-  }
+  .contacts { grid-area: contacts; }
+  .map { grid-area: map; }
+  .targeting { grid-area: targeting; }
+  .ship-status { grid-area: ship-status; }
+  .combat-log { grid-area: combat-log; }
+  .weapons { grid-area: weapons; }
+  .support { grid-area: support; overflow: visible; }
 
-  @media (max-width: 1500px) {
-    .tactical-root,
-    .tactical-root.arcade,
-    .tactical-root.cpu {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      grid-auto-rows: minmax(0, 1fr);
+  @media (max-width: 1280px) {
+    .tactical-root {
+      grid-template-columns: 210px minmax(0, 1fr) 260px;
     }
   }
 
-  @media (max-width: 1080px) {
-    .tactical-root,
-    .tactical-root.arcade,
-    .tactical-root.cpu {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+  @media (max-width: 980px) {
+    .tactical-root {
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      grid-template-rows: minmax(320px, 1.4fr) auto auto auto auto;
+      grid-template-areas:
+        "map map"
+        "contacts targeting"
+        "ship-status weapons"
+        "combat-log combat-log"
+        "support support";
       height: auto;
       overflow: auto;
     }
-
-    .group {
-      overflow: visible;
-    }
   }
 
-  @media (max-width: 760px) {
-    .tactical-root,
-    .tactical-root.arcade,
-    .tactical-root.cpu {
+  @media (max-width: 720px) {
+    .tactical-root {
       grid-template-columns: 1fr;
+      grid-template-areas:
+        "map"
+        "contacts"
+        "targeting"
+        "ship-status"
+        "weapons"
+        "combat-log"
+        "support";
     }
   }
 </style>

--- a/hybrid/command_handler.py
+++ b/hybrid/command_handler.py
@@ -68,8 +68,8 @@ system_commands = {
     "fire": ("weapons", "fire"),
     "fire_weapon": ("weapons", "fire"),
     # Combat system commands (Sprint C - truth weapons)
-    "fire_railgun": ("combat", "fire"),
-    "fire_pdc": ("combat", "fire"),
+    "fire_railgun": ("combat", "fire_railgun"),
+    "fire_pdc": ("combat", "fire_pdc"),
     "fire_combat": ("combat", "fire"),
     "fire_all": ("combat", "fire_all"),
     "fire_unguided": ("combat", "fire_unguided"),

--- a/hybrid/systems/combat/auto_fire_manager.py
+++ b/hybrid/systems/combat/auto_fire_manager.py
@@ -27,7 +27,7 @@ from hybrid.utils.errors import success_dict, error_dict
 logger = logging.getLogger(__name__)
 
 # Valid weapon types that can be authorized
-VALID_WEAPON_TYPES = {"railgun", "torpedo", "missile"}
+VALID_WEAPON_TYPES = {"railgun", "torpedo", "missile", "pdc"}
 
 
 class AutoFireManager:
@@ -43,6 +43,7 @@ class AutoFireManager:
             "railgun": False,
             "torpedo": False,
             "missile": False,
+            "pdc": False,
         }
         # Per-type cooldown remaining (seconds).  Prevents double-commanding
         # the same weapon mount within its cycle time.
@@ -50,6 +51,7 @@ class AutoFireManager:
             "railgun": 0.0,
             "torpedo": 0.0,
             "missile": 0.0,
+            "pdc": 0.0,
         }
         # Missile launch configuration (count reserved for future salvo support)
         self._missile_config: dict = {"count": 1, "profile": "direct"}
@@ -170,6 +172,12 @@ class AutoFireManager:
             if result:
                 events.append(result)
 
+        # --- PDC: continuous fire while authorized ---
+        if self._authorized["pdc"] and self._cooldowns["pdc"] <= 0:
+            result = self._try_fire_pdc(combat_system)
+            if result:
+                events.append(result)
+
         # --- Torpedo: single-shot, then deauthorize ---
         if self._authorized["torpedo"] and self._cooldowns["torpedo"] <= 0:
             result = self._try_fire_torpedo(combat_system, ship)
@@ -220,6 +228,38 @@ class AutoFireManager:
                 self._cooldowns["railgun"] = weapon.specs.cycle_time
                 result["auto_fire"] = True
                 result["weapon_type"] = "railgun"
+                return result
+        return None
+
+    def _try_fire_pdc(self, combat_system) -> Optional[dict]:
+        """Attempt to fire a PDC offensively if conditions are met.
+
+        Finds the first PDC mount with a ready solution for the main locked
+        target, then fires it. This enables PDCs to be used offensively via
+        CPU-Assist instead of just defensively.
+
+        Args:
+            combat_system: CombatSystem instance.
+
+        Returns:
+            dict or None: Fire result if fired, None otherwise.
+        """
+        for mount_id, weapon in combat_system.truth_weapons.items():
+            if not mount_id.startswith("pdc"):
+                continue
+            if weapon.ammo <= 0:
+                continue
+            if not weapon.can_fire(combat_system._sim_time):
+                continue
+            solution = weapon.current_solution
+            if not solution or not solution.ready_to_fire:
+                continue
+
+            result = combat_system.fire_weapon(mount_id)
+            if result.get("ok"):
+                self._cooldowns["pdc"] = weapon.specs.cycle_time
+                result["auto_fire"] = True
+                result["weapon_type"] = "pdc"
                 return result
         return None
 

--- a/hybrid/systems/combat/combat_system.py
+++ b/hybrid/systems/combat/combat_system.py
@@ -452,10 +452,10 @@ class CombatSystem(BaseSystem):
 
         # Get power manager
         power = self._ship_ref.systems.get("power_management") or self._ship_ref.systems.get("power")
+        targeting = self._ship_ref.systems.get("targeting")
 
         # Get target from targeting system if not provided
         if target_ship is None:
-            targeting = self._ship_ref.systems.get("targeting")
             if targeting and targeting.locked_target:
                 locked_id = targeting.locked_target
                 # Resolve contact ID to real ship ID via sensor contact tracker
@@ -470,8 +470,59 @@ class CombatSystem(BaseSystem):
                                 target_ship = ships_dict.get(real_id)
                                 break
 
+        resolved_contact_id = None
+        if target_ship is not None and targeting:
+            sensors = self._ship_ref.systems.get("sensors")
+            if targeting.locked_target:
+                locked_id = targeting.locked_target
+                if target_ship.id == locked_id:
+                    resolved_contact_id = locked_id
+                elif sensors and hasattr(sensors, "contact_tracker"):
+                    tracker = sensors.contact_tracker
+                    for real_id, stable_id in tracker.id_mapping.items():
+                        if stable_id == locked_id and real_id == target_ship.id:
+                            resolved_contact_id = locked_id
+                            break
+
+            if not resolved_contact_id and sensors and hasattr(sensors, "contact_tracker"):
+                tracker = sensors.contact_tracker
+                for real_id, stable_id in tracker.id_mapping.items():
+                    if real_id == target_ship.id:
+                        resolved_contact_id = stable_id
+                        break
+
+            if not resolved_contact_id:
+                resolved_contact_id = target_ship.id
+
+            current_target_id = getattr(weapon.current_solution, "target_id", None)
+            if current_target_id != resolved_contact_id or not weapon.current_solution:
+                track_quality = getattr(targeting, "track_quality", 1.0)
+                multi_track = getattr(targeting, "multi_track", None)
+                if multi_track and resolved_contact_id:
+                    for track in getattr(multi_track, "tracks", []):
+                        if getattr(track, "contact_id", None) == resolved_contact_id:
+                            track_quality = max(0.15, track_quality * getattr(track, "quality_modifier", 1.0))
+                            break
+
+                target_accel = None
+                if hasattr(targeting, "_get_target_accel") and targeting.locked_target == resolved_contact_id:
+                    target_accel = targeting._get_target_accel()
+
+                weapon.calculate_solution(
+                    shooter_pos=self._ship_ref.position,
+                    shooter_vel=self._ship_ref.velocity,
+                    target_pos=target_ship.position,
+                    target_vel=target_ship.velocity,
+                    target_id=resolved_contact_id,
+                    sim_time=self._sim_time,
+                    track_quality=track_quality,
+                    shooter_angular_vel=getattr(self._ship_ref, "angular_velocity", None),
+                    weapon_damage_factor=self._damage_factor,
+                    target_accel=target_accel,
+                    shooter_heading=getattr(self._ship_ref, "orientation", None),
+                )
+
         if target_subsystem is None:
-            targeting = self._ship_ref.systems.get("targeting")
             if targeting and hasattr(targeting, "target_subsystem"):
                 target_subsystem = targeting.target_subsystem
 
@@ -1162,11 +1213,25 @@ class CombatSystem(BaseSystem):
         Returns:
             dict: Result
         """
-        if action == "fire":
+        if action in ("fire", "fire_pdc", "fire_railgun"):
             # GUI sends mount_id, accept all common param names
             weapon_id = (params.get("weapon_id")
                          or params.get("weapon")
                          or params.get("mount_id"))
+            
+            # Auto-assign if missing but implied by action name
+            if not weapon_id:
+                if action == "fire_pdc":
+                    for mid in self.truth_weapons:
+                        if mid.startswith("pdc"):
+                            weapon_id = mid
+                            break
+                elif action == "fire_railgun":
+                    for mid in self.truth_weapons:
+                        if mid.startswith("railgun"):
+                            weapon_id = mid
+                            break
+
             if not weapon_id:
                 return error_dict("MISSING_PARAMETER", "weapon_id required")
 
@@ -1365,6 +1430,43 @@ class CombatSystem(BaseSystem):
         weapons_state = {}
         for weapon_id, weapon in self.truth_weapons.items():
             weapons_state[weapon_id] = weapon.get_state()
+
+        # Inject mock truth_weapons for torpedo and missile launchers to make them selectable in V3 GUI.
+        # Extra tubes/launchers are scaffolding for GUI mount selection; the real ammo pool is
+        # ship-wide (torpedoes_loaded / missiles_loaded). Show the true loaded count on the first
+        # tube so the player sees the full magazine; other tubes display 0 rather than a clipped
+        # per-tube slice (which misreported stock when loaded > torpedo_capacity).
+        for i in range(self.torpedo_tubes):
+            mid = f"torpedo_tube_{i+1}"
+            # Tube 0 shows the real loaded count; extra tubes are empty scaffolding
+            ammo = self.torpedoes_loaded if i == 0 else 0
+            ammo_capacity = self.torpedo_capacity * self.torpedo_tubes  # total ship capacity
+            weapons_state[mid] = {
+                "id": mid, "name": f"Torpedo Tube {i+1}", "type": "torpedo_launcher",
+                "weapon_type": "torpedo", "enabled": True,
+                "ready": self.torpedoes_loaded > 0 and self._torpedo_cooldown <= 0,
+                "ammo": ammo, "ammo_capacity": ammo_capacity,
+                "status": "ready" if self._torpedo_cooldown <= 0 else "standby",
+                "reloading": self._torpedo_cooldown > 0,
+                "cooldown": self.torpedo_reload_time,
+                "cooldown_remaining": self._torpedo_cooldown,
+            }
+
+        for i in range(self.missile_launchers):
+            mid = f"missile_launcher_{i+1}"
+            # Launcher 0 shows the real loaded count; extra launchers are empty scaffolding
+            ammo = self.missiles_loaded if i == 0 else 0
+            ammo_capacity = self.missile_capacity * self.missile_launchers  # total ship capacity
+            weapons_state[mid] = {
+                "id": mid, "name": f"Missile Silo {i+1}", "type": "missile_launcher",
+                "weapon_type": "missile", "enabled": True,
+                "ready": self.missiles_loaded > 0 and self._missile_cooldown <= 0,
+                "ammo": ammo, "ammo_capacity": ammo_capacity,
+                "status": "ready" if self._missile_cooldown <= 0 else "standby",
+                "reloading": self._missile_cooldown > 0,
+                "cooldown": self.missile_reload_time,
+                "cooldown_remaining": self._missile_cooldown,
+            }
 
         # Summarize PDC mode from PDC mounts
         pdc_mode = "hold_fire"

--- a/hybrid/systems/combat/projectile_manager.py
+++ b/hybrid/systems/combat/projectile_manager.py
@@ -449,6 +449,18 @@ class ProjectileManager:
                 proj, target_ship, actual_hit, subsystem_hit, flight_time
             )
 
+        # Pre-calculate true reported damage
+        reported_damage = 0.0
+        reported_sub_damage = 0.0
+        if actual_hit:
+            # pen_factor was set during armor resolution
+            if locals().get("is_ricochet"):
+                reported_damage = proj.damage * 0.1
+                reported_sub_damage = 0.0
+            else:
+                reported_damage = proj.damage * locals().get("pen_factor", 1.0)
+                reported_sub_damage = proj.subsystem_damage * locals().get("pen_factor", 1.0)
+
         event = {
             "type": "projectile_impact",
             "projectile_id": proj.id,
@@ -457,9 +469,9 @@ class ProjectileManager:
             "shooter": proj.shooter_id,
             "target": target_ship.id,
             "hit": actual_hit,
-            "damage": proj.damage * (hit_location.penetration_factor if hit_location else 1.0) if actual_hit else 0,
+            "damage": reported_damage,
             "subsystem_hit": subsystem_hit,
-            "subsystem_damage": proj.subsystem_damage * (hit_location.penetration_factor if hit_location else 1.0) if actual_hit and not (hit_location and hit_location.is_ricochet) else 0,
+            "subsystem_damage": reported_sub_damage,
             "sim_time": sim_time,
             "flight_time": flight_time,
             "damage_result": damage_result,

--- a/hybrid/systems/weapons/truth_weapons.py
+++ b/hybrid/systems/weapons/truth_weapons.py
@@ -137,7 +137,7 @@ RAILGUN_SPECS = WeaponSpecs(
     ammo_capacity=20,  # Limited heavy rounds
     mass_per_round=5.0,  # 5 kg tungsten penetrator
     reload_time=0.0,  # Railgun uses electromagnetic acceleration, no magazine reload
-    power_per_shot=50.0,  # High power draw
+    power_per_shot=15.0,  # Balanced for 4-shot volley before heat saturation
     charge_time=2.0,  # 2 second charge
     base_accuracy=0.85,  # High accuracy
     accuracy_falloff=0.3,  # Maintains accuracy at range
@@ -154,9 +154,9 @@ PDC_SPECS = WeaponSpecs(
     base_damage=5.0,  # Light damage per round (ablative, not penetrating)
     subsystem_damage=3.0,  # Can chip away at external subsystems
     armor_penetration=0.5,  # Poor vs heavy armor — strips plating, doesn't punch
-    cycle_time=0.02,  # 50 rps = 3000 RPM per turret (Expanse CIWS fire rate)
+    cycle_time=0.2,  # 5 bursts of 10 = 50 rps = 3000 RPM per turret
     burst_count=10,  # Longer bursts — sustained fire strips armor
-    burst_delay=0.02,  # Matches cycle time for continuous stream
+    burst_delay=0.02,  # Delay between rounds in the burst
     ammo_capacity=3000,  # High ammo count — bullet hose needs deep magazines
     mass_per_round=0.05,  # 50g 40mm autocannon rounds
     reload_time=3.0,  # 3 seconds to swap magazine (every 200 rounds)
@@ -1277,30 +1277,25 @@ class TruthWeapon:
                 return {"ok": False, "reason": "no_ammo"}
             self.ammo -= 1
 
+        # Heat generation (per burst, not per round)
+        self.heat += 10.0 * (1.0 / max(0.5, damage_factor))
+        if damage_model is not None:
+            heat_scale = self.specs.subsystem_damage / max(1.0, self.specs.base_damage)
+            heat_amount = self.specs.power_per_shot * (1.0 + heat_scale)
+            if heat_amount > 0:
+                damage_model.add_heat("weapons", heat_amount, event_bus, ship_id)
+
         for shot_i in range(self.specs.burst_count):
-            burst_rounds += 1
-
-            # Magazine reload check per round (> 0: only count live rounds)
-            if self._magazine_size > 0 and self.ammo is not None and self.ammo > 0:
-                self._rounds_since_reload += 1
-                if self._rounds_since_reload >= self._magazine_size:
-                    self.reloading = True
-                    self._reload_timer = self.specs.reload_time
-                    self.reload_progress = 0.0
-                    self.event_bus.publish("weapon_reloading", {
-                        "weapon": self.specs.name,
-                        "mount_id": self.mount_id,
-                        "reload_time": self.specs.reload_time,
-                    })
+            if self.ammo <= 0:
+                if self.specs.reload_time > 0 and self.inventory:
+                    self.inventory.start_reload(self.mount_id, self.specs.name, self.specs.reload_time)
+                    if self.event_bus:
+                        self.event_bus.publish("weapon_reloading", {
+                            "weapon": self.specs.name,
+                            "mount_id": self.mount_id,
+                            "reload_time": self.specs.reload_time,
+                        })
                     break  # Stop burst on reload
-
-            # Heat per round
-            self.heat += 10.0 * (1.0 / max(0.5, damage_factor))
-            if damage_model is not None:
-                heat_scale = self.specs.subsystem_damage / max(1.0, self.specs.base_damage)
-                heat_amount = self.specs.power_per_shot * (1.0 + heat_scale)
-                if heat_amount > 0:
-                    damage_model.add_heat("weapons", heat_amount, event_bus, ship_id)
 
             # Hit roll per round
             hit = random.random() < self.current_solution.hit_probability
@@ -1310,9 +1305,24 @@ class TruthWeapon:
 
             if hit and target_ship:
                 # Use hit-location physics for PDC hits
-                hit_loc = self._compute_instant_hit_location(target_ship)
-                pen_factor = hit_loc.penetration_factor if hit_loc else 1.0
-                is_ricochet = hit_loc.is_ricochet if hit_loc else False
+                hit_result = self._compute_instant_hit_location(target_ship)
+                hit_loc, proj_vel = hit_result if hit_result else (None, None)
+
+                # Resolve penetration through the mutable armor model when available.
+                armor_model = getattr(target_ship, "armor_model", None)
+                if armor_model is not None and hit_loc is not None:
+                    armor_result = armor_model.resolve_hit(
+                        section=hit_loc.armor_section,
+                        projectile_velocity=proj_vel,
+                        projectile_mass=self.specs.mass_per_round,
+                        armor_penetration_rating=self.specs.armor_penetration,
+                        angle_of_incidence=hit_loc.angle_of_incidence,
+                    )
+                    pen_factor = armor_result.penetration_factor
+                    is_ricochet = armor_result.is_ricochet
+                else:
+                    pen_factor = hit_loc.penetration_factor if hit_loc else 1.0
+                    is_ricochet = hit_loc.is_ricochet if hit_loc else False
 
                 if is_ricochet:
                     effective_damage = self.specs.base_damage * damage_factor * 0.1
@@ -1462,7 +1472,7 @@ class TruthWeapon:
             target_ship: Target ship object
 
         Returns:
-            HitLocation or None if ship lacks required data
+            Tuple of (HitLocation, projectile_velocity_dict) or None if ship lacks required data
         """
         if not target_ship or not hasattr(target_ship, 'position'):
             return None
@@ -1474,11 +1484,14 @@ class TruthWeapon:
 
         # PDC projectile velocity toward intercept point
         intercept = solution.intercept_point
-        target_pos = target_ship.position
+        shooter_pos = {"x": 0, "y": 0, "z": 0}
+        if hasattr(self, '_ship_ref') and self._ship_ref and hasattr(self._ship_ref, 'position'):
+            shooter_pos = self._ship_ref.position
+            
         aim_vec = {
-            "x": intercept["x"] - target_pos["x"],
-            "y": intercept["y"] - target_pos["y"],
-            "z": intercept["z"] - target_pos["z"],
+            "x": intercept["x"] - shooter_pos["x"],
+            "y": intercept["y"] - shooter_pos["y"],
+            "z": intercept["z"] - shooter_pos["z"],
         }
         # Normalize and scale to muzzle velocity
         aim_mag = math.sqrt(aim_vec["x"]**2 + aim_vec["y"]**2 + aim_vec["z"]**2)
@@ -1503,7 +1516,7 @@ class TruthWeapon:
             subsystem_names = list(target_ship.damage_model.subsystems.keys())
 
         try:
-            return compute_hit_location(
+            hit_loc = compute_hit_location(
                 projectile_velocity=proj_vel,
                 projectile_mass=self.specs.mass_per_round,
                 projectile_armor_pen=self.specs.armor_penetration,
@@ -1515,6 +1528,7 @@ class TruthWeapon:
                 ship_weapon_mounts=ship_weapon_mounts,
                 ship_subsystems=subsystem_names,
             )
+            return (hit_loc, proj_vel)
         except Exception as e:
             logger.warning(f"Hit location calc failed for PDC: {e}")
             return None

--- a/tests/systems/combat/test_auto_fire.py
+++ b/tests/systems/combat/test_auto_fire.py
@@ -90,7 +90,7 @@ class TestAuthorization:
         """All weapon types start deauthorized."""
         mgr = AutoFireManager()
         state = mgr.get_state()
-        assert state["authorized"] == {"railgun": False, "torpedo": False, "missile": False}
+        assert state["authorized"] == {"railgun": False, "torpedo": False, "missile": False, "pdc": False}
 
     def test_authorize_railgun(self):
         """Authorizing railgun sets its state to True."""
@@ -145,7 +145,7 @@ class TestAuthorization:
         result = mgr.cease_fire()
         assert result["ok"] is True
         state = mgr.get_state()
-        assert state["authorized"] == {"railgun": False, "torpedo": False, "missile": False}
+        assert state["authorized"] == {"railgun": False, "torpedo": False, "missile": False, "pdc": False}
 
 
 class TestTickRailgun:

--- a/tests/systems/combat/test_combat_polish.py
+++ b/tests/systems/combat/test_combat_polish.py
@@ -685,9 +685,12 @@ class TestPDCRangeFalloff:
         )
 
     def test_pdc_fire_rate_is_3000_rpm(self):
-        """PDC cycle_time of 0.02s equals 50 rps = 3000 RPM."""
+        """PDC fires in bursts that sum to 50 rps = 3000 RPM (Expanse CIWS)."""
         from hybrid.systems.weapons.truth_weapons import PDC_SPECS
-        rps = 1.0 / PDC_SPECS.cycle_time
+        # Each trigger pull fires burst_count rounds at burst_delay spacing, and
+        # a new trigger pull happens every cycle_time seconds. Sustained rate is
+        # therefore burst_count / cycle_time rounds per second.
+        rps = PDC_SPECS.burst_count / PDC_SPECS.cycle_time
         rpm = rps * 60
         assert abs(rps - 50.0) < 0.1, f"Expected 50 rps, got {rps:.1f}"
         assert abs(rpm - 3000.0) < 10, f"Expected 3000 RPM, got {rpm:.0f}"

--- a/tests/systems/combat/test_combat_system.py
+++ b/tests/systems/combat/test_combat_system.py
@@ -27,7 +27,7 @@ class TestTruthWeapons:
         assert PDC_SPECS.muzzle_velocity == 2000.0  # 2 km/s (40mm rounds)
         assert PDC_SPECS.effective_range == 2000.0  # 2 km (accuracy-limited)
         assert PDC_SPECS.base_damage == 5.0  # Ablative, not penetrating
-        assert PDC_SPECS.cycle_time == 0.02  # 50 rps = 3000 RPM
+        assert PDC_SPECS.cycle_time == 0.2  # 5 bursts/sec * burst_count=10 = 50 rps = 3000 RPM
         assert PDC_SPECS.burst_count == 10  # Longer bursts
         assert PDC_SPECS.ammo_capacity == 3000  # Deep magazines
 

--- a/tools/start_gui_stack.py
+++ b/tools/start_gui_stack.py
@@ -2,7 +2,7 @@
 Start the full GUI stack in a single terminal:
 - TCP simulation server (unified entrypoint)
 - WebSocket bridge
-- GUI frontend (`gui-svelte` build by default, legacy `gui/` on demand)
+- Bridge UI v3 (`gui-svelte` build by default, legacy `gui/` still available as a deprecated fallback)
 
 Uses the unified server.main entrypoint with --mode flag.
 """
@@ -148,13 +148,14 @@ def main() -> int:
     parser.add_argument("--lan", action="store_true", help="Enable LAN mode (bind to 0.0.0.0)")
     parser.add_argument(
         "--ui",
-        choices=["legacy", "svelte", "dev"],
-        default="svelte",
+        choices=["legacy", "svelte", "dev", "v3"],
+        default="v3",
         help=(
             "Frontend to serve: "
-            "svelte (default, builds gui-svelte/ then serves dist/), "
-            "legacy (serves gui/), "
-            "dev (starts vite dev server on :5174 alongside the game servers)"
+            "v3 (default, builds gui-svelte/ then serves dist/), "
+            "svelte (alias for v3), "
+            "legacy (deprecated fallback serving gui/), "
+            "dev (starts vite dev server for the v3 UI on :5174 alongside the game servers)"
         ),
     )
     parser.add_argument("--no-browser", action="store_true", default=True, help="Do not open browser (default)")
@@ -244,7 +245,7 @@ def main() -> int:
         ws_bridge_cmd.extend(["--allowed-origin-host", origin_host])
 
     http_bind = "0.0.0.0" if args.lan else "127.0.0.1"
-    ui_mode = args.ui  # legacy | svelte | dev
+    ui_mode = "svelte" if args.ui == "v3" else args.ui  # legacy | svelte | dev
 
     # Resolve which directory to serve for HTTP
     if ui_mode == "svelte":
@@ -344,6 +345,9 @@ def main() -> int:
             gui_url = f"http://localhost:{args.http_port}/"
             razorback_url = f"http://localhost:{args.http_port}/razorback.html"
 
+        if ui_mode == "legacy":
+            print("[warn] Legacy GUI selected. The supported default is the v3 bridge UI.")
+
         if args.game_code:
             gui_url = _append_query_param(gui_url, "game_code", args.game_code)
             razorback_url = _append_query_param(
@@ -352,12 +356,13 @@ def main() -> int:
                 args.game_code,
             )
 
-        print(f"[ready] Mode: {mode} | UI: {ui_mode}")
+        display_ui_mode = "v3" if ui_mode in {"svelte", "dev"} else "legacy"
+        print(f"[ready] Mode: {mode} | UI: {display_ui_mode}")
         print(f"[ready] GUI: {gui_url}")
         if ui_mode == "legacy":
             print(f"[ready] Razorback cockpit: {razorback_url}")
         if ui_mode == "dev":
-            print(f"[ready] Vite dev server: {gui_url} (hot reload)")
+            print(f"[ready] Vite dev server (v3): {gui_url} (hot reload)")
         print(f"[ready] WS bridge: ws://localhost:{args.ws_port}")
         print(f"[ready] TCP server: {args.host}:{args.tcp_port}")
         if args.game_code:


### PR DESCRIPTION
## Summary

- **Tier-aware tactical controls**: Manual/Raw gets direct hardpoint fire buttons per-weapon; Arcade gets TargetingLock + WeaponsCharge mini-games with a single FIRE button; CPU-Assist gets one-click weapon authorization via FireAuthorization
- **Tier-aware helm controls**: Manual/Raw gets ManualFlightPanel + RcsControls stacked; Arcade gets HelmBalanceGame; CPU-Assist gets FlightComputerPanel program selector
- **12 new components**: BridgeHeader, ArcadeTacticalPanel, AttitudeIndicator, HelmNavigationPanel, HelmSupportDrawer, ShipOrientationDisplay, TacticalSupportDrawer, WeaponMountList, WeaponsHardpointsDisplay, WeaponsWorkflowPanel, EngineeringShipSchematic, PowerFlowDisplay
- **Engineering Damage Control**: live SVG hull schematic with subsystem health nodes
- **StatusBar expanded**: speed, heading, reactor%, thermal bar, mission clock
- **Design tokens** aligned to prototype palette with legacy aliases for backward compatibility
- **Combat fixes**: fire_railgun/fire_pdc now route correctly; PDC added to auto-fire; launcher mounts injected into weapon state for GUI selection; railgun power balanced; PDC burst heat fixed

## Test plan

- [ ] Start server + `python3 -m pytest tests/ -x -q` → 2287 passed
- [ ] Load a scenario with railgun ship; switch to Tactical Manual → verify individual weapon fire buttons per mount
- [ ] Switch to Arcade tier → verify TargetingLockGame pre-lock, WeaponsChargeGame post-lock, FIRE button arms when locked
- [ ] Switch to CPU-Assist → verify FireAuthorization one-click weapon type buttons
- [ ] Helm Manual/Raw → ManualFlightPanel + RCS controls in center; Arcade → HelmBalanceGame; CPU-Assist → FlightComputerPanel
- [ ] Engineering → Damage Control schematic column renders with live hull data
- [ ] BridgeHeader tab nav: keyboard 1-7 switches views; domain colours per tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)